### PR TITLE
add Desktop DAU and DAU 28MA

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -267,7 +267,7 @@ description = """
     The average number of unique clients with >0 active hours and >0 URIs loaded that
     we received a main ping from each day in the 28-day period ending on December 15th. 
     To reconstruct the annual Desktop DAU KPI, this metric needs to be aggregated by
-    `EXTRACT(YEAR FROM submission_date)`.
+    `EXTRACT(YEAR FROM submission_date)`.  
 
     For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -239,48 +239,40 @@ description = """
 
 [metrics.daily_active_users]
 data_source = "clients_daily"
-select_expression = """COUNTIF(
-    active_hours_sum > 0 AND
-    COALESCE(
-        scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum,
-        scalar_parent_browser_engagement_total_uri_count_sum,
-        0
-    ) > 0
-)"""
+select_expression = "COUNTIF(active_hours_sum > 0 AND total_uri_count > 0)"
 type = "scalar"
 friendly_name = "DAU"
 description = """
-    The number of unique clients that we received a main ping from on each `submission_date`,
-    given that the client had >0 active hours and >0 URIs loaded.
+    The number of unique clients with >0 active hours and >0 URIs loaded that
+    we received a main ping from each day. To be comparable to DAU used for KPI
+    tracking, this metric needs to be aggregated by `submission_date`.  
 
-    For questions, please contact bochocki@mozilla.com or the Browser Data Science team.
+    For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
 category = "KPI"
-owner = "bochocki@mozilla.com"
+owner = "bochocki@mozilla.com, firefox-kpi@mozilla.com"
 deprecated = false
 
 
-[metrics.daily_active_users_28_day_moving_average]
+[metrics.desktop_dau_kpi]
 data_source = "clients_daily"
-select_expression = """AVG(COUNTIF(
+select_expression = """COUNTIF(
     active_hours_sum > 0 AND
-    COALESCE(
-        scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum,
-        scalar_parent_browser_engagement_total_uri_count_sum,
-        0
-    ) > 0
-)) OVER (ORDER BY submission_date ROWS BETWEEN 27 PRECEDING AND CURRENT ROW)"""
+    total_uri_count > 0 AND
+    FORMAT_DATE('%m-%d', submission_date) BETWEEN '11-18' AND '12-15'
+    ) / 28"""
 type = "scalar"
-friendly_name = "DAU 28MA"
+friendly_name = "Desktop DAU KPI"
 description = """
-    The number of unique clients that we received a main ping from on each `submission_date`,
-    given that the client had >0 active hours and >0 URIs loaded, averaged over a 28-day
-    period that ends on the `submission_date`.
+    The average number of unique clients with >0 active hours and >0 URIs loaded that
+    we received a main ping from each day in the 28-day period ending on December 15th. 
+    To reconstruct the annual Desktop DAU KPI, this metric needs to be aggregated by
+    `EXTRACT(YEAR FROM submission_date)`.
 
-    For questions, please contact bochocki@mozilla.com or the Browser Data Science team.
+    For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
 category = "KPI"
-owner = "bochocki@mozilla.com"
+owner = "bochocki@mozilla.com, firefox-kpi@mozilla.com"
 deprecated = false
 
 

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -237,6 +237,53 @@ description = """
 """
 
 
+[metrics.daily_active_users]
+data_source = "clients_daily"
+select_expression = """COUNTIF(
+    active_hours_sum > 0 AND
+    COALESCE(
+        scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum,
+        scalar_parent_browser_engagement_total_uri_count_sum,
+        0
+    ) > 0
+)"""
+type = "scalar"
+friendly_name = "DAU"
+description = """
+    The number of unique clients that we received a main ping from on each `submission_date`,
+    given that the client had >0 active hours and >0 URIs loaded.
+
+    For questions, please contact bochocki@mozilla.com or the Browser Data Science team.
+"""
+category = "KPI"
+owner = "bochocki@mozilla.com"
+deprecated = false
+
+
+[metrics.daily_active_users_28_day_moving_average]
+data_source = "clients_daily"
+select_expression = """AVG(COUNTIF(
+    active_hours_sum > 0 AND
+    COALESCE(
+        scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum,
+        scalar_parent_browser_engagement_total_uri_count_sum,
+        0
+    ) > 0
+)) OVER (ORDER BY submission_date ROWS BETWEEN 27 PRECEDING AND CURRENT ROW)"""
+type = "scalar"
+friendly_name = "DAU 28MA"
+description = """
+    The number of unique clients that we received a main ping from on each `submission_date`,
+    given that the client had >0 active hours and >0 URIs loaded, averaged over a 28-day
+    period that ends on the `submission_date`.
+
+    For questions, please contact bochocki@mozilla.com or the Browser Data Science team.
+"""
+category = "KPI"
+owner = "bochocki@mozilla.com"
+deprecated = false
+
+
 [metrics.disable_pocket_clicks]
 data_source = "activity_stream_events"
 select_expression = """COUNTIF(

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -245,7 +245,9 @@ friendly_name = "DAU"
 description = """
     The number of unique clients with >0 active hours and >0 URIs loaded that
     we received a main ping from each day. To be comparable to DAU used for KPI
-    tracking, this metric needs to be aggregated by `submission_date`.  
+    tracking, this metric needs to be aggregated by `submission_date`. If the
+    metric is NOT aggregated by `submission_date`, the metric is similar to a 
+    "days of use" metric.
 
     For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """


### PR DESCRIPTION
Adds definitions for desktop DAU and DAU 28MA.

I added more context around metric ownership in the description because we want to have clear signposts for issues with these metrics, and it seems like the `owner` field is not rendered on [mozilla.github.io](https://mozilla.github.io/metric-hub). Please let me know if there's a better way to make ownership/contact information available.

Ticket: https://mozilla-hub.atlassian.net/browse/DS-2680