### PR TITLE
[AD-144] Creating new data_source and pointing most dismissal metrics to it. Also new metrics for organic tile dismissals.

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1172,15 +1172,6 @@ description = """
 Count of New Tab organic tile impressions.
 """
 
-[metrics.newtab_organic_topsite_impressions]
-data_source = "newtab_interactions"
-select_expression = "SUM(COALESCE(organic_topsite_impressions, 0))"
-friendly_name = "Newtab Organic Tile Impressions"
-type = "scalar"
-description = """
-Count of New Tab organic tile impressions.
-"""
-
 
 ########################### END OF NEW TAB METRICS ###########################
 

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1591,6 +1591,7 @@ from_expression = """(
 submission_date_column = "submission_date"
 description = "Topsite Tiles Visit Activity Daily"
 friendly_name = "Topsite Tiles Visit Activity Daily"
+client_id_column = "legacy_telemetry_client_id"
 
 
 [segments]

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -3,9 +3,9 @@
 [metrics.ad_click_rate]
 friendly_name = "Ad Click Rate"
 description = """
-    This is a Population Ratio Metric. It is the total number of 
-    ad clicks over all clients in the population divided by the 
-    total number of SAP searches over all clients in the 
+    This is a Population Ratio Metric. It is the total number of
+    ad clicks over all clients in the population divided by the
+    total number of SAP searches over all clients in the
     population.
 """
 category = "search"
@@ -121,8 +121,8 @@ data_source = "search_clients_engines_sources_daily"
 select_expression = '{{agg_sum("search_with_ads_organic")}}'
 friendly_name = "Organic searches with ads"
 description = """
