### PR TITLE
Rs650 add focus i os search offset to metrics hub

### DIFF
--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -76,7 +76,7 @@ owner = "xluo-all@mozilla.com"
 [metrics.search_count_imputed]
 friendly_name = "SAP search count (legacy to glean conversion)"
 description = "Imputed SAP for converting historical search counts from legacy to glean"
-select_expression = "ROUND(SUM(IF((submission_date > '2023-01-01') AND (app_version < 111), search_count - search_count * 0.4, search_count)))"
+select_expression = "ROUND(SUM(IF((submission_date > '2023-01-01') AND (browser_version_info.major_version < 111), search_count - search_count * 0.4, search_count)))"
 data_source = "mobile_search_clients_engines_sources_daily"
 category = "search"
 type = "scalar" 

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -73,6 +73,15 @@ category = "search"
 type = "scalar"
 owner = "xluo-all@mozilla.com"
 
+[metrics.search_count_imputed]
+friendly_name = "SAP search count (legacy to glean conversion)"
+description = "Imputed SAP for converting historical search counts from legacy to glean"
+select_expression = "ROUND(SUM(IF((submission_date > '2023-01-01') AND (app_version < 111), search_count - search_count * 0.4, search_count)))"
+data_source = "mobile_search_clients_engines_sources_daily"
+category = "search"
+type = "scalar" 
+owner = "xluo-all@mozilla.com"
+
 
 [metrics.tagged_search_count]
 friendly_name = "Tagged SAP searches"


### PR DESCRIPTION
in Focus iOS, search numbers reported by Glean do not match the ones reported by legacy. After investigating, we found that that is due to a [product bug](https://github.com/mozilla-mobile/focus-ios/issues/3703) that makes it so direct URLs typed in the address bar are counted as search. This inflates Glean reported search numbers in Focus iOS by roughly 40%.
search_count_imputed field  accounts for this discrepancy in metrics-hub