### PR TITLE
add `submission_date_column` and `client_id_column`

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1233,6 +1233,8 @@ description = "Search Clients Engines Sources Daily"
 
 [data_sources.clients_daily]
 from_expression = "mozdata.telemetry.clients_daily"
+submission_date_column = "submission_date"
+client_id_column = "client_id"
 friendly_name = "Clients Daily"
 description = "Clients Daily"
 

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -219,6 +219,7 @@ from_expression = """(
     FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
 )"""
 client_id_column = "client_info.client_id"
+submission_date_column = "DATE(submission_timestamp)"
 experiments_column_type = "glean"
 default_dataset = "firefox_ios"
 friendly_name = "Baseline"

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -188,6 +188,7 @@ from_expression = """(
     FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
 )"""
 client_id_column = "client_info.client_id"
+submission_date_column = "DATE(submission_timestamp)"
 experiments_column_type = "glean"
 default_dataset = "focus_android"
 friendly_name = "Baseline"

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -193,6 +193,7 @@ from_expression = """(
     FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
 )"""
 client_id_column = "client_info.client_id"
+submission_date_column = "DATE(submission_timestamp)"
 experiments_column_type = "glean"
 default_dataset = "focus_ios"
 friendly_name = "Baseline"


### PR DESCRIPTION
- Add `submission_date_column` to `baseline_v2` data sources in for KPI-relevant mobile products.
- Add `submission_date_column` and `client_id_column` to `data_sources.clients_daily` for `firefox_desktop`.