### PR TITLE
add mobile DAU definitions

### DIFF
--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -357,6 +357,20 @@ friendly_name = "Baseline"
 description = "Baseline Ping"
 build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
 
+[data_sources.baseline_v2]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "fenix"
+friendly_name = "Baseline"
+description = "Baseline Ping"
+build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
+
 [data_sources.events]
 from_expression = """(
     SELECT

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -28,7 +28,8 @@ description = """
     The number of unique clients that we received a baseline ping from each day, excluding
     pings originating from BrowserStack. To be comparable to DAU used for KPI tracking,
     this metric needs to be aggregated by `submission_date`. If the metric is NOT
-    aggregated by `submission_date`, the metric is similar to a "days of use" metric.
+    aggregated by `submission_date`, the metric is similar to a "days of use" metric. For more details, refer to
+    [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
 
     For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -20,7 +20,7 @@ data_source = "baseline"
 
 
 [metrics.daily_active_users]
-data_source = "baseline"
+data_source = "baseline_v2"
 select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
 type = "scalar"
 friendly_name = "DAU"

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -18,6 +18,25 @@ description = "The number of days in an observation window that clients used the
 select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
 data_source = "baseline"
 
+
+[metrics.daily_active_users]
+data_source = "baseline"
+select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
+type = "scalar"
+friendly_name = "DAU"
+description = """
+    The number of unique clients that we received a baseline ping from each day, excluding
+    pings originating from BrowserStack. To be comparable to DAU used for KPI tracking,
+    this metric needs to be aggregated by `submission_date`. If the metric is NOT
+    aggregated by `submission_date`, the metric is similar to a "days of use" metric.
+
+    For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+category = "KPI"
+owner = "bochocki@mozilla.com, firefox-kpi@mozilla.com"
+deprecated = false
+
+
 [metrics.user_reports_site_issue_count]
 data_source = "events"
 select_expression = """

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -253,7 +253,7 @@ description = """
     For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
 category = "KPI"
-owner = "bochocki@mozilla.com, firefox-kpi@mozilla.com"
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
 
@@ -275,7 +275,7 @@ description = """
     For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
 category = "KPI"
-owner = "bochocki@mozilla.com, firefox-kpi@mozilla.com"
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
 

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -247,7 +247,8 @@ description = """
     we received a main ping from each day. To be comparable to DAU used for KPI
     tracking, this metric needs to be aggregated by `submission_date`. If the
     metric is NOT aggregated by `submission_date`, the metric is similar to a 
-    "days of use" metric.
+    "days of use" metric. For more details, refer to
+    [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
 
     For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -33,7 +33,7 @@ data_source = "baseline"
 
 
 [metrics.daily_active_users]
-data_source = "baseline"
+data_source = "baseline_v2"
 select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
 type = "scalar"
 friendly_name = "DAU"

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -31,6 +31,25 @@ description = "The number of days in an observation window that clients used the
 select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
 data_source = "baseline"
 
+
+[metrics.daily_active_users]
+data_source = "baseline"
+select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
+type = "scalar"
+friendly_name = "DAU"
+description = """
+    The number of unique clients that we received a baseline ping from each day, excluding
+    pings originating from BrowserStack. To be comparable to DAU used for KPI tracking,
+    this metric needs to be aggregated by `submission_date`. If the metric is NOT
+    aggregated by `submission_date`, the metric is similar to a "days of use" metric.
+
+    For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+category = "KPI"
+owner = "bochocki@mozilla.com, firefox-kpi@mozilla.com"
+deprecated = false
+
+
 ## search metrics
 
 [metrics.organic_search_count]

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -211,6 +211,20 @@ friendly_name = "Baseline"
 description = "Baseline Ping"
 build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
 
+[data_sources.baseline_v2]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "firefox_ios"
+friendly_name = "Baseline"
+description = "Baseline Ping"
+build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
+
 [data_sources.events]
 from_expression = """(
     SELECT

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -41,7 +41,8 @@ description = """
     The number of unique clients that we received a baseline ping from each day, excluding
     pings originating from BrowserStack. To be comparable to DAU used for KPI tracking,
     this metric needs to be aggregated by `submission_date`. If the metric is NOT
-    aggregated by `submission_date`, the metric is similar to a "days of use" metric.
+    aggregated by `submission_date`, the metric is similar to a "days of use" metric. For more details, refer to
+    [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
 
     For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -48,7 +48,8 @@ description = """
     this metric needs to be aggregated by `submission_date`. If the metric is NOT
     aggregated by `submission_date`, the metric is similar to a "days of use" metric. Note
     that data retention on `focus_android.baseline` has [historically been only 180 days](https://bugzilla.mozilla.org/show_bug.cgi?id=1828666),
-    which is shorter than other mobile `baseline` tables.
+    which is shorter than other mobile `baseline` tables. For more details, refer to
+    [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
 
     For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -37,6 +37,26 @@ select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
 data_source = "baseline"
 
 
+[metrics.daily_active_users]
+data_source = "baseline"
+select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
+type = "scalar"
+friendly_name = "DAU"
+description = """
+    The number of unique clients that we received a baseline ping from each day, excluding
+    pings originating from BrowserStack. To be comparable to DAU used for KPI tracking,
+    this metric needs to be aggregated by `submission_date`. If the metric is NOT
+    aggregated by `submission_date`, the metric is similar to a "days of use" metric. Note
+    that data retention on `focus_android.baseline` has [historically been only 180 days](https://bugzilla.mozilla.org/show_bug.cgi?id=1828666),
+    which is shorter than other mobile `baseline` tables.
+
+    For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+category = "KPI"
+owner = "bochocki@mozilla.com, firefox-kpi@mozilla.com"
+deprecated = false
+
+
 [metrics.ad_clicks]
 select_expression = "{{agg_sum('ad_click')}}"
 data_source = "mobile_search_clients_engines_sources_daily"

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -38,7 +38,7 @@ data_source = "baseline"
 
 
 [metrics.daily_active_users]
-data_source = "baseline"
+data_source = "baseline_v2"
 select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
 type = "scalar"
 friendly_name = "DAU"

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -180,6 +180,20 @@ friendly_name = "Baseline"
 description = "Baseline Ping"
 build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
 
+[data_sources.baseline_v2]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "focus_android"
+friendly_name = "Baseline"
+description = "Baseline Ping"
+build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
+
 [data_sources.events]
 from_expression = """(
     SELECT

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -36,6 +36,24 @@ select_expression = "COUNT(DISTINCT DATE(submission_timestamp))"
 data_source = "baseline"
 
 
+[metrics.daily_active_users]
+data_source = "baseline"
+select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
+type = "scalar"
+friendly_name = "DAU"
+description = """
+    The number of unique clients that we received a baseline ping from each day, excluding
+    pings originating from BrowserStack. To be comparable to DAU used for KPI tracking,
+    this metric needs to be aggregated by `submission_date`. If the metric is NOT
+    aggregated by `submission_date`, the metric is similar to a "days of use" metric.
+
+    For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+category = "KPI"
+owner = "bochocki@mozilla.com, firefox-kpi@mozilla.com"
+deprecated = false
+
+
 [metrics.ad_clicks]
 select_expression = "{{agg_sum('ad_click')}}"
 data_source = "mobile_search_clients_engines_sources_daily"

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -45,7 +45,8 @@ description = """
     The number of unique clients that we received a baseline ping from each day, excluding
     pings originating from BrowserStack. To be comparable to DAU used for KPI tracking,
     this metric needs to be aggregated by `submission_date`. If the metric is NOT
-    aggregated by `submission_date`, the metric is similar to a "days of use" metric.
+    aggregated by `submission_date`, the metric is similar to a "days of use" metric. For more details, refer to
+    [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
 
     For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -185,6 +185,20 @@ friendly_name = "Baseline"
 description = "Baseline Ping"
 build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
 
+[data_sources.baseline_v2]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
+)"""
+client_id_column = "client_info.client_id"
+experiments_column_type = "glean"
+default_dataset = "focus_ios"
+friendly_name = "Baseline"
+description = "Baseline Ping"
+build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
+
 [data_sources.events]
 from_expression = """(
     SELECT

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -37,7 +37,7 @@ data_source = "baseline"
 
 
 [metrics.daily_active_users]
-data_source = "baseline"
+data_source = "baseline_v2"
 select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
 type = "scalar"
 friendly_name = "DAU"


### PR DESCRIPTION
Ticket: [DS-2680](https://mozilla-hub.atlassian.net/browse/DS-2680)

This adds product-specific DAU metrics for the four mobile products that contribute to our Mobile KPI: Fenix, Firefox iOS, Focus Android, and Focus iOS.

Note that the retention period on `focus_android.baseline` is currently only 180 days, but [there's an open ticket to expand that to 760 days](https://bugzilla.mozilla.org/show_bug.cgi?id=1828666). When calculating DAU for reporting, we've been using `focus_android.baseline_clients_daily` instead of `focus_android.baseline`:

```sql
SELECT submission_date,
       COUNT(1) AS dau
  FROM focus_android.baseline_clients_daily
 WHERE submission_date >= start_date
   AND (isp != 'BrowserStack' OR isp IS NULL)
 GROUP BY 1
```

But for the purpose of experiments -- which Metric Hub is most commonly used for -- the `baseline` table includes useful columns (like `ping_info.experiments.*`) that are not available in the `baseline_clients_daily` table. So I opted to use `focus_android.baseline` here. This will keep its DAU behavior consistent with other mobile products on Metric Hub.