### PR TITLE
add end date in line with original duration

### DIFF
--- a/jetstream/ios-sync-manager-integration.toml
+++ b/jetstream/ios-sync-manager-integration.toml
@@ -1,3 +1,6 @@
+[experiment]
+end_date = "2023-07-08"
+
 [metrics]
 
 daily = ["rust_tab_sync_success", "bookmarks_sync_success", "logins_sync_success", "history_sync_success"]


### PR DESCRIPTION
This experiment was still running until today despite ending being requested. Adding a custom config so that Jetstream doesn't needlessly compute 6 months worth of data.