### PR TITLE
Add toml files for import bookmarks image localized experiments

### DIFF
--- a/jetstream/import-bookmarks-image-and-segmentation-de.toml
+++ b/jetstream/import-bookmarks-image-and-segmentation-de.toml
@@ -1,0 +1,4 @@
+[metrics]
+weekly = ['imported_bookmarks', 'imported_logins', 'imported_history']
+
+overall = ['imported_bookmarks', 'imported_logins', 'imported_history']

--- a/jetstream/import-bookmarks-image-and-segmentation-en.toml
+++ b/jetstream/import-bookmarks-image-and-segmentation-en.toml
@@ -1,0 +1,4 @@
+[metrics]
+weekly = ['imported_bookmarks', 'imported_logins', 'imported_history']
+
+overall = ['imported_bookmarks', 'imported_logins', 'imported_history']

--- a/jetstream/import-bookmarks-image-and-segmentation-fr.toml
+++ b/jetstream/import-bookmarks-image-and-segmentation-fr.toml
@@ -1,0 +1,4 @@
+[metrics]
+weekly = ['imported_bookmarks', 'imported_logins', 'imported_history']
+
+overall = ['imported_bookmarks', 'imported_logins', 'imported_history']


### PR DESCRIPTION
Hi, 

PR to incorporate additional import metrics for the following experiments:

https://experimenter.services.mozilla.com/nimbus/import-bookmarks-image-and-segmentation-fr/summary
https://experimenter.services.mozilla.com/nimbus/import-bookmarks-image-and-segmentation-de/summary
https://experimenter.services.mozilla.com/nimbus/import-bookmarks-image-and-segmentation-en/summary

The following metrics are being added: imported_logins, imported_bookmarks, imported_history