### PR TITLE
Add placeholder folder for tooling-specific configs

### DIFF
--- a/jetstream/README.md
+++ b/jetstream/README.md
@@ -1,0 +1,24 @@
+# Jetstream Config
+
+> This is currently a WIP.
+> We are moving [jetstream-config](https://github.com/mozilla/jetstream-config) into metric-hub. This is to improve the development experience when writing experiment analysis configs that depend on new or existing metrics.
+> For now, keep adding configs to [jetstream-config](https://github.com/mozilla/jetstream-config)
+
+Custom configs for experiments and outcome snippets
+analyzed in [jetstream](https://github.com/mozilla/jetstream).
+
+## Adding Custom Configurations
+
+Custom configuration files are written in [TOML](https://toml.io/en/).
+
+To add or update a custom configuration, open a pull request.
+CI checks will validate the columns, data sources, and SQL syntax.
+Once CI completes, you may merge the pull request, which will trigger Jetstream to re-run your analysis.
+No additional review is necessary to land configurations.
+Are your analyses not rendering as expected? See https://experimenter.info/jetstream/troubleshooting.
+
+Learn how to write a Jetstream configuration at <https://experimenter.info/jetstream/configuration>.
+
+Learn more about Outcomes at <https://experimenter.info/jetstream/outcomes>.
+
+See what outcomes and pre-defined metrics are available at https://mozilla.github.io/metric-hub

--- a/opmon/README.md
+++ b/opmon/README.md
@@ -1,0 +1,15 @@
+# OpMon Config
+
+> This is currently a WIP.
+> We are moving [opmon-config](https://github.com/mozilla/opmon-config) into metric-hub. This is to improve the development experience when writing configs that depend on new or existing metrics.
+> For now, keep adding configs to [opmon-config](https://github.com/mozilla/opmon-config)
+
+Custom configs operational monitoring projects run via [opmon](https://github.com/mozilla/opmon).
+
+## Adding Custom Configurations
+
+Custom configuration files are written in [TOML](https://toml.io/en/).
+More information on adding or changing configurations is available on [dtmo](https://docs.telemetry.mozilla.org/cookbooks/operational_monitoring.html).
+
+To add or update a custom configuration, open a pull request.
+CI checks will validate the columns, data sources, and SQL syntax.


### PR DESCRIPTION
My plan is to:

1. create these folders that will contain the tool configs
2. update jetstream to merge configs from these folders and the existing jetstream-config repo
3. announce that we are changing the location of the configs
4. update docs
5. move jetstream-config into this repo
6. update jetstream to only use configs from this repo
