### PR TITLE
Rerun only experiments changed in PR

### DIFF
--- a/.circleci/validation-config.yml
+++ b/.circleci/validation-config.yml
@@ -106,12 +106,26 @@ jobs:
     - run:
         name: Rerun jetstream
         command: |
+          changed_files=$(git diff --name-only $BASE_COMMIT..$REVISION_COMMIT -- 'jetstream/*.toml' 'jetstream/*.toml.example')
+          echo "Rerun changed files: "
+          echo $changed_files
+
+          # determine slugs of configs that got changed; filter out outcomes and defaults
+          params=""
+          for config in $changed_files; do
+            slug=${config##*/}
+            slug="${slug%.*}"
+            if [ -e jetstream/"$slug".toml ]; then
+              params+="--experiment_slug=${slug} "
+            fi
+          done
+
           # stop running instances so that they do not interfere
           uuid=`uuidgen`
           pod_identifier="jetstream-${uuid}"
           kubectl delete pod -l app=$pod_identifier
           # start a new instance
-          kubectl run $pod_identifier --image=gcr.io/moz-fx-data-experiments/jetstream -l app=$pod_identifier --restart=Never --command -- jetstream rerun-config-changed --argo --return-status --recreate-enrollments
+          kubectl run $pod_identifier --image=gcr.io/moz-fx-data-experiments/jetstream -l app=$pod_identifier --restart=Never --command -- jetstream rerun --argo --return-status --recreate-enrollments $(echo $params)
           # link to logs
           cur_date=`date -u +%FT%TZ`
           echo "Pod Logs: https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22moz-fx-data-experiments%22%0Aresource.labels.location%3D%22us-central1-a%22%0Aresource.labels.cluster_name%3D%22jetstream%22%0Aresource.labels.namespace_name%3D%22default%22?scrollTimestamp=$cur_date"

--- a/jetstream/outcomes/firefox_ios/default_browser.toml
+++ b/jetstream/outcomes/firefox_ios/default_browser.toml
@@ -21,3 +21,4 @@ description = """
 select_expression = "SUM(metrics.counter.default_browser_card_go_to_settings_pressed)"
 data_source = "metrics"
 statistics = { bootstrap_mean = { pre_treatments = ["remove_nulls"] }, deciles = { pre_treatments = ["remove_nulls"] } }
+

--- a/jetstream/rally-first-prompt-for-users-without-an-enrolled-study-2nd-stage-rollout.toml
+++ b/jetstream/rally-first-prompt-for-users-without-an-enrolled-study-2nd-stage-rollout.toml
@@ -1,3 +1,3 @@
 [experiment]
-skip = true
 
+skip = true

--- a/jetstream/rally-first-prompt-for-users-without-an-enrolled-study.toml
+++ b/jetstream/rally-first-prompt-for-users-without-an-enrolled-study.toml
@@ -1,3 +1,3 @@
 [experiment]
-skip = true
 
+skip = true


### PR DESCRIPTION
Depends on https://github.com/mozilla/jetstream/pull/1560

The reason to change this is to only rerun configs that got changed in the PR. Previously, we reran all experiments that had a changed config. This resulted in experiments getting rerun multiple times when PRs got merged right after each other before the rerun had completed.
This was especially a problem when defaults got changed since that affected a lot of experiments, costing money.

With this change experiments affected by a change in defaults will only get rerun during nightly runs. Which I think is fine


cc @danielkberry 