### PR TITLE
Auto approvals

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,0 @@
-⚠️ A review is required when adding new metric definitions
-
-Reviews are optional for making changes to configs in `jetstream/` or `opmon/`.

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,42 @@
+name: "Auto approve"
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  changed:
+    runs-on: ubuntu-latest 
+    name: Get changed metric definition files
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Get changed files in the metrics definitions folder
+      id: changed-files-specific
+      uses: tj-actions/changed-files@v34
+      with:
+        files: definitions/*.toml
+    outputs:
+      any_changed: ${{ steps.changed-files-specific.outputs.any_changed }}
+
+  approve:
+    name: Auto approve PR if no metrics definitions changed
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest 
+    needs: changed
+    steps:
+    - uses: actions/github-script@v6
+      if: needs.changed.outputs.any_changed == 'false'
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.rest.pulls.createReview({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number,
+            event: "APPROVE"
+          })


### PR DESCRIPTION
⚠️ A review is required when adding new metric definitions

Reviews are optional for making changes to configs in `jetstream/` or `opmon/`.
