### PR TITLE
[ci skip-rerun] Escape underscores in `LIKE` patterns

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -424,7 +424,7 @@ type = "scalar"
 
 [metrics.shutdown_hangs]
 data_source = "crash"
-select_expression = "SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0))"
+select_expression = '''SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0))'''
 friendly_name = "Shutdown Hangs"
 description = "Number of Shutdown Hangs"
 category = "stability"

--- a/jetstream/bookmarks-toolbar-default-on.toml
+++ b/jetstream/bookmarks-toolbar-default-on.toml
@@ -5,12 +5,12 @@ overall = ['bookmarks_bar_pinned_on', 'bookmarks_bar_pinned_off', 'bookmarks_bar
 
 
 [metrics.bookmarks_bar_pinned_on]
-select_expression = "CAST(COALESCE(SUM(CASE WHEN(SELECT CAST(COUNT(t) AS BOOL) FROM UNNEST(payload.processes.parent.keyed_scalars.browser_ui_toolbar_widgets) t WHERE t.key LIKE 'bookmarks-bar_pinned_on' AND t.value) THEN 1 ELSE 0 END),0) > 0 AS INT)"
+select_expression = '''CAST(COALESCE(SUM(CASE WHEN(SELECT CAST(COUNT(t) AS BOOL) FROM UNNEST(payload.processes.parent.keyed_scalars.browser_ui_toolbar_widgets) t WHERE t.key LIKE r'bookmarks-bar\_pinned\_on' AND t.value) THEN 1 ELSE 0 END),0) > 0 AS INT)'''
 data_source = 'main'
 
 
 [metrics.bookmarks_bar_pinned_off]
-select_expression = "CAST(COALESCE(SUM(CASE WHEN(SELECT CAST(COUNT(t) AS BOOL) FROM UNNEST(payload.processes.parent.keyed_scalars.browser_ui_toolbar_widgets) t WHERE t.key LIKE 'bookmarks-bar_pinned_off' AND t.value) THEN 1 ELSE 0 END),0) > 0 AS INT)"
+select_expression = '''CAST(COALESCE(SUM(CASE WHEN(SELECT CAST(COUNT(t) AS BOOL) FROM UNNEST(payload.processes.parent.keyed_scalars.browser_ui_toolbar_widgets) t WHERE t.key LIKE r'bookmarks-bar\_pinned\_off' AND t.value) THEN 1 ELSE 0 END),0) > 0 AS INT)'''
 data_source = 'main'
 
 

--- a/jetstream/bug-1698297-pref-fission-m7-beta-experiment-beta-88-89.toml
+++ b/jetstream/bug-1698297-pref-fission-m7-beta-experiment-beta-88-89.toml
@@ -669,12 +669,12 @@ daily = [
 #        log_space = true
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)),
+            SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_cleaned'
     bigger_is_better = false
 

--- a/jetstream/bug-1706428-pref-fission-m7-beta-experiment-with-memory-filter-beta-89-91.toml
+++ b/jetstream/bug-1706428-pref-fission-m7-beta-experiment-with-memory-filter-beta-89-91.toml
@@ -670,12 +670,12 @@ daily = [
 #        log_space = true
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)),
+            SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_cleaned'
     bigger_is_better = false
 

--- a/jetstream/bug-1712979-pref-fission-beta-90-experiment-beta-90-91.toml
+++ b/jetstream/bug-1712979-pref-fission-beta-90-experiment-beta-90-91.toml
@@ -715,12 +715,12 @@ daily = [
 #        log_space = true
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)),
+            SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_cleaned'
     bigger_is_better = false
 

