### PR TITLE
fix END clause and add segments to be computed

### DIFF
--- a/jetstream/import-bookmarks-copy.toml
+++ b/jetstream/import-bookmarks-copy.toml
@@ -4,14 +4,14 @@ weekly = ['imported_bookmarks', 'imported_logins', 'imported_history', 'is_pinne
 overall = ['imported_bookmarks', 'imported_logins', 'imported_history', 'is_pinned']
 
 [segments.activity_segments]
-select_expression = """ANY_VALUE(CASE WHEN DATE_DIFF(first_seen_date, last_seen_date, DAY) < 28 THEN 'new_user' \
-WHEN DATE_DIFF(first_seen_date, last_seen_date, DAY) >= 28 \
+select_expression = """ANY_VALUE(CASE WHEN days_since_first_seen < 28 THEN 'new_user' \
+WHEN days_since_first_seen >= 28 \
      AND activity_segments_v1 = 'core_user' THEN 'core' \
-WHEN DATE_DIFF(first_seen_date, last_seen_date, DAY) >=28 \
+WHEN days_since_first_seen >=28 \
      AND activity_segments_v1 = 'regular_user' THEN 'regular' \
-WHEN DATE_DIFF(first_seen_date, last_seen_date, DAY) >= 28 \
+WHEN days_since_first_seen >= 28 \
      AND activity_segments_v1 = 'casual_user' THEN 'casual' \
-WHEN DATE_DIFF(first_seen_date, last_seen_date, DAY) >= 28 \
+WHEN days_since_first_seen >= 28 \
      AND activity_segments_v1 = 'infrequent_user' THEN 'infrequent' \
 ELSE 'other' END)"""
 data_source = 'clients_last_seen'


### PR DESCRIPTION
segmentation in experimenter failed to run due to not specifying segments to be computed. also, query was not specified correctly. fixing both issues.