### PR TITLE
Add colorways expiry jetstream config file

### DIFF
--- a/jetstream/colorways-expiring-fx108.toml
+++ b/jetstream/colorways-expiring-fx108.toml
@@ -1,0 +1,9 @@
+[metrics]
+weekly = ["fxview_opened"]
+overall = ["fxview_opened"]
+
+[metrics.fxview_opened]
+data_source = "events"
+select_expression = "CAST(SUM(CASE WHEN event_category = 'firefoxview' AND event_method = 'entered' THEN 1 ELSE 0 END) > 0 AS INT)"
+
+[metrics.fxview_opened.statistics.binomial]


### PR DESCRIPTION
Add firefox view opened metric to experiment jetstream config file for colorways expiry