--- a/jetstream/bug-1719576-pref-fission-beta-91-experiment-beta-91-91.toml
+++ b/jetstream/bug-1719576-pref-fission-beta-91-experiment-beta-91-91.toml
@@ -715,12 +715,12 @@ daily = [
 #        log_space = true
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_cleaned'
     bigger_is_better = false
 

--- a/jetstream/bug-1722112-pref-fission-process-count-nightly-92-94.toml
+++ b/jetstream/bug-1722112-pref-fission-process-count-nightly-92-94.toml
@@ -635,12 +635,12 @@ daily = [
 
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_hour'
     bigger_is_better = false
 

--- a/jetstream/bug-1722551-pref-full-js-parsing-experiment-nightly-94-94.toml
+++ b/jetstream/bug-1722551-pref-full-js-parsing-experiment-nightly-94-94.toml
@@ -757,12 +757,12 @@ daily = [
 
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_hour'
     bigger_is_better = false
 

--- a/jetstream/bug-1724054-pref-fission-beta-92-experiment-beta-92-92.toml
+++ b/jetstream/bug-1724054-pref-fission-beta-92-experiment-beta-92-92.toml
@@ -683,12 +683,12 @@ daily = [
 #        log_space = true
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_cleaned'
     bigger_is_better = false
 

--- a/jetstream/bug-1725055-pref-fission-release-92-experiment-release-92-92.toml
+++ b/jetstream/bug-1725055-pref-fission-release-92-experiment-release-92-92.toml
@@ -684,12 +684,12 @@ daily = [
 
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_cleaned'
     bigger_is_better = false
 

--- a/jetstream/bug-1727420-pref-fission-beta-93-process-count-experiment-beta-93-93.toml
+++ b/jetstream/bug-1727420-pref-fission-beta-93-process-count-experiment-beta-93-93.toml
@@ -635,12 +635,12 @@ daily = [
 
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_hour'
     bigger_is_better = false
 

--- a/jetstream/bug-1731908-pref-fission-beta-94-95-experiment-beta-94-95.toml
+++ b/jetstream/bug-1731908-pref-fission-beta-94-95-experiment-beta-94-95.toml
@@ -40,7 +40,7 @@ experiments_column_type = "native"
 
 ## crash: removing session corresponding to enrollment
 [data_sources.crash_cleaned]
-from_expression = """
+from_expression = '''
 (
   SELECT
     cr.*,
@@ -50,7 +50,7 @@ from_expression = """
     (SELECT
         DATE(submission_timestamp) AS submission_date,
         client_id,
-        COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0) AS sum_shutdown_hangs,
+        COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0) AS sum_shutdown_hangs,
         COALESCE(SUM(IF(payload.process_type = 'main' OR payload.process_type IS NULL, 1, 0)), 0) AS sum_main_crashes,
         COALESCE(SUM(IF(payload.metadata.oom_allocation_size IS NOT NULL, 1, 0)), 0) AS sum_oom_allocation_size,
         COALESCE(SUM(IF(REGEXP_CONTAINS(payload.process_type, 'content')
@@ -98,7 +98,7 @@ from_expression = """
     ON m.client_id = cr.client_id
     AND m.submission_date = cr.submission_date
 )
-"""
+'''
 experiments_column_type = "native"
 
 

--- a/jetstream/bug-1780829-pref-impact-of-concurrent-delazification-nightly-107-107.toml
+++ b/jetstream/bug-1780829-pref-impact-of-concurrent-delazification-nightly-107-107.toml
@@ -756,12 +756,12 @@ daily = [
 
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_hour'
     bigger_is_better = false
 

--- a/jetstream/bug-1811065-pref-impact-of-parallel-marking-v2-nightly-111-112.toml
+++ b/jetstream/bug-1811065-pref-impact-of-parallel-marking-v2-nightly-111-112.toml
@@ -554,12 +554,12 @@ daily = [
 
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_hour'
     bigger_is_better = false
 

--- a/jetstream/ctd-marketing-attribution.toml
+++ b/jetstream/ctd-marketing-attribution.toml
@@ -39,7 +39,7 @@ data_source = "special_onboarding_events"
 
 ## Data Sources
 [data_sources.special_onboarding_events]
-from_expression = """(
+from_expression = '''(
   SELECT
     expo.submission_date,
     expo.client_id,
@@ -110,22 +110,22 @@ from_expression = """(
           case
             -- all the different screens with set to default CTAs
             when (
-              message_id LIKE '%AW_EASY_SETUP%'
-              OR message_id LIKE '%AW_SET_DEFAULT%'
-              OR message_id LIKE '%AW_ONLY_DEFAULT%'
+              message_id LIKE r'%AW\_EASY\_SETUP%'
+              OR message_id LIKE r'%AW\_SET\_DEFAULT%'
+              OR message_id LIKE r'%AW\_ONLY\_DEFAULT%'
             ) then DATE(submission_timestamp)
           END
         ) as set_to_default_card,
         count(
           case
-            when message_id LIKE '%AW_PIN_FIREFOX%' then DATE(submission_timestamp)
+            when message_id LIKE r'%AW\_PIN\_FIREFOX%' then DATE(submission_timestamp)
           END
         ) as pin_card,
         count(
           case
             when (
-              message_id LIKE '%AW_EASY_SETUP%'
-              OR message_id LIKE '%AW_IMPORT_SETTINGS%'
+              message_id LIKE r'%AW\_EASY\_SETUP%'
+              OR message_id LIKE r'%AW\_IMPORT\_SETTINGS%'
             ) then DATE(submission_timestamp)
           END
         ) as import_card
@@ -148,14 +148,14 @@ from_expression = """(
             when (
               (
                 (
-                  message_id LIKE '%AW_SET_DEFAULT%'
-                  OR message_id LIKE '%AW_ONLY_DEFAULT%'
+                  message_id LIKE r'%AW\_SET\_DEFAULT%'
+                  OR message_id LIKE r'%AW\_ONLY\_DEFAULT%'
                 )
                 AND event = 'CLICK_BUTTON'
-                AND event_context LIKE '%primary_button%'
+                AND event_context LIKE r'%primary\_button%'
               )
               OR (
-                message_id LIKE '%AW_EASY_SETUP%'
+                message_id LIKE r'%AW\_EASY\_SETUP%'
                 AND event = 'SELECT_CHECKBOX'
                 AND event_context LIKE '%checkbox-1%'
               )
@@ -165,9 +165,9 @@ from_expression = """(
         count(
           case
             when (
-              message_id LIKE '%AW_PIN_FIREFOX%'
+              message_id LIKE r'%AW\_PIN\_FIREFOX%'
               AND event = 'CLICK_BUTTON'
-              AND event_context LIKE '%primary_button%'
+              AND event_context LIKE r'%primary\_button%'
             ) then DATE(submission_timestamp)
           END
         ) as pin,
@@ -176,12 +176,12 @@ from_expression = """(
             -- all the different ways of opening the import wizard
             when (
               (
-                message_id LIKE '%AW_IMPORT_SETTINGS%'
+                message_id LIKE r'%AW\_IMPORT\_SETTINGS%'
                 AND event = 'CLICK_BUTTON'
-                AND event_context LIKE '%primary_button%'
+                AND event_context LIKE r'%primary\_button%'
               )
               OR (
-                message_id LIKE '%AW_EASY_SETUP%'
+                message_id LIKE r'%AW\_EASY\_SETUP%'
                 AND event = 'SELECT_CHECKBOX'
                 AND event_context LIKE '%checkbox-2%'
               )
@@ -192,11 +192,11 @@ from_expression = """(
         `moz-fx-data-shared-prod.messaging_system.onboarding`
       WHERE
         (
-          message_id LIKE '%AW_SET_DEFAULT%'
-          OR message_id LIKE '%AW_ONLY_DEFAULT%'
-          OR message_id LIKE '%AW_EASY_SETUP%'
-          OR message_id LIKE '%AW_PIN_FIREFOX%'
-          OR message_id LIKE '%AW_IMPORT_SETTINGS%'
+          message_id LIKE r'%AW\_SET\_DEFAULT%'
+          OR message_id LIKE r'%AW\_ONLY\_DEFAULT%'
+          OR message_id LIKE r'%AW\_EASY\_SETUP%'
+          OR message_id LIKE r'%AW\_PIN\_FIREFOX%'
+          OR message_id LIKE r'%AW\_IMPORT\_SETTINGS%'
         )
         AND (
           event = 'CLICK_BUTTON'
@@ -215,7 +215,7 @@ from_expression = """(
     4,
     5,
     6
-)"""
+)'''
 description = "Onboarding CTAs"
 friendly_name = "Onboarding CTAs CTR base"
 experiments_column_type = "none"

--- a/jetstream/firefox-ios-homepage-experiment-sponsored-shortcuts.toml
+++ b/jetstream/firefox-ios-homepage-experiment-sponsored-shortcuts.toml
@@ -58,12 +58,12 @@ data_source = "baseline"
 [metrics.spoc_tiles_impressions]
 friendly_name = "Sponsored Tiles Impressions"
 description = "Number of times Contile Sponsored Tiles are shown."
-select_expression = """
+select_expression = '''
       COALESCE(COUNTIF(
-          event.category like 'top_site%'
+          event.category like r'top\_site%'
           AND event.name = 'contile_impression'
       ),0)
-"""
+'''
 data_source = "events"   
 statistics = { bootstrap_mean = {}, deciles = {} }
 
@@ -71,12 +71,12 @@ statistics = { bootstrap_mean = {}, deciles = {} }
 [metrics.spoc_tiles_clicks]
 friendly_name = "Sponsored Tiles Clicks"
 description = "Number of times user clicked a Contile Sponsored Tile."
-select_expression = """
+select_expression = '''
       COALESCE(COUNTIF(
-          event.category like 'top_site%'
+          event.category like r'top\_site%'
           AND event.name = 'contile_click'
       ),0)
-"""
+'''
 data_source = "events" 
 statistics = { bootstrap_mean = {}, deciles = {} }
 

--- a/jetstream/impact-of-race-cache-with-network-feature.toml
+++ b/jetstream/impact-of-race-cache-with-network-feature.toml
@@ -402,12 +402,12 @@ daily = [
 
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_hour'
     bigger_is_better = false
 

--- a/jetstream/parallel-marking-experiment.toml
+++ b/jetstream/parallel-marking-experiment.toml
@@ -896,12 +896,12 @@ daily = [
 
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_hour'
     bigger_is_better = false
 

--- a/jetstream/speculative-connect-sockets.toml
+++ b/jetstream/speculative-connect-sockets.toml
@@ -402,12 +402,12 @@ daily = [
 
 
     [metrics.shutdown_hangs_per_hour]
-    select_expression = """
+    select_expression = '''
         SAFE_DIVIDE(
-            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE 'MOZ_CRASH%', 1, 0)), 0),
+            COALESCE(SUM(IF(payload.metadata.moz_crash_reason LIKE r'MOZ\_CRASH%', 1, 0)), 0),
             SUM(active_s/3600)
          )
-        """
+        '''
     data_source = 'crash_hour'
     bigger_is_better = false
 

--- a/opmon/desktop-dau.toml
+++ b/opmon/desktop-dau.toml
@@ -42,7 +42,7 @@ client_id_column = "NULL" # this table doesn't include client_id, and we don't n
 
 
 [data_sources.kpi_forecasts]
-from_expression = """
+from_expression = '''
   (
     WITH most_recent_forecasts AS (
         SELECT aggregation_period,
@@ -59,9 +59,9 @@ from_expression = """
         FROM `moz-fx-data-shared-prod.telemetry_derived.kpi_forecasts_v0` AS forecasts
         JOIN most_recent_forecasts
        USING(aggregation_period, metric_alias, metric_hub_app_name, metric_hub_slug, forecast_predicted_at)
-       WHERE aggregation_period = 'day' AND measure IN ('observed', 'p50') AND metric_alias LIKE 'desktop_dau'
+       WHERE aggregation_period = 'day' AND measure IN ('observed', 'p50') AND metric_alias LIKE r'desktop\_dau'
        ORDER BY submission_date ASC
   )
-"""
+'''
 submission_date_column = "submission_date"
 client_id_column = "NULL"


### PR DESCRIPTION
In `LIKE` patterns unescaped underscores will match any single character.