### PR TITLE
Use NULL client_id_columns for desktop DAU

### DIFF
--- a/opmon/desktop-dau.toml
+++ b/opmon/desktop-dau.toml
@@ -31,14 +31,14 @@ statistics.mean = {}
 
 [data_sources.active_users_aggregates_v1]
 from_expression = """(
-    SELECT *, "0" AS client_id
+    SELECT *
      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
     WHERE app_name = 'Firefox Desktop'
 )"""
 friendly_name = "Active Users Aggregates"
 description = "Active Users Aggregates, filtered on Firefox Desktop"
 submission_date_column = "submission_date"
-client_id_column = "client_id" # this table doesn't include client_id, and we don't need it for calculating DAU
+client_id_column = "NULL" # this table doesn't include client_id, and we don't need it for calculating DAU
 
 
 [data_sources.kpi_forecasts]
@@ -55,7 +55,7 @@ from_expression = """
       )
 
       SELECT 
-        forecasts.* EXCEPT(forecast_parameters), "0" AS client_id
+        forecasts.* EXCEPT(forecast_parameters)
         FROM `moz-fx-data-shared-prod.telemetry_derived.kpi_forecasts_v0` AS forecasts
         JOIN most_recent_forecasts
        USING(aggregation_period, metric_alias, metric_hub_app_name, metric_hub_slug, forecast_predicted_at)
@@ -64,4 +64,4 @@ from_expression = """
   )
 """
 submission_date_column = "submission_date"
-client_id_column = "client_id"
+client_id_column = "NULL"


### PR DESCRIPTION
depends on https://github.com/mozilla/opmon/pull/173

We can set `client_id_column` to `NULL` if metrics or datasources should ignore client ID ([see](https://github.com/mozilla/metric-hub/blob/aae373bf2d2f29092e03154fae47917cc17a8415/definitions/multi_product.toml#L54)). We should do the same for the OpMon desktop DAU config

There is a preview here: https://mozilla.cloud.looker.com/dashboards/operational_monitoring::opmon_preview?Table=%27mozdata.tmp.desktop_dau_statistics%27&Submission+Date=2023-11-24+to+2023-11-28&Metric=%22kpi_forecast%22&Statistic=mean