### PR TITLE
Use legacy client_id in newtab_interactions

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1404,6 +1404,7 @@ description = "Events Ping"
 
 [data_sources.newtab_interactions]
 from_expression = "mozdata.telemetry.newtab_interactions"
+client_id_column = "legacy_telemetry_client_id"
 experiments_column_type = "native"
 submission_date_column = "submission_date"
 description = "New Tab Interactions"
@@ -1540,6 +1541,7 @@ window_end = 0
 
 [segments.data_sources.newtab_interactions]
 from_expression = "mozdata.telemetry.newtab_interactions"
+client_id = "legacy_telemetry_client_id"
 window_start = 0
 window_end = 0
 

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1549,7 +1549,7 @@ window_end = 0
 from_expression = """(
     SELECT
         DATE(submission_timestamp) AS submission_date,
-        client_info.client_id AS client_id,
+        metrics.uuid.legacy_telemetry_client_id AS client_id,
         *
     FROM
         mozdata.firefox_desktop.newtab


### PR DESCRIPTION
Currently, the `newtab_interactions` data source uses the Glean `client_id` column. This will result in all 0 values for `newtab_interactions` metrics when Jetstream attempts to join to the enrollments table.