### PR TITLE
Added http download and upload throughput metrics to Networking Outcome

### DIFF
--- a/jetstream/outcomes/firefox_desktop/networking.toml
+++ b/jetstream/outcomes/firefox_desktop/networking.toml
@@ -2,7 +2,7 @@ friendly_name = "Networking"
 description = "Network layer metrics including Necko, TLS, NSS"
 
 [metrics.dns_lookup_time]
-select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.dns_lookup_time")}}'
+select_expression = '{{agg_histogram_mean("payload.histograms.dns_lookup_time")}}'
 data_source = 'main'
 bigger_is_better = false
 
@@ -400,3 +400,108 @@ submission_date_column = "submission_date"
 friendly_name = "Certerror events"
 description = "Cert Error related events"
 experiments_column_type = "native"
+
+
+[metrics.networking_download_throughput_http_1]
+select_expression = '{{agg_histogram_mean("payload.histograms.networking_download_throughput_http_1")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.networking_download_throughput_http_1.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.networking_download_throughput_http_1.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.networking_download_throughput_http_1.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.networking_download_throughput_http_2]
+select_expression = '{{agg_histogram_mean("payload.histograms.networking_download_throughput_http_2")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.networking_download_throughput_http_2.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.networking_download_throughput_http_2.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.networking_download_throughput_http_2.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.networking_download_throughput_http_3]
+select_expression = '{{agg_histogram_mean("payload.histograms.networking_download_throughput_http_3")}}'
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.networking_download_throughput_http_3.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.networking_download_throughput_http_3.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.networking_download_throughput_http_3.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.networking_upload_throughput_http_1]
+select_expression = """{{agg_histogram_mean("mozfun.map.get_key(payload.keyed_histograms.http_upload_bandwidth_mbps,'http/1.1')")}}"""
+
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.networking_upload_throughput_http_1.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.networking_upload_throughput_http_1.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.networking_upload_throughput_http_1.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.networking_upload_throughput_http_2]
+select_expression = """{{agg_histogram_mean("mozfun.map.get_key(payload.keyed_histograms.http_upload_bandwidth_mbps,'h2')")}}"""
+
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.networking_upload_throughput_http_2.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.networking_upload_throughput_http_2.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.networking_upload_throughput_http_2.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+
+[metrics.networking_upload_throughput_http_3]
+select_expression = """{{agg_histogram_mean("mozfun.map.get_key(payload.keyed_histograms.http_upload_bandwidth_mbps,'h3')")}}"""
+
+data_source = 'main'
+bigger_is_better = false
+
+[metrics.networking_upload_throughput_http_3.statistics.deciles]
+pre_treatments = ["remove_nulls"]
+
+[metrics.networking_upload_throughput_http_3.statistics.kernel_density_estimate]
+pre_treatments = ["remove_nulls"]
+log_space = true
+
+[metrics.networking_upload_throughput_http_3.statistics.empirical_cdf]
+pre_treatments = ["remove_nulls"]
+log_space = true


### PR DESCRIPTION
Adding histograms,
```
networking_download_throughput_http_1
networking_download_throughput_http_2
networking_download_throughput_http_3
```

And keyed histogram `http_upload_bandwidth_mbps` with keys,
```
http/1.1
h2
h3
```
