### PR TITLE
Focus legacy to glean conversion

### DIFF
--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -75,7 +75,7 @@ owner = "xluo-all@mozilla.com"
 [metrics.search_count_imputed]
 friendly_name = "SAP search count (legacy to glean)"
 description = "Imputed SAP for converting historical search counts from legacy to glean"
-select_expression = "{{agg_sum('search_count') * 0.45}}"
+select_expression = "SUM(IF(submission_date <= '2023-01-01', 'search_count'* 0.45,'search_count'))"
 data_source = "mobile_search_clients_engines_sources_daily"
 category = "search"
 type = "scalar" 
@@ -196,3 +196,4 @@ from_expression = "mozdata.search.mobile_search_clients_engines_sources_daily"
 experiments_column_type = "simple"
 client_id_column = "client_id"
 submission_date_column = "submission_date"
+

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -72,6 +72,14 @@ category = "search"
 type = "scalar" 
 owner = "xluo-all@mozilla.com"
 
+[metrics.search_count_imputed]
+friendly_name = "SAP search count (legacy to glean)"
+description = "Imputed SAP for converting historical search counts from legacy to glean"
+select_expression = "{{agg_sum('search_count') * 0.45}}"
+data_source = "mobile_search_clients_engines_sources_daily"
+category = "search"
+type = "scalar" 
+owner = "xluo-all@mozilla.com"
 
 [metrics.tagged_search_count]
 data_source = "mobile_search_clients_engines_sources_daily"

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -73,9 +73,9 @@ type = "scalar"
 owner = "xluo-all@mozilla.com"
 
 [metrics.search_count_imputed]
-friendly_name = "SAP search count (legacy to glean)"
+friendly_name = "SAP search count (legacy to glean conversion)"
 description = "Imputed SAP for converting historical search counts from legacy to glean"
-select_expression = "SUM(IF(submission_date <= '2023-01-01', 'search_count'* 0.45,'search_count'))"
+select_expression = 'ROUND(SUM(IF(submission_date < '2023-01-01', "search_count"* 0.49,"search_count")))'
 data_source = "mobile_search_clients_engines_sources_daily"
 category = "search"
 type = "scalar" 


### PR DESCRIPTION
The field "search_count_imputed"  converts legacy search count data prior to 2023-01-01 to glean using legacy to glean multiplier  of 0.49. This field is introduced  because we observed that the search counts for glean and legacy differ  by big margin for Focus android . Hence we developed a multiplier for converting historical search counts from legacy to glean for focus android. For more details please refer to : https://docs.google.com/document/d/1mx9bdm2jXlcO4UsqdzaSvOE4Ig2ZoDKeDPMR1XiRMvI/edit#