### PR TITLE
Pre-filter etp events in stricter_pbm outcome

### DIFF
--- a/jetstream/outcomes/firefox_desktop/stricter_pbm.toml
+++ b/jetstream/outcomes/firefox_desktop/stricter_pbm.toml
@@ -14,7 +14,7 @@ select_expression = """(
         event_object = 'etp_toggle_off'        
     ), 0)
 )"""
-data_source = "events"
+data_source = "etp_events"
 friendly_name = "ETP Disablement"
 
 [metrics.etp_disablement.statistics.bootstrap_mean]
@@ -34,3 +34,15 @@ data_source = "clients_daily"
 friendly_name = "Proportion of URIs coming from PBM"
 
 [metrics.share_of_uri_count_in_pbm.statistics.bootstrap_mean]
+
+[data_sources.etp_events]
+from_expression = """
+(
+    SELECT * 
+    FROM mozdata.telemetry.events
+    WHERE event_category = 'security.ui.protectionspopup' AND 
+        event_method = 'click' AND 
+        event_object = 'etp_toggle_off' 
+)
+"""
+experiments_column_type = "native"


### PR DESCRIPTION
Pre-filtering the events should resolve the resource exceeded issues. The `mozdata.telemetry.events` table is clustered on `event_method`