### PR TITLE
Add sponsored tiles metrics

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1444,7 +1444,6 @@ description = "Activity Stream Event pings"
 
 [data_sources.sponsored_tiles_clients_daily]
 from_expression = "mozdata.telemetry.sponsored_tiles_clients_daily"
-experiments_column_type = "native"
 submission_date_column = "submission_date"
 description = "Sponsored Tiles Clients Daily"
 friendly_name = "Sponsored Tiles Clients Daily"

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -143,7 +143,7 @@ description = """
 
 [metrics.unenroll]
 data_source = "normandy_events"
-select_expression='''{{agg_any(
+select_expression = '''{{agg_any(
     """
         event_category = 'normandy'
         AND event_method = 'unenroll'
@@ -216,7 +216,6 @@ friendly_name = "about:protections viewers"
 description = """
     Counts the number of clients that viewed about:protections.
 """
-
 
 
 [metrics.connect_fxa]
@@ -405,7 +404,6 @@ description = """
     Counts the number of clicks to disable Pocket sponsored content
     in New Tab made by each client.
 """
-
 
 
 [metrics.content_shutdown_crashes]
@@ -1255,6 +1253,43 @@ data_source = "main"
 friendly_name = "SSL Loads Probe Ratio"
 description = "Ratio of clients that have the http_pageload_is_ssl_ratio_v1 probe"
 
+[metrics.sponsored_tiles_disabled]
+select_expression = '{{agg_any("sponsored_tiles_disable_count > 0")}}'
+data_source = "sponsored_tiles_clients_daily"
+friendly_name = "Sponsored Tiles Disabled Event"
+description = "Boolean that identifies clients that disabled sponsored tiles during experiment"
+
+[metrics.sponsored_tiles_dismissals]
+select_expression = """COUNTIF(
+        event = 'BLOCK'
+        AND value LIKE '%spoc%'
+        AND SOURCE = 'TOP_SITES'
+      )"""
+data_source = "activity_stream_events"
+friendly_name = "Sponsored Tiles Dismissals Count"
+description = "Count of sponsored tiles dismissals in all positions"
+
+[metrics.any_sponsored_tiles_dismissals]
+select_expression = """COALESCE(LOGICAL_OR(
+        event = 'BLOCK'
+        AND value LIKE '%spoc%'
+        AND SOURCE = 'TOP_SITES'
+      ), FALSE)"""
+data_source = "activity_stream_events"
+friendly_name = "Any Sponsored Tiles Dismissed"
+description = "Clients that dismissed any sponsored tiles"
+
+[metrics.sponsored_tiles_dismissals_pos1_2]
+select_expression = """COUNTIF(
+        event = 'BLOCK'
+        AND value LIKE '%spoc%'
+        AND SOURCE = 'TOP_SITES'
+        AND action_position <= 1
+      )"""
+data_source = "activity_stream_events"
+friendly_name = "Sponsored Tiles Dismissals Count (Positions 1 and 2)"
+description = "Count of sponsored tiles dismissals in the first two positions"
+
 
 [dimensions]
 
@@ -1294,7 +1329,7 @@ from_expression = """(
 friendly_name = "Active Users Aggregates"
 description = "Active Users Aggregates, filtered on Firefox Desktop"
 submission_date_column = "submission_date"
-client_id_column = "NULL"  # this table doesn't include client_id, and we don't need it for calculating DAU
+client_id_column = "NULL" # this table doesn't include client_id, and we don't need it for calculating DAU
 
 [data_sources.main]
 from_expression = """(
@@ -1381,7 +1416,7 @@ from_expression = """(
     FROM mozdata.telemetry.events
     WHERE event_category = 'normandy'
 )"""
-experiments_column_type="native"
+experiments_column_type = "native"
 friendly_name = "Normandy Events"
 description = "Normandy Events"
 
@@ -1407,6 +1442,12 @@ experiments_column_type = "native"
 friendly_name = "Activity Stream Events"
 description = "Activity Stream Event pings"
 
+[data_sources.sponsored_tiles_clients_daily]
+from_expression = "mozdata.telemetry.sponsored_tiles_clients_daily"
+experiments_column_type = "native"
+submission_date_column = "submission_date"
+description = "Sponsored Tiles Clients Daily"
+friendly_name = "Sponsored Tiles Clients Daily"
 
 
 [segments]
@@ -1477,6 +1518,15 @@ description = """
     Clients in countries considered Tier 1 by Marketing. Other business units may have different definitions of 'Tier 1'.
 """
 
+[segments.clients_with_blocked_sponsors]
+data_source = "newtab"
+select_expression = '{{agg_any("ARRAY_LENGTH(metrics.string_list.newtab_blocked_sponsors) > 0")}}'
+friendly_name = "Clients with Blocked Sponsors"
+description = """
+    Clients with any sponsors in their newtab blocked sponsors list.
+"""
+
+
 [segments.data_sources]
 
 [segments.data_sources.clients_last_seen]
@@ -1491,5 +1541,17 @@ window_end = 0
 
 [segments.data_sources.newtab_interactions]
 from_expression = "mozdata.telemetry.newtab_interactions"
+window_start = 0
+window_end = 0
+
+[segments.data_sources.newtab]
+from_expression = """(
+    SELECT
+        DATE(submission_timestamp) AS submission_date,
+        client_info.client_id AS client_id,
+        *
+    FROM
+        mozdata.firefox_desktop.newtab
+)"""
 window_start = 0
 window_end = 0

--- a/jetstream/outcomes/firefox_desktop/sponsored_tiles.toml
+++ b/jetstream/outcomes/firefox_desktop/sponsored_tiles.toml
@@ -1,0 +1,17 @@
+friendly_name = "Sponsored Tiles"
+description = "Interaction metrics for sponsored tiles."
+
+[metrics.sponsored_tiles_disabled.statistics.binomial]
+[metrics.any_sponsored_tiles_dismissals.statistics.binomial]
+
+[metrics.sponsored_tiles_dismissals.statistics.bootstrap_mean]
+[metrics.sponsored_tiles_dismissals.statistics.deciles]
+
+[metrics.sponsored_tiles_dismissals_pos1_2.statistics.bootstrap_mean]
+[metrics.sponsored_tiles_dismissals_pos1_2.statistics.deciles]
+
+[metrics.sponsored_tile_clicks.statistics.bootstrap_mean]
+[metrics.sponsored_tile_clicks.statistics.deciles]
+
+[metrics.sponsored_tile_impressions.statistics.bootstrap_mean]
+[metrics.sponsored_tile_impressions.statistics.deciles]


### PR DESCRIPTION
Adds defaults for sponsored tiles metrics on Desktop. This will be used for the [Third Sponsored Tiles](https://mozilla-hub.atlassian.net/browse/AD-52) experiment and for ongoing experiments for Project Honeycomb.

Adds:
Metrics:
- Sponsored tiles disabled (boolean)
- Any tile dismissals (boolean)
- Total tiles dismissals (count)
- Dismissals in positions 1 and 2 (count)
Data source:
- Sponsored tiles clients daily data source
Outcomes file:
- sponsored_tiles.toml