### PR TITLE
Rerun `abouthome-startup-cache-3` experiment

### DIFF
--- a/jetstream/abouthome-startup-cache-3.toml
+++ b/jetstream/abouthome-startup-cache-3.toml
@@ -485,3 +485,5 @@ data_source = "clients_last_seen"
 [segments.high_mem]
 select_expression = 'COALESCE(MAX(memory_mb) >= 8192, FALSE)'
 data_source = "clients_last_seen"
+
+


### PR DESCRIPTION
This experiment was attempted to be rerun yesterday but was affected by a CI bug where it did not actually rerun. This was recently fixed, so I'm triggering the rerun again