### PR TITLE
Additional newtab metrics

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1046,7 +1046,7 @@ description = """
 Count of clicks on Organic Pocket content.
 """
 
-[metrics.sponsered_pocket_clicks]
+[metrics.sponsored_pocket_clicks]
 data_source = "newtab_interactions"
 select_expression = "SUM(COALESCE(sponsored_pocket_clicks, 0))"
 friendly_name = "Sponsored Pocket Clicks"

--- a/jetstream/outcomes/firefox_desktop/newtab_engagement.toml
+++ b/jetstream/outcomes/firefox_desktop/newtab_engagement.toml
@@ -1,0 +1,34 @@
+friendly_name = "New Tab Engagement"
+description = """
+    Measures engagement across surfaces on the New Tab. This includes
+    metrics on user abandonment of these features.
+"""
+
+## Engagement
+[metrics.newtab_searches.statistics.bootstrap_mean]
+[metrics.newtab_searches.statistics.deciles]
+
+[metrics.newtab_organic_topsite_clicks.statistics.bootstrap_mean]
+[metrics.newtab_organic_topsite_clicks.statistics.deciles]
+
+[metrics.sponsored_tile_impressions.statistics.bootstrap_mean]
+[metrics.sponsored_tile_impressions.statistics.deciles]
+
+[metrics.sponsored_tile_clicks.statistics.bootstrap_mean]
+[metrics.sponsored_tile_clicks.statistics.deciles]
+
+[metrics.organic_pocket_clicks.statistics.bootstrap_mean]
+[metrics.organic_pocket_clicks.statistics.deciles]
+
+[metrics.sponsored_pocket_clicks.statistics.bootstrap_mean]
+[metrics.sponsored_pocket_clicks.statistics.deciles]
+
+[metrics.sponsored_pocket_impressions.statistics.bootstrap_mean]
+[metrics.sponsored_pocket_impressions.statistics.deciles]
+
+## Abandonment
+[metrics.newtab_homepage_enabled.statistics.boolean]
+[metrics.newtab_pocket_enabled.statistics.boolean]
+[metrics.newtab_sponsored_pocket_stories_enabled.statistics.boolean]
+[metrics.newtab_tiles_enabled.statistics.boolean]
+[metrics.sponsored_tiles_disabled.statistics.boolean]

--- a/jetstream/outcomes/firefox_desktop/newtab_search.toml
+++ b/jetstream/outcomes/firefox_desktop/newtab_search.toml
@@ -1,0 +1,15 @@
+friendly_name = "New Tab Search"
+description = """
+    Measures interactions with search on the New Tab.
+"""
+
+[metrics.newtab_searches.statistics.bootstrap_mean]
+[metrics.newtab_searches.statistics.deciles]
+
+[metrics.newtab_searches_with_ads.statistics.bootstrap_mean]
+[metrics.newtab_searches_with_ads.statistics.deciles]
+
+[metrics.newtab_ad_clicks.statistics.bootstrap_mean]
+[metrics.newtab_ad_clicks.statistics.deciles]
+
+[metrics.newtab_ad_click_rate.deciles]

--- a/jetstream/outcomes/firefox_desktop/newtab_search.toml
+++ b/jetstream/outcomes/firefox_desktop/newtab_search.toml
@@ -12,4 +12,4 @@ description = """
 [metrics.newtab_ad_clicks.statistics.bootstrap_mean]
 [metrics.newtab_ad_clicks.statistics.deciles]
 
-[metrics.newtab_ad_click_rate.deciles]
+[metrics.newtab_ad_click_rate.statistics.deciles]

--- a/jetstream/outcomes/firefox_desktop/newtab_tiles.toml
+++ b/jetstream/outcomes/firefox_desktop/newtab_tiles.toml
@@ -1,0 +1,19 @@
+friendly_name = "New Tab Tiles"
+description = """
+    Measures interactions with tiles on the New Tab.
+"""
+
+[metrics.sponsored_tile_impressions.statistics.bootstrap_mean]
+[metrics.sponsored_tile_impressions.statistics.decile]
+
+[metrics.sponsored_tile_clicks.statistics.bootstrap_mean]
+[metrics.sponsored_tile_clicks.statistics.decile]
+
+[metrics.newtab_tiles_enabled.statistics.boolean]
+[metrics.sponsored_tiles_disabled.statistics.boolean]
+
+[metrics.newtab_organic_topsite_clicks.statistics.bootstrap_mean]
+[metrics.newtab_organic_topsite_clicks.statistics.decile]
+
+[metrics.newtab_organic_topsite_impressions.statistics.bootstrap_mean]
+[metrics.newtab_organic_topsite_impressions.statistics.decile]


### PR DESCRIPTION
Adds additional outcomes for New Tab features:
1. `newtab_search.toml`
2. `newtab_tiles.toml`
3. `newtab_engagement.toml`

With the new feature-specific outcomes, there will be an outcome file to measure engagement specific to every feature on new tab. The engagement outcome will be used to measure overall engagement with the new tab, across all features.