### PR TITLE
Add default metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,20 +4,19 @@ jobs:
   validate:
     docker:
     - image: python:3.8
-    environment:
-      BASE_COMMIT: <<pipeline.git.base_revision>>
-      REVISION_COMMIT: <<pipeline.git.revision>>
     steps:
     - checkout
     - run:
+        name: Build
+        command: |
+          pip install -r .script/requirements.txt
+    - run:
         name: Validate config files
         command: |
-          python3.8 -m venv venv/
-          venv/bin/pip install -r .script/requirements.txt
-          changed_files=$(git diff --name-only $BASE_COMMIT..$REVISION_COMMIT -- '*.toml' '*.toml.example')
+          changed_files=$(git diff origin/main... --name-only --diff-filter=d -- '*.toml' '*.toml.example')
           echo "Run validation on changed files: "
           echo $changed_files
-          venv/bin/python3 .script/validate.py $changed_files
+          python3 .script/validate.py $changed_files
   docs:
     docker:
       - image: python:3.8

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -225,3 +225,7 @@ default_dataset = "org_mozilla_firefox"
 friendly_name = "Metrics"
 description = "Metrics Ping"
 build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
+
+[data_sources.mobile_search_clients_engines_sources_daily]
+from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
+experiments_column_type = "simple"

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -6,6 +6,38 @@ select_expression = '{{agg_sum("metrics.counter.events_total_uri_count")}}'
 friendly_name = "URIs visited"
 description = "Counts the number of URIs each client visited"
 
+[metrics.active_hours]
+select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
+data_source = "baseline"
+friendly_name = "Active Hours"
+description = "Total time Firefox was active"
+
+[metrics.ad_clicks]
+select_expression = "{{agg_sum('ad_click')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+friendly_name = "Ad Clicks"
+description = """
+    Counts clicks on ads on search engine result pages with a Mozilla
+    partner tag.
+"""
+
+[metrics.days_of_use]
+friendly_name = "Days of use"
+description = "The number of days in an observation window that clients used the browser."
+select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
+data_source = "baseline"
+
+[metrics.tagged_sap_searches]
+select_expression = "{{agg_sum('tagged_sap')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+friendly_name = "Tagged SAP Searches"
+description = "Total number of tagged SAP searches."
+
+[metrics.search_count]
+friendly_name = "SAP search count"
+description = "Number of searches performed through a Search Access Point."
+select_expression = "{{agg_sum('search_count')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
 
 [metrics.user_reports_site_issue_count]
 data_source = "events"

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -95,3 +95,7 @@ default_dataset = "org_mozilla_ios_firefox"
 friendly_name = "Metrics"
 description = "Metrics Ping"
 build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
+
+[data_sources.mobile_search_clients_engines_sources_daily]
+from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
+experiments_column_type = "simple"

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -19,6 +19,34 @@ select_expression = "MIN(client_info.first_run_date)"
 friendly_name = "First run date"
 description = "The earliest first-run date reported by each client."
 
+[metrics.active_hours]
+select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
+data_source = "baseline"
+friendly_name = "Active Hours"
+description = "Total time Firefox was active"
+
+[metrics.days_of_use]
+friendly_name = "Days of use"
+description = "The number of days in an observation window that clients used the browser."
+select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
+data_source = "baseline"
+
+[metrics.ad_clicks]
+select_expression = "{{agg_sum('ad_click')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+friendly_name = "Ad Clicks"
+description = """
+    Counts clicks on ads on search engine result pages with a Mozilla
+    partner tag.
+"""
+
+[metrics.search_count]
+friendly_name = "SAP search count"
+description = "Number of searches performed through a Search Access Point."
+select_expression = "{{agg_sum('search_count')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+
+
 
 [data_sources]
 

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -98,3 +98,7 @@ default_dataset = "org_mozilla_focus"
 friendly_name = "Metrics"
 description = "Metrics Ping"
 build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
+
+[data_sources.mobile_search_clients_engines_sources_daily]
+from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
+experiments_column_type = "simple"

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -22,6 +22,33 @@ select_expression = "MIN(client_info.first_run_date)"
 friendly_name = "First run date"
 description = "The earliest first-run date reported by each client."
 
+[metrics.active_hours]
+select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
+data_source = "baseline"
+friendly_name = "Active Hours"
+description = "Total time Firefox was active"
+
+[metrics.days_of_use]
+friendly_name = "Days of use"
+description = "The number of days in an observation window that clients used the browser."
+select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
+data_source = "baseline"
+
+[metrics.ad_clicks]
+select_expression = "{{agg_sum('ad_click')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+friendly_name = "Ad Clicks"
+description = """
+    Counts clicks on ads on search engine result pages with a Mozilla
+    partner tag.
+"""
+
+[metrics.search_count]
+friendly_name = "SAP search count"
+description = "Number of searches performed through a Search Access Point."
+select_expression = "{{agg_sum('search_count')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+
 
 
 [data_sources]

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -98,3 +98,7 @@ default_dataset = "org_mozilla_ios_focus"
 friendly_name = "Metrics"
 description = "Metrics Ping"
 build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
