### PR TITLE
Update persist-search-term-staged-rollout-phase-1.toml

### DIFF
--- a/jetstream/persist-search-term-staged-rollout-phase-1.toml
+++ b/jetstream/persist-search-term-staged-rollout-phase-1.toml
@@ -1,9 +1,6 @@
 
 
 [experiment]
-skip = true
-start_date = "2023-01-17"
-
 
 [metrics]
 


### PR DESCRIPTION
Start of the experiment has been moved to March. We should use the Experimenter date instead of overwriting it here