### PR TITLE
RS-839

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1484,6 +1484,17 @@ submission_date_column = "first_seen_date"
 description = "Clients First Seen V2"
 friendly_name = "Clients First Seen V2"
 
+[data_sources.urlbar_events]
+from_expression = """(
+    SELECT *
+     FROM `moz-fx-data-shared-prod.firefox_desktop.urlbar_events`
+)"""
+friendly_name = "Urlbar Events"
+description = "Urlbar Events"
+submission_date_column = "submission_date"
+client_id_column = "legacy_telemetry_client_id"
+
+
 
 [segments]
 

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1486,14 +1486,13 @@ friendly_name = "Clients First Seen V2"
 
 [data_sources.urlbar_events]
 from_expression = """(
-    SELECT * EXCEPT(experiments),
-      ARRAY(SELECT STRUCT(e.key, e.value.branch AS value) FROM UNNEST(experiments) AS e) AS experiments
-    FROM `moz-fx-data-shared-prod.firefox_desktop.urlbar_events`
+    SELECT * FROM `moz-fx-data-shared-prod.firefox_desktop.urlbar_events`
 )"""
 friendly_name = "Urlbar Events"
 description = "Urlbar Events"
 submission_date_column = "submission_date"
 client_id_column = "legacy_telemetry_client_id"
+experiments_column_type = "native"
 
 
 

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1486,8 +1486,9 @@ friendly_name = "Clients First Seen V2"
 
 [data_sources.urlbar_events]
 from_expression = """(
-    SELECT *
-     FROM `moz-fx-data-shared-prod.firefox_desktop.urlbar_events`
+    SELECT * EXCEPT(experiments),
+      ARRAY(SELECT STRUCT(e.key, e.value.branch) FROM UNNEST(experiments) AS e) AS experiments
+    FROM `moz-fx-data-shared-prod.firefox_desktop.urlbar_events`
 )"""
 friendly_name = "Urlbar Events"
 description = "Urlbar Events"

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1487,7 +1487,7 @@ friendly_name = "Clients First Seen V2"
 [data_sources.urlbar_events]
 from_expression = """(
     SELECT * EXCEPT(experiments),
-      ARRAY(SELECT STRUCT(e.key, e.value.branch) FROM UNNEST(experiments) AS e) AS experiments
+      ARRAY(SELECT STRUCT(e.key, e.value.branch AS value) FROM UNNEST(experiments) AS e) AS experiments
     FROM `moz-fx-data-shared-prod.firefox_desktop.urlbar_events`
 )"""
 friendly_name = "Urlbar Events"

--- a/jetstream/outcomes/firefox_desktop/firefox_suggest.toml
+++ b/jetstream/outcomes/firefox_desktop/firefox_suggest.toml
@@ -14,7 +14,7 @@ numerator = "ad_clicks"
 denominator = "search_count"
 
 [metrics.urlbar_clicks]
-select_expression = "COUNT(DISTINCT(CASE WHEN is_terminal and event_action = "engaged" THEN event_id ELSE NULL END))"
+select_expression = "COUNT(DISTINCT(CASE WHEN is_terminal and event_action = 'engaged' THEN event_id ELSE NULL END))"
 data_source = "urlbar_events"
 description = "Count of clicks on any result shown in the urlbar dropdown menu"
 friendly_name = "urlbar clicks"
@@ -37,7 +37,7 @@ description = "Count of urlbar clicks divided by count of urlbar impressions. Th
 friendly_name = "urlbar click-through rate (ctr)"
 
 [metrics.urlbar_annoyances]
-select_expression = "COUNT(DISTINCT(CASE WHEN event_action = "annoyance" THEN event_id ELSE NULL END))"
+select_expression = "COUNT(DISTINCT(CASE WHEN event_action = 'annoyance' THEN event_id ELSE NULL END))"
 data_source = "urlbar_events"
 description = "Count of clicks on annoyance signals across all results shown in the urlbar dropdown menu"
 friendly_name = "urlbar annoyances"

