### PR TITLE
Triggering a rerun of the android search widget experiment

### DIFF
--- a/jetstream/android-onboarding-search-widget.toml
+++ b/jetstream/android-onboarding-search-widget.toml
@@ -17,3 +17,5 @@ experiments_column_type = "none"
 
 [experiment]
 segments = ["new_users"]
+
+


### PR DESCRIPTION
The last run was done while search results were missing due to the bug, with the recent fix we can now rerun this experiment. 