### PR TITLE
change search data source filters and fix fenix uri count

### DIFF
--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -2,7 +2,7 @@
 
 [metrics.uri_count]
 data_source = "baseline"
-select_expression = '{{agg_sum("metrics.counter.events_total_uri_count")}}'
+select_expression = '{{agg_sum("metrics.counter.events_normal_and_private_uri_count")}}'
 friendly_name = "URIs visited"
 description = "Counts the number of URIs each client visited"
 
@@ -499,7 +499,7 @@ build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_
 from_expression = """(
     SELECT *
     FROM `mozdata.search.mobile_search_clients_engines_sources_daily`
-    WHERE normalized_app_name = "Fenix"
+    WHERE normalized_app_name_os = 'Firefox Android'
 )"""
 experiments_column_type = "simple"
 client_id_column = "client_id"

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -410,7 +410,7 @@ build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_
 from_expression = """(
     SELECT *
     FROM `mozdata.search.mobile_search_clients_engines_sources_daily`
-    WHERE os = "iOS" AND normalized_app_name = "Fennec"
+    WHERE normalized_app_name_os = 'Firefox iOS'
 )"""
 experiments_column_type = "simple"
 client_id_column = "client_id"

--- a/definitions/focus_ios.toml
+++ b/definitions/focus_ios.toml
@@ -285,7 +285,7 @@ build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_
 from_expression = """(
     SELECT *
     FROM `mozdata.search.mobile_search_clients_engines_sources_daily`
-    WHERE app_name = 'Focus' and os = 'iOS'
+    WHERE normalized_app_name_os = 'Focus iOS'
  )"""
 experiments_column_type = "simple"
 client_id_column = "client_id"

--- a/definitions/klar_ios.toml
+++ b/definitions/klar_ios.toml
@@ -184,7 +184,7 @@ build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_
 from_expression = """(
     SELECT *
     FROM `mozdata.search.mobile_search_clients_engines_sources_daily`
-    WHERE app_name = 'Klar' and os = 'iOS'
+    WHERE normalized_app_name_os = 'Klar iOS'
  )"""
  experiments_column_type = "simple"
 client_id_column = "client_id"


### PR DESCRIPTION
We noticed that the search metrics for Fenix in jetstream were broken. Using the current definition (pasted below) now returns no results:

```sql
(
    SELECT *
    FROM `mozdata.search.mobile_search_clients_engines_sources_daily`
    WHERE normalized_app_name = "Fenix"
)
```

This is because "Fenix" is no longer a value in `normalized_app_name`. I'm not sure when or where this changed, but it appears to be recent. The filter needs to be changed to either:

```sql
WHERE app_name = "Fenix"
```
OR 
```sql
WHERE normalized_app_name_os = "Firefox Android"
```

[It appears that these two filters return the same data](https://sql.telemetry.mozilla.org/queries/97049/source).

I also went ahead and changed the filters for the other apps to follow the same pattern. 

I also changed the URI count metric on fenix to point to a non-expired probe. [The current metric](https://github.com/mozilla/metric-hub/blob/main/jetstream/defaults/fenix.toml#L99-L101)  [points to an expired probe](https://dictionary.telemetry.mozilla.org/apps/fenix/metrics/events_total_uri_count). I believe it should [use this one instead](https://dictionary.telemetry.mozilla.org/apps/fenix/metrics/events_normal_and_private_uri_count).

