### PR TITLE
add enrollments query for downsampling

### DIFF
--- a/jetstream/extensions-migration-experiment-in-116.toml
+++ b/jetstream/extensions-migration-experiment-in-116.toml
@@ -1,0 +1,21 @@
+[experiment]
+
+enrollment_query = '''
+SELECT
+    e.client_id,
+    `mozfun.map.get_key`(e.event_map_values, 'branch')
+        AS branch,
+    MIN(e.submission_date) AS enrollment_date,
+    COUNT(e.submission_date) AS num_enrollment_events
+FROM
+    `moz-fx-data-shared-prod.telemetry.events` e
+WHERE
+    e.event_category = 'normandy'
+    AND e.event_method = 'enroll'
+    AND e.submission_date
+        BETWEEN '2023-08-09' AND '2023-08-16'
+    AND e.event_string_value = 'extensions-migration-experiment-in-116'
+    AND sample_id <= 20
+GROUP BY e.client_id, branch
+'''
+

--- a/jetstream/extensions-migration-experiment-in-116.toml
+++ b/jetstream/extensions-migration-experiment-in-116.toml
@@ -15,7 +15,7 @@ WHERE
     AND e.submission_date
         BETWEEN '2023-08-09' AND '2023-08-16'
     AND e.event_string_value = 'extensions-migration-experiment-in-116'
-    AND sample_id <= 20
+    AND e.sample_id <= 20
 GROUP BY e.client_id, branch
 '''
 


### PR DESCRIPTION
Downsample `extensions-migration-experiment-in-116` due to memory issues. Picked `sample_id <=20` based on another custom config I found, but not sure if this should be something different.