--- a/jetstream/outcomes/firefox_desktop/firefox_suggest.toml
+++ b/jetstream/outcomes/firefox_desktop/firefox_suggest.toml
@@ -12,3 +12,34 @@ statistics = { deciles = {}, bootstrap_mean = {} }
 [metrics.ad_click_rate.statistics.population_ratio]
 numerator = "ad_clicks"
 denominator = "search_count"
+
+[metrics.urlbar_clicks]
+select_expression = "COUNT(DISTINCT(CASE WHEN is_terminal and event_action = "engaged" THEN event_id ELSE NULL END))"
+data_source = "urlbar_events"
+description = "Count of clicks on any result shown in the urlbar dropdown menu"
+friendly_name = "urlbar clicks"
+exposure_basis = ["exposures", "enrollments"]
+statistics = { deciles = {}, bootstrap_mean = {} }
+
+[metrics.urlbar_impressions]
+select_expression = "COUNT(DISTINCT(CASE WHEN is_terminal THEN event_id ELSE NULL END))"
+data_source = "urlbar_events"
+description = "The number of times a user exits the urlbar dropdown menu, either by abandoning the urlbar, engaging with a urlbar result, or selecting an annoyance signal that closes the urlbar dropdown menu"
+friendly_name = "urlbar impressions"
+exposure_basis = ["exposures", "enrollments"]
+statistics = { deciles = {}, bootstrap_mean = {} }
+
+[metrics.urlbar_ctr]
+[metrics.urlbar_ctr.statistics.population_ratio]
+numerator = "urlbar_clicks"
+denominator = "urlbar_impressions"
+description = "Count of urlbar clicks divided by count of urlbar impressions. This is a `population-ratio` metric, not a client-level metric."
+friendly_name = "urlbar click-through rate (ctr)"
+
+[metrics.urlbar_annoyances]
+select_expression = "COUNT(DISTINCT(CASE WHEN event_action = "annoyance" THEN event_id ELSE NULL END))"
+data_source = "urlbar_events"
+description = "Count of clicks on annoyance signals across all results shown in the urlbar dropdown menu"
+friendly_name = "urlbar annoyances"
+exposure_basis = ["exposures", "enrollments"]
+statistics = { deciles = {}, bootstrap_mean = {} }

--- a/jetstream/outcomes/firefox_desktop/firefox_suggest.toml
+++ b/jetstream/outcomes/firefox_desktop/firefox_suggest.toml
@@ -29,11 +29,14 @@ friendly_name = "urlbar impressions"
 exposure_basis = ["exposures", "enrollments"]
 statistics = { deciles = {}, bootstrap_mean = {} }
 
+[metrics.urlbar_ctr]
+description = "Count of urlbar clicks divided by count of urlbar impressions. This is a `population-ratio` metric, not a client-level metric."
+friendly_name = "urlbar click-through rate (ctr)"
+depends_on = ["urlbar_clicks", "urlbar_impressions"]
+
 [metrics.urlbar_ctr.statistics.population_ratio]
 numerator = "urlbar_clicks"
 denominator = "urlbar_impressions"
-description = "Count of urlbar clicks divided by count of urlbar impressions. This is a `population-ratio` metric, not a client-level metric."
-friendly_name = "urlbar click-through rate (ctr)"
 
 [metrics.urlbar_annoyances]
 select_expression = "COUNT(DISTINCT(CASE WHEN event_action = 'annoyance' THEN event_id ELSE NULL END))"

--- a/jetstream/outcomes/firefox_desktop/firefox_suggest.toml
+++ b/jetstream/outcomes/firefox_desktop/firefox_suggest.toml
@@ -29,7 +29,6 @@ friendly_name = "urlbar impressions"
 exposure_basis = ["exposures", "enrollments"]
 statistics = { deciles = {}, bootstrap_mean = {} }
 
-[metrics.urlbar_ctr]
 [metrics.urlbar_ctr.statistics.population_ratio]
 numerator = "urlbar_clicks"
 denominator = "urlbar_impressions"


### PR DESCRIPTION
Implements https://mozilla-hub.atlassian.net/browse/RS-839

1. Adds urlbar_events as a new Firefox Desktop data source
2. Adds new metrics to the Firefox Suggest outcome. One of these is a population ratio metric that depends on 2 of the other new metrics added in the same outcome.