### PR TITLE
[ci rerun-skip] add monitor_cirrus datasource and metric

### DIFF
--- a/definitions/monitor_cirrus.toml
+++ b/definitions/monitor_cirrus.toml
@@ -19,6 +19,7 @@ deprecated = false
 [data_sources.monitor_events_v1]
 from_expression = """(
     SELECT
+        DATE(submission_timestamp) AS submission_date,
         e.* EXCEPT (events),
         mozfun.map.get_key(event.extra, 'user_id') as client_id
     FROM

--- a/definitions/monitor_cirrus.toml
+++ b/definitions/monitor_cirrus.toml
@@ -24,7 +24,7 @@ from_expression = """(
     FROM
         `moz-fx-data-shared-prod.monitor_frontend.events` e
     CROSS JOIN
-    	UNNEST(p.events) AS event
+    	UNNEST(e.events) AS event
 )"""
 experiments_column_type = "glean"
 friendly_name = "Monitor Events"

--- a/definitions/monitor_cirrus.toml
+++ b/definitions/monitor_cirrus.toml
@@ -2,7 +2,9 @@
 
 [metrics.monitor_pageviews_v1]
 data_source = "monitor_events_v1"
-select_expression = "SUM(dau)"
+select_expression = """
+    COUNTIF(event.category = 'page' AND event.name = 'view')
+"""
 type = "scalar"
 friendly_name = "Monitor Page Views"
 description = """
@@ -18,7 +20,7 @@ deprecated = false
 from_expression = """(
     SELECT
         e.* EXCEPT (events),
-        mozfun.map.get_key(event.extras, 'user_id') as client_id
+        mozfun.map.get_key(event.extra, 'user_id') as client_id
     FROM
         `moz-fx-data-shared-prod.monitor_frontend.events` e
     CROSS JOIN

--- a/definitions/monitor_cirrus.toml
+++ b/definitions/monitor_cirrus.toml
@@ -21,7 +21,8 @@ from_expression = """(
     SELECT
         DATE(submission_timestamp) AS submission_date,
         e.* EXCEPT (events),
-        mozfun.map.get_key(event.extra, 'user_id') as client_id
+        mozfun.map.get_key(event.extra, 'user_id') as client_id,
+        event
     FROM
         `moz-fx-data-shared-prod.monitor_frontend.events` e
     CROSS JOIN

--- a/definitions/monitor_cirrus.toml
+++ b/definitions/monitor_cirrus.toml
@@ -1,0 +1,29 @@
+[metrics]
+
+[metrics.monitor_pageviews_v1]
+data_source = "monitor_events_v1"
+select_expression = "SUM(dau)"
+type = "scalar"
+friendly_name = "Monitor Page Views"
+description = """
+    This is a metric intended to test the functionality of Cirrus within Monitor.
+    It simply sums the page view events for Monitor.
+"""
+owner = ["mwilliams@mozilla.com"]
+deprecated = false
+
+[data_sources]
+
+[data_sources.monitor_events_v1]
+from_expression = """(
+    SELECT
+        e.* EXCEPT (events),
+        mozfun.map.get_key(event.extras, 'user_id') as client_id
+    FROM
+        `moz-fx-data-shared-prod.monitor_frontend.events` e
+    CROSS JOIN
+    	UNNEST(p.events) AS event
+)"""
+experiments_column_type = "glean"
+friendly_name = "Monitor Events"
+description = "Monitor Events"

--- a/jetstream/defaults/monitor_cirrus.toml
+++ b/jetstream/defaults/monitor_cirrus.toml
@@ -1,0 +1,8 @@
+# This defines the default metrics and statistics calculated for each experiment
+
+[metrics]
+daily = ["monitor_pageviews_v1"]
+
+weekly = ["monitor_pageviews_v1"]
+
+overall = ["monitor_pageviews_v1"]

--- a/jetstream/definitions/monitor_cirrus.toml
+++ b/jetstream/definitions/monitor_cirrus.toml
@@ -1,0 +1,6 @@
+[metrics]
+
+[metrics.monitor_pageviews_v1.statistics]
+bootstrap_mean = {}
+deciles = {}
+empirical_cdf = {}


### PR DESCRIPTION
I'm not sure what to try measuring, but I wanted to at least get something out there for feedback. 

- Does this look broadly correct?
- @danielkberry can you help with what the metric definition should actually be?