### PR TITLE
Add Jetstream config for parallel-marking-experiment

### DIFF
--- a/jetstream/parallel-marking-experiment.toml
+++ b/jetstream/parallel-marking-experiment.toml
@@ -1,0 +1,598 @@
+[experiment]
+
+segments = [
+    'gt_one_cpu',
+    'gt_one_cpu_windows',
+    'gt_one_cpu_linux',
+    'gt_one_cpu_mac'
+]
+
+## Data Sources
+
+[data_sources]
+
+## crash: removing session corresponding to enrollment
+[data_sources.crash_hour]
+from_expression = """
+(
+  SELECT
+    cr.*,
+    DATE(cr.submission_timestamp) AS submission_date,
+    cr.environment.experiments,
+    COALESCE(m.payload.processes.parent.scalars.browser_engagement_active_ticks, 0)*5 as active_s
+  FROM
+    `moz-fx-data-shared-prod.telemetry_stable.crash_v4` cr
+    INNER JOIN  `moz-fx-data-shared-prod`.telemetry_stable.main_v4 m
+      ON m.client_id = cr.client_id
+      AND DATE(m.submission_timestamp) = DATE(cr.submission_timestamp)
+    WHERE DATE(m.submission_timestamp) >= '2023-08-25'
+    AND DATE(cr.submission_timestamp) >= '2023-08-25'
+    AND m.normalized_channel = 'nightly'
+    AND cr.normalized_channel = 'nightly'
+    )
+"""
+experiments_column_type = "native"
+
+## Metrics
+[metrics]
+
+overall = [
+    'perf_page_load_time_ms', 'time_to_first_interaction_ms',
+    'input_event_response_ms', 'input_event_response_ms_parent',
+    'perf_first_contentful_paint_ms',
+    'js_pageload_execution_ms',
+    'gpu_keypress_present_latency',
+    'memory_total', 'memory_unique_content_startup',
+    'cycle_collector_max_pause', 'cycle_collector_max_pause_content',
+    'gc_max_pause_ms_2', 'gc_max_pause_ms_2_content',
+    'gc_ms', 'gc_ms_content',
+    'gc_slice_during_idle', 'gc_slice_during_idle_content',
+    'gc_mark_ms', 'gc_mark_ms_content',
+    'gc_mark_rate_2', 'gc_mark_rate_2_content',
+    'main_crashes_per_hour', 'content_crashes_per_hour',
+    'oom_crashes_per_hour', 'shutdown_hangs_per_hour'
+]
+
+weekly = [
+    'perf_page_load_time_ms', 'time_to_first_interaction_ms',
+    'input_event_response_ms', 'input_event_response_ms_parent',
+    'perf_first_contentful_paint_ms',
+    'js_pageload_execution_ms',
+    'gpu_keypress_present_latency',
+    'memory_total', 'memory_unique_content_startup',
+    'cycle_collector_max_pause', 'cycle_collector_max_pause_content',
+    'gc_max_pause_ms_2', 'gc_max_pause_ms_2_content',
+    'gc_ms', 'gc_ms_content',
+    'gc_slice_during_idle', 'gc_slice_during_idle_content',
+    'gc_mark_ms', 'gc_mark_ms_content',
+    'gc_mark_rate_2', 'gc_mark_rate_2_content',
+    'main_crashes_per_hour', 'content_crashes_per_hour',
+    'oom_crashes_per_hour', 'shutdown_hangs_per_hour'
+]
+
+daily = [
+]
+
+## Performance
+    [metrics.perf_page_load_time_ms]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.perf_page_load_time_ms")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.perf_page_load_time_ms.statistics.bootstrap_mean]
+#        [pre_treatments = ["remove_nulls"]
+
+        [metrics.perf_page_load_time_ms.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.perf_page_load_time_ms.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.perf_page_load_time_ms.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+
+    [metrics.js_pageload_execution_ms]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.js_pageload_execution_ms")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.js_pageload_execution_ms.statistics.bootstrap_mean]
+#        [pre_treatments = ["remove_nulls"]
+
+        [metrics.js_pageload_execution_ms.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.js_pageload_execution_ms.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.js_pageload_execution_ms.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+
+    [metrics.time_to_first_interaction_ms]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.time_to_first_interaction_ms")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.time_to_first_interaction_ms.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.time_to_first_interaction_ms.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.time_to_first_interaction_ms.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.time_to_first_interaction_ms.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.input_event_response_ms]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.input_event_response_ms")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.input_event_response_ms.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.input_event_response_ms.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.input_event_response_ms.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.input_event_response_ms.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.input_event_response_ms_parent]
+    select_expression = '{{agg_histogram_mean("payload.histograms.input_event_response_ms")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.input_event_response_ms.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.input_event_response_ms_parent.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.input_event_response_ms_parent.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.input_event_response_ms_parent.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.perf_first_contentful_paint_ms]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.perf_first_contentful_paint_ms")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.perf_first_contentful_paint_ms.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.perf_first_contentful_paint_ms.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.perf_first_contentful_paint_ms.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.perf_first_contentful_paint_ms.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+
+    [metrics.gpu_keypress_present_latency]
+    select_expression = '{{agg_histogram_mean("payload.processes.gpu.histograms.keypress_present_latency")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.gpu_keypress_present_latency.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.gpu_keypress_present_latency.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.gpu_keypress_present_latency.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.gpu_keypress_present_latency.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+
+## Memory
+    [metrics.memory_total]
+    select_expression = '{{agg_histogram_mean("payload.histograms.memory_total")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.memory_total.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.memory_total.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.memory_total.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.memory_total.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.memory_unique_content_startup]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.memory_unique_content_startup")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.memory_unique_content_startup.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.memory_unique_content_startup.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.memory_unique_content_startup.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.memory_unique_content_startup.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.cycle_collector_max_pause]
+    select_expression = '{{agg_histogram_mean("payload.histograms.cycle_collector_max_pause")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.cycle_collector_max_pause.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.cycle_collector_max_pause.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.cycle_collector_max_pause.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.cycle_collector_max_pause.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.cycle_collector_max_pause_content]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.cycle_collector_max_pause")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.cycle_collector_max_pause_content.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.cycle_collector_max_pause_content.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.cycle_collector_max_pause_content.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.cycle_collector_max_pause_content.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+   [metrics.gc_max_pause_ms_2]
+    select_expression = '{{agg_histogram_mean("payload.histograms.gc_max_pause_ms_2")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.gc_max_pause_ms_2.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_max_pause_ms_2.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_max_pause_ms_2.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.gc_max_pause_ms_2.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+   [metrics.gc_max_pause_ms_2_content]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.cycle_collector_max_pause")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.gc_max_pause_ms_2_content.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_max_pause_ms_2_content.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_max_pause_ms_2_content.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.gc_max_pause_ms_2_content.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+   [metrics.gc_ms]
+    select_expression = '{{agg_histogram_mean("payload.histograms.gc_ms")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.gc_ms.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_ms.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_ms.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.gc_ms.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.gc_ms_content]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.gc_ms")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.gc_ms_content.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_ms_content.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_ms_content.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.gc_ms_content.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.gc_slice_during_idle]
+    select_expression = '{{agg_histogram_mean("payload.histograms.gc_slice_during_idle")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.gc_slice_during_idle.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_slice_during_idle.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_slice_during_idle.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.gc_slice_during_idle.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.gc_slice_during_idle_content]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.gc_slice_during_idle")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.gc_slice_during_idle_content.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_slice_during_idle_content.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_slice_during_idle_content.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.gc_slice_during_idle_content.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.gc_mark_ms]
+    select_expression = '{{agg_histogram_mean("payload.histograms.gc_mark_ms")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.gc_mark_ms.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_mark_ms.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_mark_ms.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.gc_mark_ms.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.gc_mark_ms_content]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.gc_mark_ms")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.gc_mark_ms_content.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_mark_ms_content.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_mark_ms_content.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.gc_mark_ms_content.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.gc_mark_rate_2]
+    select_expression = '{{agg_histogram_mean("payload.histograms.gc_mark_rate_2")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.gc_mark_rate_2.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_mark_rate_2.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_mark_rate_2.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.gc_mark_rate_2.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+    [metrics.gc_mark_rate_2_content]
+    select_expression = '{{agg_histogram_mean("payload.processes.content.histograms.gc_mark_rate_2")}}'
+    data_source = 'main'
+    bigger_is_better = false
+
+#        [metrics.gc_mark_rate_2_content.statistics.bootstrap_mean]
+#        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_mark_rate_2_content.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.gc_mark_rate_2_content.statistics.kernel_density_estimate]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+        [metrics.gc_mark_rate_2_content.statistics.empirical_cdf]
+        pre_treatments = ["remove_nulls"]
+        log_space = true
+
+## Crashes
+    [metrics.main_crashes_per_hour]
+    select_expression = """
+        SAFE_DIVIDE(
+            COALESCE(SUM(IF(payload.process_type = 'main' OR payload.process_type IS NULL, 1, 0)), 0),
+            SUM(active_s/3600)
+         )
+        """
+    data_source = 'crash_hour'
+    bigger_is_better = false
+
+        [metrics.main_crashes_per_hour.statistics.bootstrap_mean]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.main_crashes_per_hour.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+#        [metrics.main_crashes_per_hour.statistics.kernel_density_estimate]
+#        pre_treatments = ["remove_nulls"]
+#        log_space = true
+#
+#        [metrics.main_crashes_per_hour.statistics.empirical_cdf]
+#        pre_treatments = ["remove_nulls"]
+#        log_space = true
+
+    [metrics.content_crashes_per_hour]
+    select_expression = """
+        SAFE_DIVIDE(
+            COALESCE(SUM(IF(REGEXP_CONTAINS(payload.process_type, 'content')
+                AND NOT REGEXP_CONTAINS(COALESCE(payload.metadata.ipc_channel_error, ''), 'ShutDownKill'), 1,0)), 0),
+            SUM(active_s/3600)
+         )
+        """
+    data_source = 'crash_hour'
+    bigger_is_better = false
+
+        [metrics.content_crashes_per_hour.statistics.bootstrap_mean]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.content_crashes_per_hour.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+#        [metrics.content_crashes_per_hour.statistics.kernel_density_estimate]
+#        pre_treatments = ["remove_nulls"]
+#        log_space = true
+#
+#        [metrics.content_crashes_per_hour.statistics.empirical_cdf]
+#        pre_treatments = ["remove_nulls"]
+#        log_space = true
+
+    [metrics.oom_crashes_per_hour]
+    select_expression = """
+        SAFE_DIVIDE(
+            COALESCE(SUM(IF(payload.metadata.oom_allocation_size IS NOT NULL, 1, 0)), 0),
+            SUM(active_s/3600)
+         )
+        """
+    data_source = 'crash_hour'
+    bigger_is_better = false
+
+        [metrics.oom_crashes_per_hour.statistics.bootstrap_mean]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.oom_crashes_per_hour.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+#        [metrics.oom_crashes_per_hour.statistics.kernel_density_estimate]
+#        pre_treatments = ["remove_nulls"]
+#        log_space = true
+#
+#        [metrics.oom_crashes_per_hour.statistics.empirical_cdf]
+#        pre_treatments = ["remove_nulls"]
+#        log_space = true
+
+
+    [metrics.shutdown_hangs_per_hour]
+    select_expression = """
+        SAFE_DIVIDE(
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            SUM(active_s/3600)
+         )
+        """
+    data_source = 'crash_hour'
+    bigger_is_better = false
+
+        [metrics.shutdown_hangs_per_hour.statistics.bootstrap_mean]
+        pre_treatments = ["remove_nulls"]
+
+        [metrics.shutdown_hangs_per_hour.statistics.deciles]
+        pre_treatments = ["remove_nulls"]
+
+#        [metrics.shutdown_crashes_per_hour.statistics.kernel_density_estimate]
+#        pre_treatments = ["remove_nulls"]
+#        log_space = true
+#
+#        [metrics.shutdown_crashes_per_hour.statistics.empirical_cdf]
+#        pre_treatments = ["remove_nulls"]
+#        log_space = true
+
+
+## Segments
+[segments]
+
+[segments.gt_one_cpu]
+select_expression = 'COALESCE(MAX(cpu_cores) > 1, FALSE)'
+data_source = "clients_last_seen"
+
+[segments.gt_one_cpu_windows]
+select_expression = """COALESCE(MAX(cpu_cores) > 1 AND LOGICAL_OR(os='Windows_NT'), FALSE)"""
+data_source = "clients_last_seen"
+
+[segments.gt_one_cpu_linux]
+select_expression = """COALESCE(MAX(cpu_cores) > 1 AND LOGICAL_OR(os='Linux'), FALSE)"""
+data_source = "clients_last_seen"
+
+[segments.gt_one_cpu_mac]
+select_expression = """COALESCE(MAX(cpu_cores) > 1 AND LOGICAL_OR(os='Darwin'), FALSE)"""
+data_source = "clients_last_seen"


### PR DESCRIPTION
Add a custom config for the parallel marking experiment which segments by OS and cpu_cores.