### PR TITLE
fix binomial computation for dict add on metric

### DIFF
--- a/jetstream/dictionary-addon-all-users.toml
+++ b/jetstream/dictionary-addon-all-users.toml
@@ -13,7 +13,7 @@ data_source = 'main'
 friendly_name = 'Dictionary Anywhere addon install'
 description = 'If Dictionary Anywhere addon installed'
 
-[metrics.dictionary_addon_install.statistics.bootstrap_mean]
+[metrics.dictionary_addon_install.statistics.binomial]
 
 [metrics.addons_count]
 select_expression = """COALESCE(MAX((SELECT ARRAY_LENGTH(ARRAY_AGG(IF(NOT is_system, addon_id, NULL) IGNORE NULLS)) FROM UNNEST(active_addons))), 0)"""
@@ -21,7 +21,7 @@ data_source = 'clients_daily'
 friendly_name = 'Count of installed self-installed active addons'
 description = 'The number of self-installed active addons'
 
-[metrics.addons_count.statistics.binomial]
+[metrics.addons_count.statistics.bootstrap_mean]
 
 
 [segments.has_self_installed_addons]


### PR DESCRIPTION
previous statistic computed bootstramp mean for a 0/1 variable which caused an error