+
+[data_sources.mobile_search_clients_engines_sources_daily]
+from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
+experiments_column_type = "simple"

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -22,6 +22,32 @@ select_expression = "MIN(client_info.first_run_date)"
 friendly_name = "First run date"
 description = "The earliest first-run date reported by each client."
 
+[metrics.active_hours]
+select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
+data_source = "baseline"
+friendly_name = "Active Hours"
+description = "Total time Firefox was active"
+
+[metrics.days_of_use]
+friendly_name = "Days of use"
+description = "The number of days in an observation window that clients used the browser."
+select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
+data_source = "baseline"
+
+[metrics.ad_clicks]
+select_expression = "{{agg_sum('ad_click')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+friendly_name = "Ad Clicks"
+description = """
+    Counts clicks on ads on search engine result pages with a Mozilla
+    partner tag.
+"""
+
+[metrics.search_count]
+friendly_name = "SAP search count"
+description = "Number of searches performed through a Search Access Point."
+select_expression = "{{agg_sum('search_count')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
 
 
 

--- a/definitions/klar_android.toml
+++ b/definitions/klar_android.toml
@@ -20,6 +20,32 @@ select_expression = "MIN(client_info.first_run_date)"
 friendly_name = "First run date"
 description = "The earliest first-run date reported by each client."
 
+[metrics.active_hours]
+select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
+data_source = "baseline"
+friendly_name = "Active Hours"
+description = "Total time Firefox was active"
+
+[metrics.days_of_use]
+friendly_name = "Days of use"
+description = "The number of days in an observation window that clients used the browser."
+select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
+data_source = "baseline"
+
+[metrics.ad_clicks]
+select_expression = "{{agg_sum('ad_click')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+friendly_name = "Ad Clicks"
+description = """
+    Counts clicks on ads on search engine result pages with a Mozilla
+    partner tag.
+"""
+
+[metrics.search_count]
+friendly_name = "SAP search count"
+description = "Number of searches performed through a Search Access Point."
+select_expression = "{{agg_sum('search_count')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
 
 
 

--- a/definitions/klar_android.toml
+++ b/definitions/klar_android.toml
@@ -97,3 +97,7 @@ default_dataset = "org_mozilla_klar"
 friendly_name = "Metrics"
 description = "Metrics Ping"
 build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
+
+[data_sources.mobile_search_clients_engines_sources_daily]
+from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
+experiments_column_type = "simple"

--- a/definitions/klar_ios.toml
+++ b/definitions/klar_ios.toml
@@ -22,6 +22,32 @@ select_expression = "MIN(client_info.first_run_date)"
 friendly_name = "First run date"
 description = "The earliest first-run date reported by each client."
 
+[metrics.active_hours]
+select_expression = "COALESCE(SUM(metrics.timespan.glean_baseline_duration.value), 0) / 3600.0"
+data_source = "baseline"
+friendly_name = "Active Hours"
+description = "Total time Firefox was active"
+
+[metrics.days_of_use]
+friendly_name = "Days of use"
+description = "The number of days in an observation window that clients used the browser."
+select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
+data_source = "baseline"
+
+[metrics.ad_clicks]
+select_expression = "{{agg_sum('ad_click')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+friendly_name = "Ad Clicks"
+description = """
+    Counts clicks on ads on search engine result pages with a Mozilla
+    partner tag.
+"""
+
+[metrics.search_count]
+friendly_name = "SAP search count"
+description = "Number of searches performed through a Search Access Point."
+select_expression = "{{agg_sum('search_count')}}"
+data_source = "mobile_search_clients_engines_sources_daily"
 
 
 

--- a/definitions/klar_ios.toml
+++ b/definitions/klar_ios.toml
@@ -6,15 +6,11 @@ select_expression = "COUNT(document_id)"
 friendly_name = "Baseline pings"
 description = "Counts the number of `baseline` pings received from each client."
 
-
-
 [metrics.metric_ping_count]
 data_source = "metrics"
 select_expression = "COUNT(document_id)"
 friendly_name = "Metrics pings"
 description = "Counts the number of `metrics` pings received from each client."
-
-
 
 [metrics.first_run_date]
 data_source = "baseline"
@@ -98,3 +94,7 @@ default_dataset = "org_mozilla_ios_klar"
 friendly_name = "Metrics"
 description = "Metrics Ping"
 build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
+
+[data_sources.mobile_search_clients_engines_sources_daily]
+from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
+experiments_column_type = "simple"


### PR DESCRIPTION
Adds some of the default metric definitions needed for https://github.com/mozilla/opmon-config