### PR TITLE
Update end date for iOS default browser experiment

### DIFF
--- a/jetstream/mobile-default-browser-homepage-banner-copy-test-ios.toml
+++ b/jetstream/mobile-default-browser-homepage-banner-copy-test-ios.toml
@@ -1,4 +1,5 @@
 [experiment]
+end_date = "2023-11-27"
 
 [experiment.exposure_signal]
 name = "shown_default_browser_message"


### PR DESCRIPTION
[This experiment](https://experimenter.services.mozilla.com/nimbus/mobile-default-browser-homepage-banner-copy-test-ios/summary) was initially set up as 28 days **total**, but given that the PM is interested in 4th week retention we need to run it for 28 days after enrollment ends.

This PR it to overwrite the config date that was originally set.