### PR TITLE
add and update DAU definitions

### DIFF
--- a/definitions/cross_product.toml
+++ b/definitions/cross_product.toml
@@ -1,6 +1,6 @@
 [metrics]
 
-[metrics.mobile_daily_active_users]
+[metrics.mobile_daily_active_users_v1]
 data_source = "mobile_active_users_aggregates"
 select_expression = "SUM(dau)"
 type = "scalar"

--- a/definitions/cross_product.toml
+++ b/definitions/cross_product.toml
@@ -1,0 +1,53 @@
+[metrics]
+
+[metrics.mobile_daily_active_users]
+data_source = "mobile_active_users_aggregates"
+select_expression = "SUM(dau)"
+type = "scalar"
+friendly_name = "Mobile DAU"
+description = """
+    This is the official DAU reporting definition. The logic is
+    [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/tree/main/sql_generators/active_users/templates)
+    and is automatically cross-checked, actively monitored, and change controlled.
+    Whenever possible, this is the preferred DAU reporting definition to use for Mobile products.
+    This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`,
+    it is similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = false
+
+[metrics.mobile_dau_kpi]
+data_source = "mobile_active_users_aggregates"
+select_expression = "SUM(IF(FORMAT_DATE('%m-%d', submission_date) BETWEEN '11-18' AND '12-15', dau, 0)) / 28"
+type = "scalar"
+friendly_name = "Mobile DAU KPI"
+description = """
+    The average [Mobile DAU](https://mozilla.github.io/metric-hub/metrics/cross_product/#mobile_daily_active_users) in the 28-day period ending on December 15th. This is the official
+    Mobile DAU KPI reporting definition. The logic for calculating DAU is
+    [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/tree/main/sql_generators/active_users/templates)
+    and is automatically cross-checked, actively monitored, and change controlled.
+    To reconstruct the annual Mobile DAU KPI, this metric needs to be aggregated by
+    `EXTRACT(YEAR FROM submission_date)`.  
+
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+category = "KPI"
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = false
+
+
+[data_sources]
+
+[data_sources.mobile_active_users_aggregates]
+from_expression = """(
+    SELECT *
+     FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
+    WHERE app_name IN ('Fenix',  'Firefox iOS', 'Focus Android', 'Focus iOS')
+)"""
+friendly_name = "Active Users Aggregates"
+description = "Active Users Aggregates, filtered on the Mobile product group"
+submission_date_column = "submission_date"

--- a/definitions/cross_product.toml
+++ b/definitions/cross_product.toml
@@ -1,7 +1,7 @@
 [metrics]
 
 [metrics.mobile_daily_active_users_v1]
-data_source = "mobile_active_users_aggregates"
+data_source = "mobile_active_users_aggregates_v1"
 select_expression = "SUM(dau)"
 type = "scalar"
 friendly_name = "Mobile DAU"
@@ -20,7 +20,7 @@ owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
 [metrics.mobile_dau_kpi_v1]
-data_source = "mobile_active_users_aggregates"
+data_source = "mobile_active_users_aggregates_v1"
 select_expression = "SUM(IF(FORMAT_DATE('%m-%d', submission_date) BETWEEN '11-18' AND '12-15', dau, 0)) / 28"
 type = "scalar"
 friendly_name = "Mobile DAU KPI"

--- a/definitions/cross_product.toml
+++ b/definitions/cross_product.toml
@@ -44,10 +44,11 @@ deprecated = false
 
 [data_sources.mobile_active_users_aggregates_v1]
 from_expression = """(
-    SELECT *, NULL as client_id
+    SELECT *
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name IN ('Fenix',  'Firefox iOS', 'Focus Android', 'Focus iOS')
 )"""
 friendly_name = "Active Users Aggregates"
 description = "Active Users Aggregates, filtered on the Mobile product group"
 submission_date_column = "submission_date"
+client_id_column = "NULL"  # this table doesn't include client_id, and we don't need it for calculating DAU

--- a/definitions/cross_product.toml
+++ b/definitions/cross_product.toml
@@ -44,7 +44,7 @@ deprecated = false
 
 [data_sources.mobile_active_users_aggregates]
 from_expression = """(
-    SELECT *
+    SELECT *, NULL as client_id
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name IN ('Fenix',  'Firefox iOS', 'Focus Android', 'Focus iOS')
 )"""

--- a/definitions/cross_product.toml
+++ b/definitions/cross_product.toml
@@ -42,7 +42,7 @@ deprecated = false
 
 [data_sources]
 
-[data_sources.mobile_active_users_aggregates]
+[data_sources.mobile_active_users_aggregates_v1]
 from_expression = """(
     SELECT *, NULL as client_id
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`

--- a/definitions/cross_product.toml
+++ b/definitions/cross_product.toml
@@ -19,7 +19,7 @@ description = """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
-[metrics.mobile_dau_kpi]
+[metrics.mobile_dau_kpi_v1]
 data_source = "mobile_active_users_aggregates"
 select_expression = "SUM(IF(FORMAT_DATE('%m-%d', submission_date) BETWEEN '11-18' AND '12-15', dau, 0)) / 28"
 type = "scalar"

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -382,7 +382,7 @@ owner = "vsabino@mozilla.com"
 
 [data_sources.active_users_aggregates]
 from_expression = """(
-    SELECT *
+    SELECT *, NULL as client_id
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name = 'Fenix'
 )"""

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -35,8 +35,45 @@ description = """
 """
 category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = true
+
+[metrics.daily_active_users_v2]
+data_source = "active_users_aggregates"
+select_expression = "SUM(dau)"
+type = "scalar"
+friendly_name = "Fenix DAU"
+description = """
+    This is the official DAU reporting definition. The logic is
+    [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/blob/main/sql_generators/active_users/templates/mobile_query.sql)
+    and is automatically cross-checked, actively monitored, and change controlled.
+    Whenever possible, this is the preferred DAU reporting definition to use for Fenix.
+    This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`,
+    it is similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
+[metrics.client_level_daily_active_users]
+data_source = "baseline_v2"
+select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
+type = "scalar"
+friendly_name = "Fenix Client-Level DAU"
+description = """
+    This metric reports DAU values similar (but not necessarily identical)
+    to the [official DAU reporting definition](https://mozilla.github.io/metric-hub/metrics/fenix/#daily_active_users_v2).
+    It's generally preferable to use the official DAU reporting definition when possible; this metric
+    exists only for cases where reporting `client_id` is required (e.g. for experiments). This metric
+    needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`, it is
+    similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = false
 
 [metrics.user_reports_site_issue_count]
 data_source = "events"
@@ -343,6 +380,16 @@ owner = "vsabino@mozilla.com"
 
 [data_sources]
 
+[data_sources.active_users_aggregates]
+from_expression = """(
+    SELECT *
+     FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
+    WHERE app_name = 'Fenix'
+)"""
+friendly_name = "Active Users Aggregates"
+description = "Active Users Aggregates, filtered on Fenix"
+submission_date_column = "submission_date"
+
 [data_sources.baseline]
 from_expression = """(
     SELECT
@@ -365,6 +412,7 @@ from_expression = """(
     FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
 )"""
 client_id_column = "client_info.client_id"
+submission_date_column = "DATE(submission_timestamp)"
 experiments_column_type = "glean"
 default_dataset = "fenix"
 friendly_name = "Baseline"

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -56,7 +56,7 @@ description = """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
-[metrics.client_level_daily_active_users]
+[metrics.client_level_daily_active_users_v1]
 data_source = "baseline_v2"
 select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
 type = "scalar"
@@ -380,15 +380,16 @@ owner = "vsabino@mozilla.com"
 
 [data_sources]
 
-[data_sources.active_users_aggregates]
+[data_sources.active_users_aggregates_v1]
 from_expression = """(
-    SELECT *, NULL as client_id
+    SELECT *
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name = 'Fenix'
 )"""
 friendly_name = "Active Users Aggregates"
 description = "Active Users Aggregates, filtered on Fenix"
 submission_date_column = "submission_date"
+client_id_column = "NULL"  # this table doesn't include client_id, and we don't need it for calculating DAU
 
 [data_sources.baseline]
 from_expression = """(

--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -38,7 +38,7 @@ owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = true
 
 [metrics.daily_active_users_v2]
-data_source = "active_users_aggregates"
+data_source = "active_users_aggregates_v1"
 select_expression = "SUM(dau)"
 type = "scalar"
 friendly_name = "Fenix DAU"

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -256,9 +256,28 @@ category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = true
 
+[metrics.daily_active_users_v2]
+data_source = "active_users_aggregates_v1"
+select_expression = "SUM(dau)"
+type = "scalar"
+friendly_name = "Firefox Desktop DAU"
+description = """
+    This is the official DAU reporting definition. The logic is
+    [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/blob/main/sql_generators/active_users/templates/desktop_query.sql)
+    and is automatically cross-checked, actively monitored, and change controlled.
+    Whenever possible, this is the preferred DAU reporting definition to use for Desktop.
+    This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`,
+    it is similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = false
+
 [metrics.client_level_daily_active_users_v1]
 data_source = "clients_daily"
-select_expression = "COUNTIF(active_hours_sum > 0 AND total_uri_count > 0)"
+select_expression = "COUNTIF(active_hours_sum > 0 AND total_uri_count > 0 AND isp_name <> 'BrowserStack')"
 type = "scalar"
 friendly_name = "Firefox Desktop Client-Level DAU"
 description = """
@@ -282,6 +301,23 @@ select_expression = """COUNTIF(
     total_uri_count > 0 AND
     FORMAT_DATE('%m-%d', submission_date) BETWEEN '11-18' AND '12-15'
     ) / 28"""
+type = "scalar"
+friendly_name = "Desktop DAU KPI"
+description = """
+    The average number of unique clients with >0 active hours and >0 URIs loaded that
+    we received a main ping from each day in the 28-day period ending on December 15th. 
+    To reconstruct the annual Desktop DAU KPI, this metric needs to be aggregated by
+    `EXTRACT(YEAR FROM submission_date)`.  
+
+    For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+category = "KPI"
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = true
+
+[metrics.desktop_dau_kpi_v2]
+data_source = "active_users_aggregates_v1"
+select_expression = "SUM(IF(FORMAT_DATE('%m-%d', submission_date) BETWEEN '11-18' AND '12-15', dau, 0)) / 28"
 type = "scalar"
 friendly_name = "Firefox Desktop DAU KPI"
 description = """

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1227,7 +1227,7 @@ description = "Normalized Country Code"
 
 [data_sources.active_users_aggregates]
 from_expression = """(
-    SELECT *
+    SELECT *, NULL as client_id
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name = 'Firefox Desktop'
 )"""

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -254,6 +254,44 @@ description = """
 """
 category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = true
+
+[metrics.daily_active_users_v2]
+data_source = "active_users_aggregates"
+select_expression = "SUM(dau)"
+type = "scalar"
+friendly_name = "Firefox Desktop DAU"
+description = """
+    This is the official DAU reporting definition. The logic is
+    [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/blob/bba17589320d48363c83081d1b8dc9acd5d9cde3/sql_generators/active_users/templates/desktop_query.sql#L81)
+    and is automatically cross-checked, actively monitored, and change controlled.
+    Whenever possible, this is the preferred DAU reporting definition to use for Firefox Desktop.
+    This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`,
+    it is similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = false
+
+[metrics.client_level_daily_active_users]
+data_source = "baseline_v2"
+select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
+type = "scalar"
+friendly_name = "Firefox Desktop Client-Level DAU"
+description = """
+    This metric reports DAU values similar (but not necessarily identical)
+    to the [official DAU reporting definition](https://mozilla.github.io/metric-hub/metrics/firefox_desktop/#daily_active_users_v2).
+    It's generally preferable to use the official DAU reporting definition when possible; this metric
+    exists only for cases where reporting `client_id` is required (e.g. for experiments). This metric
+    needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`, it is
+    similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
 
@@ -265,14 +303,17 @@ select_expression = """COUNTIF(
     FORMAT_DATE('%m-%d', submission_date) BETWEEN '11-18' AND '12-15'
     ) / 28"""
 type = "scalar"
-friendly_name = "Desktop DAU KPI"
+friendly_name = "Firefox Desktop DAU KPI"
 description = """
-    The average number of unique clients with >0 active hours and >0 URIs loaded that
-    we received a main ping from each day in the 28-day period ending on December 15th. 
+    The average [Firefox Desktop DAU](https://mozilla.github.io/metric-hub/metrics/firefox_desktop/#daily_active_users_v2)
+    in the 28-day period ending on December 15th. This is the official Desktop DAU KPI reporting definition. The logic for calculating DAU is
+    [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/blob/main/sql_generators/active_users/templates/desktop_query.sql)
+    and is automatically cross-checked, actively monitored, and change controlled.
     To reconstruct the annual Desktop DAU KPI, this metric needs to be aggregated by
     `EXTRACT(YEAR FROM submission_date)`.  
 
-    For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
 category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
@@ -1183,7 +1224,17 @@ description = "Normalized Country Code"
 
 
 [data_sources]
-  
+
+[data_sources.active_users_aggregates]
+from_expression = """(
+    SELECT *
+     FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
+    WHERE app_name = 'Firefox Desktop'
+)"""
+friendly_name = "Active Users Aggregates"
+description = "Active Users Aggregates, filtered on Firefox Desktop"
+submission_date_column = "submission_date"
+
 [data_sources.main]
 from_expression = """(
     SELECT

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -256,28 +256,9 @@ category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = true
 
-[metrics.daily_active_users_v2]
-data_source = "active_users_aggregates"
-select_expression = "SUM(dau)"
-type = "scalar"
-friendly_name = "Firefox Desktop DAU"
-description = """
-    This is the official DAU reporting definition. The logic is
-    [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/blob/bba17589320d48363c83081d1b8dc9acd5d9cde3/sql_generators/active_users/templates/desktop_query.sql#L81)
-    and is automatically cross-checked, actively monitored, and change controlled.
-    Whenever possible, this is the preferred DAU reporting definition to use for Firefox Desktop.
-    This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`,
-    it is similar to a "days of use" metric, and not DAU.
-    
-    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
-    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
-"""
-owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
-deprecated = false
-
 [metrics.client_level_daily_active_users]
-data_source = "baseline_v2"
-select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
+data_source = "clients_daily"
+select_expression = "COUNTIF(active_hours_sum > 0 AND total_uri_count > 0)"
 type = "scalar"
 friendly_name = "Firefox Desktop Client-Level DAU"
 description = """
@@ -293,7 +274,6 @@ description = """
 """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
-
 
 [metrics.desktop_dau_kpi]
 data_source = "clients_daily"

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -256,7 +256,7 @@ category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = true
 
-[metrics.client_level_daily_active_users]
+[metrics.client_level_daily_active_users_v1]
 data_source = "clients_daily"
 select_expression = "COUNTIF(active_hours_sum > 0 AND total_uri_count > 0)"
 type = "scalar"
@@ -1205,15 +1205,16 @@ description = "Normalized Country Code"
 
 [data_sources]
 
-[data_sources.active_users_aggregates]
+[data_sources.active_users_aggregates_v1]
 from_expression = """(
-    SELECT *, NULL as client_id
+    SELECT *
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name = 'Firefox Desktop'
 )"""
 friendly_name = "Active Users Aggregates"
 description = "Active Users Aggregates, filtered on Firefox Desktop"
 submission_date_column = "submission_date"
+client_id_column = "NULL"  # this table doesn't include client_id, and we don't need it for calculating DAU
 
 [data_sources.main]
 from_expression = """(

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -237,13 +237,14 @@ owner = "vsabino@mozilla.com"
 
 [data_sources.active_users_aggregates]
 from_expression = """(
-    SELECT *, NULL as client_id
+    SELECT *
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name = 'Firefox iOS'
 )"""
 friendly_name = "Active Users Aggregates"
 description = "Active Users Aggregates, filtered on Firefox iOS"
 submission_date_column = "submission_date"
+client_id_column = "NULL"  # this table doesn't include client_id, and we don't need it for calculating DAU
 
 [data_sources.baseline]
 from_expression = """(

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -51,7 +51,7 @@ owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = true
 
 [metrics.daily_active_users_v2]
-data_source = "active_users_aggregates"
+data_source = "active_users_aggregates_v1"
 select_expression = "SUM(dau)"
 type = "scalar"
 friendly_name = "Firefox iOS DAU"

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -48,6 +48,44 @@ description = """
 """
 category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = true
+
+[metrics.daily_active_users_v2]
+data_source = "active_users_aggregates"
+select_expression = "SUM(dau)"
+type = "scalar"
+friendly_name = "Firefox iOS DAU"
+description = """
+    This is the official DAU reporting definition. The logic is
+    [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/blob/main/sql_generators/active_users/templates/mobile_query.sql)
+    and is automatically cross-checked, actively monitored, and change controlled.
+    Whenever possible, this is the preferred DAU reporting definition to use for Firefox iOS.
+    This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`,
+    it is similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = false
+
+[metrics.client_level_daily_active_users]
+data_source = "baseline_v2"
+select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
+type = "scalar"
+friendly_name = "Firefox iOS Client-Level DAU"
+description = """
+    This metric reports DAU values similar (but not necessarily identical)
+    to the [official DAU reporting definition](https://mozilla.github.io/metric-hub/metrics/firefox_ios/#daily_active_users_v2).
+    It's generally preferable to use the official DAU reporting definition when possible; this metric
+    exists only for cases where reporting `client_id` is required (e.g. for experiments). This metric
+    needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`, it is
+    similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
 
@@ -196,6 +234,16 @@ owner = "vsabino@mozilla.com"
 
 
 [data_sources]
+
+[data_sources.active_users_aggregates]
+from_expression = """(
+    SELECT *
+     FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
+    WHERE app_name = 'Firefox iOS'
+)"""
+friendly_name = "Active Users Aggregates"
+description = "Active Users Aggregates, filtered on Firefox iOS"
+submission_date_column = "submission_date"
 
 [data_sources.baseline]
 from_expression = """(

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -69,7 +69,7 @@ description = """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
-[metrics.client_level_daily_active_users]
+[metrics.client_level_daily_active_users_v1]
 data_source = "baseline_v2"
 select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
 type = "scalar"
@@ -235,7 +235,7 @@ owner = "vsabino@mozilla.com"
 
 [data_sources]
 
-[data_sources.active_users_aggregates]
+[data_sources.active_users_aggregates_v1]
 from_expression = """(
     SELECT *
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -237,7 +237,7 @@ owner = "vsabino@mozilla.com"
 
 [data_sources.active_users_aggregates]
 from_expression = """(
-    SELECT *
+    SELECT *, NULL as client_id
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name = 'Firefox iOS'
 )"""

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -55,6 +55,44 @@ description = """
 """
 category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = true
+
+[metrics.daily_active_users_v2]
+data_source = "active_users_aggregates"
+select_expression = "SUM(dau)"
+type = "scalar"
+friendly_name = "Focus Android DAU"
+description = """
+    This is the official DAU reporting definition. The logic is
+    [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/blob/main/sql_generators/active_users/templates/focus_android_query.sql)
+    and is automatically cross-checked, actively monitored, and change controlled.
+    Whenever possible, this is the preferred DAU reporting definition to use for Focus Android.
+    This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`,
+    it is similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = false
+
+[metrics.client_level_daily_active_users]
+data_source = "baseline_v2"
+select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
+type = "scalar"
+friendly_name = "Focus Android Client-Level DAU"
+description = """
+    This metric reports DAU values similar (but not necessarily identical)
+    to the [official DAU reporting definition](https://mozilla.github.io/metric-hub/metrics/focus_android/#daily_active_users_v2).
+    It's generally preferable to use the official DAU reporting definition when possible; this metric
+    exists only for cases where reporting `client_id` is required (e.g. for experiments). This metric
+    needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`, it is
+    similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
 
@@ -165,6 +203,16 @@ owner = "xluo-all@mozilla.com"
 
 
 [data_sources]
+
+[data_sources.active_users_aggregates]
+from_expression = """(
+    SELECT *
+     FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
+    WHERE app_name = 'Focus Android'
+)"""
+friendly_name = "Active Users Aggregates"
+description = "Active Users Aggregates, filtered on Focus Android"
+submission_date_column = "submission_date"
 
 [data_sources.baseline]
 from_expression = """(

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -76,7 +76,7 @@ description = """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
-[metrics.client_level_daily_active_users]
+[metrics.client_level_daily_active_users_v1]
 data_source = "baseline_v2"
 select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
 type = "scalar"
@@ -204,15 +204,16 @@ owner = "xluo-all@mozilla.com"
 
 [data_sources]
 
-[data_sources.active_users_aggregates]
+[data_sources.active_users_aggregates_v1]
 from_expression = """(
-    SELECT *, NULL as client_id
+    SELECT *
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name = 'Focus Android'
 )"""
 friendly_name = "Active Users Aggregates"
 description = "Active Users Aggregates, filtered on Focus Android"
 submission_date_column = "submission_date"
+client_id_column = "NULL"  # this table doesn't include client_id, and we don't need it for calculating DAU
 
 [data_sources.baseline]
 from_expression = """(

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -206,7 +206,7 @@ owner = "xluo-all@mozilla.com"
 
 [data_sources.active_users_aggregates]
 from_expression = """(
-    SELECT *
+    SELECT *, NULL as client_id
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name = 'Focus Android'
 )"""

--- a/definitions/focus_android.toml
+++ b/definitions/focus_android.toml
@@ -58,7 +58,7 @@ owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = true
 
 [metrics.daily_active_users_v2]
-data_source = "active_users_aggregates"
+data_source = "active_users_aggregates_v1"
 select_expression = "SUM(dau)"
 type = "scalar"
 friendly_name = "Focus Android DAU"

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -73,7 +73,7 @@ description = """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
-[metrics.client_level_daily_active_users]
+[metrics.client_level_daily_active_users_v1]
 data_source = "baseline_v2"
 select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
 type = "scalar"
@@ -209,15 +209,16 @@ owner = "xluo-all@mozilla.com"
 
 [data_sources]
 
-[data_sources.active_users_aggregates]
+[data_sources.active_users_aggregates_v1]
 from_expression = """(
-    SELECT *, NULL as client_id
+    SELECT *
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name = 'Focus iOS'
 )"""
 friendly_name = "Active Users Aggregates"
 description = "Active Users Aggregates, filtered on Focus iOS"
 submission_date_column = "submission_date"
+client_id_column = "NULL"  # this table doesn't include client_id, and we don't need it for calculating DAU
 
 [data_sources.baseline]
 from_expression = """(

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -55,7 +55,7 @@ owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = true
 
 [metrics.daily_active_users_v2]
-data_source = "active_users_aggregates"
+data_source = "active_users_aggregates_v1"
 select_expression = "SUM(dau)"
 type = "scalar"
 friendly_name = "Focus iOS DAU"

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -52,6 +52,44 @@ description = """
 """
 category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = true
+
+[metrics.daily_active_users_v2]
+data_source = "active_users_aggregates"
+select_expression = "SUM(dau)"
+type = "scalar"
+friendly_name = "Focus iOS DAU"
+description = """
+    This is the official DAU reporting definition. The logic is
+    [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/blob/main/sql_generators/active_users/templates/mobile_query.sql)
+    and is automatically cross-checked, actively monitored, and change controlled.
+    Whenever possible, this is the preferred DAU reporting definition to use for Focus iOS.
+    This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`,
+    it is similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = false
+
+[metrics.client_level_daily_active_users]
+data_source = "baseline_v2"
+select_expression = "COUNT(DISTINCT CASE WHEN LOWER(metadata.isp.name) != 'browserstack' THEN client_info.client_id ELSE NULL END)"
+type = "scalar"
+friendly_name = "Focus iOS Client-Level DAU"
+description = """
+    This metric reports DAU values similar (but not necessarily identical)
+    to the [official DAU reporting definition](https://mozilla.github.io/metric-hub/metrics/focus_ios/#daily_active_users_v2).
+    It's generally preferable to use the official DAU reporting definition when possible; this metric
+    exists only for cases where reporting `client_id` is required (e.g. for experiments). This metric
+    needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`, it is
+    similar to a "days of use" metric, and not DAU.
+    
+    For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
+    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+"""
+owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
 
@@ -170,6 +208,16 @@ owner = "xluo-all@mozilla.com"
 
 
 [data_sources]
+
+[data_sources.active_users_aggregates]
+from_expression = """(
+    SELECT *
+     FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
+    WHERE app_name = 'Focus iOS'
+)"""
+friendly_name = "Active Users Aggregates"
+description = "Active Users Aggregates, filtered on Focus iOS"
+submission_date_column = "submission_date"
 
 [data_sources.baseline]
 from_expression = """(

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -211,7 +211,7 @@ owner = "xluo-all@mozilla.com"
 
 [data_sources.active_users_aggregates]
 from_expression = """(
-    SELECT *
+    SELECT *, NULL as client_id
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name = 'Focus iOS'
 )"""

--- a/definitions/multi_product.toml
+++ b/definitions/multi_product.toml
@@ -25,7 +25,7 @@ select_expression = "SUM(IF(FORMAT_DATE('%m-%d', submission_date) BETWEEN '11-18
 type = "scalar"
 friendly_name = "Mobile DAU KPI"
 description = """
-    The average [Mobile DAU](https://mozilla.github.io/metric-hub/metrics/cross_product/#mobile_daily_active_users) in the 28-day period ending on December 15th. This is the official
+    The average [Mobile DAU](https://mozilla.github.io/metric-hub/metrics/multi_product/#mobile_daily_active_users) in the 28-day period ending on December 15th. This is the official
     Mobile DAU KPI reporting definition. The logic for calculating DAU is
     [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/tree/main/sql_generators/active_users/templates)
     and is automatically cross-checked, actively monitored, and change controlled.

--- a/definitions/multi_product.toml
+++ b/definitions/multi_product.toml
@@ -16,6 +16,7 @@ description = """
     For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
     For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
+products = ['Fenix', 'Firefox iOS', 'Focus Android', 'Focus iOS']
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
@@ -35,6 +36,7 @@ description = """
     For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
     For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
+products = ['Fenix', 'Firefox iOS', 'Focus Android', 'Focus iOS']
 category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
@@ -50,5 +52,6 @@ from_expression = """(
 )"""
 friendly_name = "Active Users Aggregates"
 description = "Active Users Aggregates, filtered on the Mobile product group"
+products = ['Fenix', 'Firefox iOS', 'Focus Android', 'Focus iOS']
 submission_date_column = "submission_date"
 client_id_column = "NULL"  # this table doesn't include client_id, and we don't need it for calculating DAU

--- a/definitions/multi_product.toml
+++ b/definitions/multi_product.toml
@@ -16,7 +16,6 @@ description = """
     For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
     For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
-products = ['Fenix', 'Firefox iOS', 'Focus Android', 'Focus iOS']
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
@@ -36,7 +35,6 @@ description = """
     For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
     For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
-products = ['Fenix', 'Firefox iOS', 'Focus Android', 'Focus iOS']
 category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
@@ -52,6 +50,5 @@ from_expression = """(
 )"""
 friendly_name = "Active Users Aggregates"
 description = "Active Users Aggregates, filtered on the Mobile product group"
-products = ['Fenix', 'Firefox iOS', 'Focus Android', 'Focus iOS']
 submission_date_column = "submission_date"
 client_id_column = "NULL"  # this table doesn't include client_id, and we don't need it for calculating DAU


### PR DESCRIPTION
Makes several changes to the DAU definitions to simplify definitions and improve discoverability for the five products that contribute towards DAU: Firefox Desktop, Fenix, Firefox iOS, Focus Android, and Focus iOS.

Changes
- Added a `daily_active_users` and `client_level_daily_active_users` metric for each of the five relevant products.
  - `daily_active_users` is simply the sum of DAU in the `active_users_aggregates` table; this is the version of DAU that should generally be used for reporting.
  - `client_level_daily_active_users` is a version of DAU that provides client-level information. This is not used for reporting and is not guaranteed to be exactly equal to `daily_active_users` for any product on a particular date.
- Added `data_sources.active_users_aggregates` for each product; the data source is filtered by the relevant product to improve query efficiency.
- Added `cross_product.toml`, a place to store metrics that need to be applied across products. The use case here is for mobile DAU, which needs to be calculated across 4 mobile products. I added the relevant definitions to that file.
- Deprecated previous versions of DAU definitions when relevant.