-    Counts search result pages from organic searches served with advertising. Organic searches 
-    are _not_ performed through a Firefox SAP and are not monetizable. 
+    Counts search result pages from organic searches served with advertising. Organic searches
+    are _not_ performed through a Firefox SAP and are not monetizable.
     Users may not actually see these ads thanks to e.g. ad-blockers.
     Learn more in the
     [search analysis documentation](https://mozilla-private.report/search-analysis-docs/book/in_content_searches.html).
@@ -137,7 +137,7 @@ select_expression = '{{agg_sum("ad_click_organic")}}'
 friendly_name = "Organic ad clicks"
 description = """
     Counts clicks on ads on search engine result pages organic searches.
-    Organic searches are _not_ performed through a Firefox SAP and are not monetizable. 
+    Organic searches are _not_ performed through a Firefox SAP and are not monetizable.
 """
 
 
@@ -289,7 +289,7 @@ description = """
     The number of unique clients with >0 active hours and >0 URIs loaded that
     we received a main ping from each day. To be comparable to DAU used for KPI
     tracking, this metric needs to be aggregated by `submission_date`. If the
-    metric is NOT aggregated by `submission_date`, the metric is similar to a 
+    metric is NOT aggregated by `submission_date`, the metric is similar to a
     "days of use" metric. For more details, refer to
     [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
 
@@ -311,7 +311,7 @@ description = """
     Whenever possible, this is the preferred DAU reporting definition to use for Desktop.
     This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`,
     it is similar to a "days of use" metric, and not DAU.
-    
+
     For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
     For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
@@ -330,7 +330,7 @@ description = """
     exists only for cases where reporting `client_id` is required (e.g. for experiments). This metric
     needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`, it is
     similar to a "days of use" metric, and not DAU.
-    
+
     For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
     For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
@@ -348,9 +348,9 @@ type = "scalar"
 friendly_name = "Desktop DAU KPI"
 description = """
     The average number of unique clients with >0 active hours and >0 URIs loaded that
-    we received a main ping from each day in the 28-day period ending on December 15th. 
+    we received a main ping from each day in the 28-day period ending on December 15th.
     To reconstruct the annual Desktop DAU KPI, this metric needs to be aggregated by
-    `EXTRACT(YEAR FROM submission_date)`.  
+    `EXTRACT(YEAR FROM submission_date)`.
 
     For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
@@ -369,7 +369,7 @@ description = """
     [defined in `bigquery-etl`](https://github.com/mozilla/bigquery-etl/blob/main/sql_generators/active_users/templates/desktop_query.sql)
     and is automatically cross-checked, actively monitored, and change controlled.
     To reconstruct the annual Desktop DAU KPI, this metric needs to be aggregated by
-    `EXTRACT(YEAR FROM submission_date)`.  
+    `EXTRACT(YEAR FROM submission_date)`.
 
     For more information, refer to [the DAU description in the Mozilla Data Documentation](https://docs.telemetry.mozilla.org/concepts/terminology.html#dau).
     For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
@@ -999,7 +999,7 @@ description = """
 Was Firefox pinned to the Windows Taskbar at any point during the interval?
 """
 
-########################### START OF NEW TAB METRICS ########################### 
+########################### START OF NEW TAB METRICS ###########################
 
 [metrics.newtab_searches]
 data_source = "newtab_interactions"
@@ -1172,7 +1172,17 @@ description = """
 Count of New Tab organic tile impressions.
 """
 
-########################### END OF NEW TAB METRICS ########################### 
+[metrics.newtab_organic_topsite_impressions]
+data_source = "newtab_interactions"
+select_expression = "SUM(COALESCE(organic_topsite_impressions, 0))"
+friendly_name = "Newtab Organic Tile Impressions"
+type = "scalar"
+description = """
+Count of New Tab organic tile impressions.
+"""
+
+
+########################### END OF NEW TAB METRICS ###########################
 
 [metrics.imported_bookmarks]
 data_source = "clients_daily"
@@ -1278,35 +1288,50 @@ friendly_name = "Sponsored Tiles Disabled Event"
 description = "Boolean that identifies clients that disabled sponsored tiles during experiment"
 
 [metrics.sponsored_tiles_dismissals]
-select_expression = """COUNTIF(
-        event = 'BLOCK'
-        AND value LIKE '%spoc%'
-        AND SOURCE = 'TOP_SITES'
-      )"""
-data_source = "activity_stream_events"
+select_expression = "COALESCE(SUM(sponsored_topsite_tile_dismissals), 0)"
+data_source = "newtab_visits_topsite_tile_interactions"
 friendly_name = "Sponsored Tiles Dismissals Count"
 description = "Count of sponsored tiles dismissals in all positions"
 
 [metrics.any_sponsored_tiles_dismissals]
 select_expression = """COALESCE(LOGICAL_OR(
-        event = 'BLOCK'
-        AND value LIKE '%spoc%'
-        AND SOURCE = 'TOP_SITES'
+        sponsored_topsite_tile_dismissals > 0
       ), FALSE)"""
-data_source = "activity_stream_events"
+data_source = "newtab_visits_topsite_tile_interactions"
 friendly_name = "Any Sponsored Tiles Dismissed"
 description = "Clients that dismissed any sponsored tiles"
 
 [metrics.sponsored_tiles_dismissals_pos1_2]
-select_expression = """COUNTIF(
-        event = 'BLOCK'
-        AND value LIKE '%spoc%'
-        AND SOURCE = 'TOP_SITES'
-        AND action_position <= 1
+select_expression = """COALESCE(
+        SUM(CASE WHEN sponsored_topsite_tile_dismissals > 0 AND topsite_tile_position < 3 THEN sponsored_topsite_tile_dismissals ELSE 0 END),
+        0
       )"""
-data_source = "activity_stream_events"
+data_source = "newtab_visits_topsite_tile_interactions"
 friendly_name = "Sponsored Tiles Dismissals Count (Positions 1 and 2)"
 description = "Count of sponsored tiles dismissals in the first two positions"
+
+[metrics.sponsored_tiles_dismissals_pos3_more]
+select_expression = """COALESCE(
+        SUM(CASE WHEN sponsored_topsite_tile_dismissals > 0 AND topsite_tile_position >= 3 THEN sponsored_topsite_tile_dismissals ELSE 0 END),
+        0
+      )"""
+data_source = "newtab_visits_topsite_tile_interactions"
+friendly_name = "Sponsored Tiles Dismissals Count (Position 3 or greater)"
+description = "Count of sponsored tiles dismissals in the third and greater positions"
+
+[metrics.organic_tiles_dismissals]
+select_expression = "COALESCE(SUM(organic_topsite_tile_dismissals),0)"
+data_source = "newtab_visits_topsite_tile_interactions"
+friendly_name = "Organic Tiles Dismissals Count"
+description = "Count of organic tiles dismissals in all positions"
+
+[metrics.any_organic_tiles_dismissals]
+select_expression = """COALESCE(LOGICAL_OR(
+        organic_topsite_tile_dismissals > 0
+      ), FALSE)"""
+data_source = "newtab_visits_topsite_tile_interactions"
+friendly_name = "Any Organic Tiles Dismissed"
+description = "Clients that dismissed any organic tiles"
 
 [metrics.separate_search_engine]
 select_expression = "COALESCE(ANY_VALUE(default_search_engine != default_private_search_engine), false)"
@@ -1324,8 +1349,8 @@ description = "The number of newly acquired Firefox Desktop clients. A client is
 [metrics.pdf_engagement]
 select_expression = """(
     (COALESCE(SUM(mozfun.map.get_key(metrics.labeled_counter.pdfjs_editing, "freetext")) > 0, FALSE) OR
-    COALESCE(SUM(mozfun.map.get_key(metrics.labeled_counter.pdfjs_editing, "ink")) > 0, FALSE)) AND 
-    (COALESCE(SUM(mozfun.map.get_key(metrics.labeled_counter.pdfjs_editing, "print")) > 0, FALSE) OR 
+    COALESCE(SUM(mozfun.map.get_key(metrics.labeled_counter.pdfjs_editing, "ink")) > 0, FALSE)) AND
+    (COALESCE(SUM(mozfun.map.get_key(metrics.labeled_counter.pdfjs_editing, "print")) > 0, FALSE) OR
     COALESCE(SUM(mozfun.map.get_key(metrics.labeled_counter.pdfjs_editing, "save")) > 0, FALSE))
 )"""
 data_source = "metrics"
@@ -1430,7 +1455,7 @@ from_expression = """
         SELECT
             *
         FROM `moz-fx-data-shared-prod.telemetry.events`
-        WHERE 
+        WHERE
             event_category = 'memory_watcher'
             AND event_method = 'on_high_memory'
             AND event_object = 'stats'
@@ -1554,13 +1579,27 @@ experiments_column_type = "native"
 friendly_name = "Glean Metrics"
 description = "The Glean metrics ping"
 from_expression = """(
-    SELECT 
+    SELECT
       p.*,
       DATE(p.submission_timestamp) AS submission_date
     FROM `mozdata.firefox_desktop.metrics` p
     )"""
 client_id_column = "metrics.uuid.legacy_telemetry_client_id"
 experiments_column_type = "glean"
+
+[data_sources.newtab_visits_topsite_tile_interactions]
+from_expression = """(
+    SELECT
+        e.* EXCEPT (topsite_tile_interactions),
+        topsite_tile_interactions
+    FROM
+        `moz-fx-data-shared-prod.telemetry.newtab_visits` e
+    CROSS JOIN
+        UNNEST(e.topsite_tile_interactions) AS topsite_tile_interactions
+)"""
+submission_date_column = "submission_date"
+description = "Topsite Tiles Visit Activity Daily"
+friendly_name = "Topsite Tiles Visit Activity Daily"
 
 
 [segments]

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1294,7 +1294,7 @@ description = "Clients that dismissed any sponsored tiles"
 
 [metrics.sponsored_tiles_dismissals_pos1_2]
 select_expression = """COALESCE(
-        SUM(CASE WHEN topsite_tile_interactions.sponsored_topsite_tile_dismissals > 0 AND topsite_tile_interactions.topsite_tile_position < 3 THEN topsite_tile_interactions.sponsored_topsite_tile_dismissals ELSE 0 END),
+        SUM(CASE WHEN topsite_tile_interactions.sponsored_topsite_tile_dismissals > 0 AND topsite_tile_interactions.topsite_tile_position < 2 THEN topsite_tile_interactions.sponsored_topsite_tile_dismissals ELSE 0 END),
         0
       )"""
 data_source = "newtab_visits_topsite_tile_interactions"
@@ -1303,7 +1303,7 @@ description = "Count of sponsored tiles dismissals in the first two positions"
 
 [metrics.sponsored_tiles_dismissals_pos3_more]
 select_expression = """COALESCE(
-        SUM(CASE WHEN topsite_tile_interactions.sponsored_topsite_tile_dismissals > 0 AND topsite_tile_interactions.topsite_tile_position >= 3 THEN topsite_tile_interactions.sponsored_topsite_tile_dismissals ELSE 0 END),
+        SUM(CASE WHEN topsite_tile_interactions.sponsored_topsite_tile_dismissals > 0 AND topsite_tile_interactions.topsite_tile_position >= 2 THEN topsite_tile_interactions.sponsored_topsite_tile_dismissals ELSE 0 END),
         0
       )"""
 data_source = "newtab_visits_topsite_tile_interactions"

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1279,14 +1279,14 @@ friendly_name = "Sponsored Tiles Disabled Event"
 description = "Boolean that identifies clients that disabled sponsored tiles during experiment"
 
 [metrics.sponsored_tiles_dismissals]
-select_expression = "COALESCE(SUM(sponsored_topsite_tile_dismissals), 0)"
+select_expression = "COALESCE(SUM(topsite_tile_interactions.sponsored_topsite_tile_dismissals), 0)"
 data_source = "newtab_visits_topsite_tile_interactions"
 friendly_name = "Sponsored Tiles Dismissals Count"
 description = "Count of sponsored tiles dismissals in all positions"
 
 [metrics.any_sponsored_tiles_dismissals]
 select_expression = """COALESCE(LOGICAL_OR(
-        sponsored_topsite_tile_dismissals > 0
+        topsite_tile_interactions.sponsored_topsite_tile_dismissals > 0
       ), FALSE)"""
 data_source = "newtab_visits_topsite_tile_interactions"
 friendly_name = "Any Sponsored Tiles Dismissed"
@@ -1294,7 +1294,7 @@ description = "Clients that dismissed any sponsored tiles"
 
 [metrics.sponsored_tiles_dismissals_pos1_2]
 select_expression = """COALESCE(
-        SUM(CASE WHEN sponsored_topsite_tile_dismissals > 0 AND topsite_tile_position < 3 THEN sponsored_topsite_tile_dismissals ELSE 0 END),
+        SUM(CASE WHEN topsite_tile_interactions.sponsored_topsite_tile_dismissals > 0 AND topsite_tile_interactions.topsite_tile_position < 3 THEN topsite_tile_interactions.sponsored_topsite_tile_dismissals ELSE 0 END),
         0
       )"""
 data_source = "newtab_visits_topsite_tile_interactions"
@@ -1303,7 +1303,7 @@ description = "Count of sponsored tiles dismissals in the first two positions"
 
 [metrics.sponsored_tiles_dismissals_pos3_more]
 select_expression = """COALESCE(
-        SUM(CASE WHEN sponsored_topsite_tile_dismissals > 0 AND topsite_tile_position >= 3 THEN sponsored_topsite_tile_dismissals ELSE 0 END),
+        SUM(CASE WHEN topsite_tile_interactions.sponsored_topsite_tile_dismissals > 0 AND topsite_tile_interactions.topsite_tile_position >= 3 THEN topsite_tile_interactions.sponsored_topsite_tile_dismissals ELSE 0 END),
         0
       )"""
 data_source = "newtab_visits_topsite_tile_interactions"
@@ -1311,14 +1311,14 @@ friendly_name = "Sponsored Tiles Dismissals Count (Position 3 or greater)"
 description = "Count of sponsored tiles dismissals in the third and greater positions"
 
 [metrics.organic_tiles_dismissals]
-select_expression = "COALESCE(SUM(organic_topsite_tile_dismissals),0)"
+select_expression = "COALESCE(SUM(topsite_tile_interactions.organic_topsite_tile_dismissals),0)"
 data_source = "newtab_visits_topsite_tile_interactions"
 friendly_name = "Organic Tiles Dismissals Count"
 description = "Count of organic tiles dismissals in all positions"
 
 [metrics.any_organic_tiles_dismissals]
 select_expression = """COALESCE(LOGICAL_OR(
-        organic_topsite_tile_dismissals > 0
+        topsite_tile_interactions.organic_topsite_tile_dismissals > 0
       ), FALSE)"""
 data_source = "newtab_visits_topsite_tile_interactions"
 friendly_name = "Any Organic Tiles Dismissed"


### PR DESCRIPTION
Creating new data_source `[data_sources.newtab_visits_topsite_tile_interactions]` based on `newtab_visits`. Pointing most dismissal metrics to it. Also adding metrics for organic tile dismissals.