### PR TITLE
Add metrics for addon installs

### DIFF
--- a/jetstream/dictionary-addon-all-users.toml
+++ b/jetstream/dictionary-addon-all-users.toml
@@ -1,0 +1,13 @@
+[metrics]
+overall = ['dictionary_addon_install']
+weekly = ['dictionary_addon_install']
+
+[metrics.dictionary_addon_install]
+select_expression = """CAST(COALESCE(LOGICAL_OR(environment.addons.active_addons[SAFE_OFFSET(0)].value.name IN ('Dictionary Anywhere')), FALSE) AS INT)"""
+data_source = 'main'
+friendly_name = 'Dictionary Anywhere addon install'
+description = 'If Dictionary Anywhere addon installed'
+
+[metrics.dictionary_addon_install.statistics.bootstrap_mean]
+
+

--- a/jetstream/facebook-container-addon-early-day-us.toml
+++ b/jetstream/facebook-container-addon-early-day-us.toml
@@ -1,0 +1,11 @@
+[metrics]
+overall = ['fbcontainer_addon_install']
+weekly = ['fbcontainer_addon_install']
+
+[metrics.fbcontainer_addon_install]
+select_expression = """CAST(COALESCE(LOGICAL_OR(environment.addons.active_addons[SAFE_OFFSET(0)].value.name IN ("Facebook Container")), FALSE) AS INT)"""
+data_source = 'main'
+friendly_name = 'Facebook container addon install'
+description = 'If Facebook container addon installed'
+
+[metrics.fbcontainer_addon_install.statistics.bootstrap_mean]


### PR DESCRIPTION
For two early user add ons experiments, I add metrics associated with the specific addons the experiments were about