### PR TITLE
Skip experiment

### DIFF
--- a/jetstream/persist-search-term-staged-rollout-phase-1.toml
+++ b/jetstream/persist-search-term-staged-rollout-phase-1.toml
@@ -1,6 +1,7 @@
 
 
 [experiment]
+skip = true
 start_date = "2023-01-17"
 
 


### PR DESCRIPTION
This experiment has never been launched, but jetstream is picking it up for analysis due to Experimenter exposing it as a real experiment.