### PR TITLE
New profile activation definitions for Fenix and iOS

### DIFF
--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -381,6 +381,4 @@ submission_date_column = "submission_date"
 
 [data_sources.new_profile_activation]
 from_expression = "`moz-fx-data-shared-prod.fenix.new_profile_activation`"
-experiments_column_type = "simple"
-client_id_column = "client_id"
-submission_date_column = "submission_date"
+experiments_column_type = "none"

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -313,6 +313,13 @@ friendly_name = "Sponsored Tiles Preference Toggled"
 description = "Number of times Contile Sponsored Tiles setting is flipped."
 owner = "xluo-all@mozilla.com"
 
+[metrics.new_profile_activation]
+select_expression = "COALESCE(SUM(activated))"
+data_source = "new_profile_activation" 
+friendly_name = "New Profile Activation"
+description = "A new profile is counted as activated one week after creation if it meets the following conditions: 1) at least 3 days of use during first week 2) at least one search between days 4-7."
+owner = "vsabino@mozilla.com"
+
 
 [data_sources]
 
@@ -368,6 +375,12 @@ from_expression = """(
     FROM `mozdata.search.mobile_search_clients_engines_sources_daily` 
     WHERE normalized_app_name = "Fenix"
 )"""
+experiments_column_type = "simple"
+client_id_column = "client_id"
+submission_date_column = "submission_date"
+
+[data_sources.new_profile_activation]
+from_expression = "`moz-fx-data-shared-prod.fenix.new_profile_activation`"
 experiments_column_type = "simple"
 client_id_column = "client_id"
 submission_date_column = "submission_date"

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -235,6 +235,5 @@ submission_date_column = "submission_date"
 
 [data_sources.new_profile_activation]
 from_expression = "`moz-fx-data-shared-prod.firefox_ios.new_profile_activation`"
-experiments_column_type = "simple"
-client_id_column = "client_id"
-submission_date_column = "submission_date"
+experiments_column_type = "none"
+

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -167,6 +167,13 @@ friendly_name = "Sponsored Tiles Preference Toggled"
 description = "Number of times Contile Sponsored Tiles setting is flipped."
 owner = "xluo-all@mozilla.com"
 
+[metrics.new_profile_activation]
+select_expression = "COALESCE(SUM(activated))"
+data_source = "new_profile_activation" 
+friendly_name = "New Profile Activation"
+description = "A new profile is counted as activated one week after creation if it meets the following conditions: 1) at least 3 days of use during first week 2) at least one search between days 4-7."
+owner = "vsabino@mozilla.com"
+
 
 [data_sources]
 
@@ -222,6 +229,12 @@ from_expression = """(
     FROM `mozdata.search.mobile_search_clients_engines_sources_daily` 
     WHERE os = "iOS" AND normalized_app_name = "Fennec"
 )"""
+experiments_column_type = "simple"
+client_id_column = "client_id"
+submission_date_column = "submission_date"
+
+[data_sources.new_profile_activation]
+from_expression = "`moz-fx-data-shared-prod.firefox_ios.new_profile_activation`"
 experiments_column_type = "simple"
 client_id_column = "client_id"
 submission_date_column = "submission_date"


### PR DESCRIPTION
This PR adds the definitions for the [Mobile Activation Metric](https://docs.google.com/document/d/1ab2bRcmOdkxgLu-Xin7fZ25qFZGY5IyyMEkVCB1jSoQ/edit#), for future use in experiments.