### PR TITLE
custom addon metrics for nuo introduce addons experiment

### DIFF
--- a/jetstream/introduce-addons-in-aboutwelcome.toml
+++ b/jetstream/introduce-addons-in-aboutwelcome.toml
@@ -1,0 +1,22 @@
+[metrics]
+overall = ['addons_count', 'amo_addons_install']
+weekly = ['addons_count', 'amo_addons_install']
+
+[metrics.addons_count]
+select_expression = """COALESCE(MAX(active_addons_count_mean), 0)"""
+data_source = 'clients_daily'
+friendly_name = 'Count of installed active addons'
+description = 'The maximum number of active addons installed'
+
+[metrics.amo_addons_install]
+select_expression = """CAST(COALESCE(LOGICAL_OR(REGEXP_CONTAINS(environment.addons.theme.id, 
+'4634d9ed-e1f8-4a04-81ee-9425b66e1642|ceefc8d7-d251-4762-bfcd-35cdeb3c52cd|a78f47b9-eac6-4996-bc9a-54701987af18|018a697b-c598-448b-8809-71fbc9b90521') 
+  OR environment.addons.active_addons[SAFE_OFFSET(0)].value.name IN ("Facebook Container", 
+  "Privacy Badger", "Firefox Translations", "Search by Image", 
+  "Tree Style Tab", "Grammar \u0026 Spell Checker—LanguageTool", "Enhancer for YouTube™")), FALSE) AS INT)"""
+data_source = 'main'
+friendly_name = 'AMO collection addon install'
+description = 'If at least one AMO collection addon installed'
+
+[metrics.addons_count.statistics.bootstrap_mean]
+[metrics.amo_addons_install.statistics.binomial]


### PR DESCRIPTION
adding 2 custom metrics to measure addon count as well as addon count from AMO collection. addon count takes the max number of `addons_count_mean` from clients daily; addons count from amo collection checks if an addon installed from the AMO collection provided in NUO is installed