### PR TITLE
Exposure event for default browser banner

### DIFF
--- a/jetstream/mobile-default-browser-homepage-banner-copy-test-ios.toml
+++ b/jetstream/mobile-default-browser-homepage-banner-copy-test-ios.toml
@@ -1,0 +1,22 @@
+[experiment]
+
+[experiment.exposure_signal]
+name = "shown_default_browser_message"
+friendly_name = "Shown Default Browser Message"
+description = "Whether or not the client was shown the default-browser message at least once"
+select_expression = "category = 'messaging' AND name = 'shown' AND mozfun.map.get_key(extra, 'message_key') = 'default-browser'"
+data_source = "events_unnested"
+
+[data_sources]
+
+[data_sources.events_unnested]
+from_expression = """(
+  SELECT client_info.client_id,
+      DATE(submission_timestamp) AS submission_date,
+      e.*
+    FROM `moz-fx-data-shared-prod.org_mozilla_ios_firefox.events` event
+    CROSS JOIN UNNEST(events) e
+)"""
+experiments_column_type = "glean"
+friendly_name = "Events Unnested"
+description = "Events with the array of events unnested so one row per event"


### PR DESCRIPTION
Due to https://github.com/mozilla-mobile/firefox-ios/issues/16579 we'll need to set up the exposure to this experiment through a config file.

This was copied from the [previous experiment](https://github.com/mozilla/metric-hub/blob/main/jetstream/mobile-default-browser-cta-copy-test-ios.toml) and I've tested the query and confirmed with the Experimenter team that this config file won't conflict with the outcomes that have been set up trough the UI.
