### PR TITLE
Updates measurement period for RC experiments

### DIFF
--- a/jetstream/review-checker-119-existing-user-profiles.toml
+++ b/jetstream/review-checker-119-existing-user-profiles.toml
@@ -1,5 +1,8 @@
 [experiment]
 
+enrollment_period = 6
+end_date = "2023-12-06"
+
 [experiment.exposure_signal]
 name = "opened_product_page"
 friendly_name = "Opened at least one product page"

--- a/jetstream/review-checker-119-new-profiles.toml
+++ b/jetstream/review-checker-119-new-profiles.toml
@@ -1,5 +1,8 @@
 [experiment]
 
+enrollment_period = 6
+end_date = "2023-12-06"
+
 [experiment.exposure_signal]
 name = "opened_product_page"
 friendly_name = "Opened at least one product page"


### PR DESCRIPTION
This change is temporarily necessary in order to deliver experiment results in time for the 12/7 go/no-go decision meeting. This change should be reverted on 12/7 after that meeting in order to deliver full results on 12/8, though this can happen as a manual verification (does not need to be done through metric-hub) as that would save on the costs of doing a full rerun. 