### PR TITLE
Replace activity stream metrics with newtab

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1046,7 +1046,7 @@ description = """
 Count of clicks on Organic Pocket content.
 """
 
-[metrics.sponsered_pocket_clicks]
+[metrics.sponsored_pocket_clicks]
 data_source = "newtab_interactions"
 select_expression = "SUM(COALESCE(sponsored_pocket_clicks, 0))"
 friendly_name = "Sponsored Pocket Clicks"
@@ -1480,7 +1480,7 @@ description = "Sponsored Tiles Clients Daily"
 friendly_name = "Sponsored Tiles Clients Daily"
 
 [data_sources.clients_first_seen_v2]
-from_expression = "moz-fx-data-shared-prod.telemetry_derived.clients_first_seen_v2"  # TODO: Replace with view
+from_expression = "moz-fx-data-shared-prod.telemetry_derived.clients_first_seen_v2" # TODO: Replace with view
 submission_date_column = "first_seen_date"
 description = "Clients First Seen V2"
 friendly_name = "Clients First Seen V2"

--- a/jetstream/outcomes/firefox_desktop/pocket_newtab.toml
+++ b/jetstream/outcomes/firefox_desktop/pocket_newtab.toml
@@ -1,72 +1,14 @@
 friendly_name = "Pocket in New Tab"
 description = "Usage and engagement metrics for Pocket content in New Tab."
 
-[metrics.pocket_organic_rec_clicks]
-friendly_name = "Pocket organic rec clicks"
-description = "Number of Pocket organic recs clicked in New Tab"
-select_expression = """
-      COUNTIF(
-          event = 'CLICK'
-          AND source = 'CARDGRID'
-          AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'organic'
-      )
-"""
-data_source = "as_events"
-statistics = { bootstrap_mean = {} }
+[metrics.organic_pocket_clicks.statistics.bootstrap_mean]
+[metrics.organic_pocket_clicks.statistics.deciles]
 
-[metrics.pocket_sponsored_content_clicks]
-friendly_name = "Pocket sponsored content clicks"
-description = "Number of Pocket sponsored content tiles clicked in New Tab"
-select_expression = """
-      COUNTIF(
-          event = 'CLICK'
-          AND source = 'CARDGRID'
-          AND JSON_EXTRACT_SCALAR(value, '$.card_type') = 'spoc'
-      )
-"""
-data_source = "as_events"
-statistics = { bootstrap_mean = {} }
+[metrics.sponsored_pocket_clicks.statistics.bootstrap_mean]
+[metrics.sponsored_pocket_clicks.statistics.deciles]
 
-[metrics.disabled_pocket_in_new_tab]
-friendly_name = "Disable Pocket in New Tab clicks"
-description = "Number of clicks to disable Pocket in New Tab"
-select_expression = """
-      COUNTIF(
-          event = 'PREF_CHANGED'
-          AND source = 'TOP_STORIES'
-          AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
-      )
-"""
-data_source = "as_events"
-statistics = { bootstrap_mean = { drop_highest = 0.0000001 } }
-bigger_is_better = false
+[metrics.newtab_searches.statistics.bootstrap_mean]
+[metrics.newtab_searches.statistics.deciles]
 
-[metrics.disabled_pocket_sponsored_content_in_new_tab]
-friendly_name = "Disable Pocket sponsored content in New Tab clicks"
-description = "Number of clicks to disable Pocket sponsored content in New Tab"
-select_expression = """
-      COUNTIF(
-          event = 'PREF_CHANGED'
-          AND source = 'POCKET_SPOCS'
-          AND JSON_EXTRACT_SCALAR(value, '$.status') = 'false'
-      )
-"""
-data_source = "as_events"
-statistics = { bootstrap_mean = { drop_highest = 0.0000001 } }
-bigger_is_better = false
-
-[metrics.urlbar_handoff_search_count]
-friendly_name = "New Tab search bar searches"
-description = "Number of searches performed in New Tab search bar."
-select_expression = "IFNULL(SUM(search_count_urlbar_handoff), 0)"
-data_source = "clients_daily"
-statistics = { bootstrap_mean = {} }
-
-[data_sources.as_events]
-from_expression = """(
-    SELECT
-        *,
-        DATE(submission_timestamp) AS submission_date
-    FROM mozdata.activity_stream.events
-    )"""
-experiments_column_type = "native"
+[metrics.newtab_pocket_enabled.statistics.binomial]
+[metrics.newtab_sponsored_pocket_stories_enabled.statistics.binomial]


### PR DESCRIPTION
Replaces the metrics in `pocket_newtab.toml` with New Tab equivalents, where available. Currently, there is not a PREF_CHANGED event instrumented in `newtab`, so I've replaced those in the outcome file with metrics that record the pref. When the event is instrumented, these should be swapped over.