### PR TITLE
fix for scalar subquery produced more than one element

### DIFF
--- a/jetstream/bookmarks-toolbar-default-on.toml
+++ b/jetstream/bookmarks-toolbar-default-on.toml
@@ -5,12 +5,12 @@ overall = ['bookmarks_bar_pinned_on', 'bookmarks_bar_pinned_off', 'bookmarks_bar
 
 
 [metrics.bookmarks_bar_pinned_on]
-select_expression = "CAST(COALESCE(SUM(CASE WHEN(SELECT t.key LIKE 'bookmarks-bar_pinned_on' AND t.value FROM UNNEST(payload.processes.parent.keyed_scalars.browser_ui_toolbar_widgets) t) THEN 1 ELSE 0 END),0) > 0 AS INT)"
+select_expression = "CAST(COALESCE(SUM(CASE WHEN(SELECT CAST(COUNT(t) AS BOOL) FROM UNNEST(payload.processes.parent.keyed_scalars.browser_ui_toolbar_widgets) t WHERE t.key LIKE 'bookmarks-bar_pinned_on' AND t.value) THEN 1 ELSE 0 END),0) > 0 AS INT)"
 data_source = 'main'
 
 
 [metrics.bookmarks_bar_pinned_off]
-select_expression = "CAST(COALESCE(SUM(CASE WHEN(SELECT t.key LIKE 'bookmarks-bar_pinned_off' AND t.value FROM UNNEST(payload.processes.parent.keyed_scalars.browser_ui_toolbar_widgets) t) THEN 1 ELSE 0 END),0) > 0 AS INT)"
+select_expression = "CAST(COALESCE(SUM(CASE WHEN(SELECT CAST(COUNT(t) AS BOOL) FROM UNNEST(payload.processes.parent.keyed_scalars.browser_ui_toolbar_widgets) t WHERE t.key LIKE 'bookmarks-bar_pinned_off' AND t.value) THEN 1 ELSE 0 END),0) > 0 AS INT)"
 data_source = 'main'
 
 


### PR DESCRIPTION
This experiment has errors in analysis like `Scalar subquery produced more than one element`, so I rearranged the scalar subquery in the metrics causing the errors. Please take a look in case something looks off.

Also just wanted to confirm: are `'bookmarks-bar_pinned_on'` and `'bookmarks-bar_pinned_off'` typos? It seems odd to have a mix of hyphens and underscores, but I don't know what these keys normally look like so wanted to ask.