### PR TITLE
add enrollment end date and period for monitor-test-production

### DIFF
--- a/jetstream/monitor-test-production.toml
+++ b/jetstream/monitor-test-production.toml
@@ -1,0 +1,3 @@
+[experiment]
+enrollment_period = 14
+enrollment_end_date = "2023-10-16"


### PR DESCRIPTION
Cirrus experiments require some updates to Experimenter, so in the meantime for testing purposes, this adds a retroactive end to enrollment for the monitor experiment.