### PR TITLE
Added Networking outcome and starter metrics

### DIFF
--- a/jetstream/outcomes/firefox_desktop/networking.toml
+++ b/jetstream/outcomes/firefox_desktop/networking.toml
@@ -1,0 +1,53 @@
+friendly_name = "Networking"
+description = "Network layer metrics including Necko, TLS, NSS"
+
+[metrics.dns_lookup_time]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.dns_lookup_time")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.dns_lookup_time.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.dns_lookup_time.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.dns_lookup_time.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.http_page_tls_handshake]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.http_page_tls_handshake")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.http_page_tls_handshake.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.http_page_tls_handshake.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.http_page_tls_handshake.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.http_page_open_to_first_sent]
+select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.http_page_open_to_first_sent")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.http_page_open_to_first_sent.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.http_page_open_to_first_sent.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.http_page_open_to_first_sent.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+


### PR DESCRIPTION
The Network/Security/Privacy teams would like to create a shared outcome tracking network layer metrics including Necko, TLS, and NSS.

I've created this outcome as a starting point.