### PR TITLE
[ci skip-rerun] remove expired total uri count probe

### DIFF
--- a/jetstream/defaults/fenix.toml
+++ b/jetstream/defaults/fenix.toml
@@ -97,7 +97,7 @@ bootstrap_mean = {}
 ##
 
 [metrics.total_uri_count]
-select_expression = "{{agg_sum('metrics.counter.events_total_uri_count')}}"
+select_expression = "{{agg_sum('metrics.counter.events_normal_and_private_uri_count")}}'
 data_source = "metrics"
 
 [metrics.total_uri_count.statistics]

--- a/jetstream/defaults/fenix.toml
+++ b/jetstream/defaults/fenix.toml
@@ -97,7 +97,7 @@ bootstrap_mean = {}
 ##
 
 [metrics.total_uri_count]
-select_expression = "{{agg_sum('metrics.counter.events_normal_and_private_uri_count")}}'
+select_expression = "{{agg_sum('metrics.counter.events_normal_and_private_uri_count')}}"
 data_source = "metrics"
 
 [metrics.total_uri_count.statistics]


### PR DESCRIPTION
Related to one of the updates in #332, this removes an expired probe from fenix defaults for experiment analysis.