### PR TITLE
add new profile retention outcomes

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1811,7 +1811,6 @@ from_expression = """`moz-fx-data-shared-prod.telemetry.desktop_cohort_daily_ret
 submission_date_column = "submission_date"
 description = "Retention Outcomes of Desktop New Profiles Over their First 112 Days"
 friendly_name = "Desktop Cohorts Daily Retention"
-client_id_column = "client_id"
 
 [segments]
 

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1808,7 +1808,7 @@ client_id_column = "client_id"
 
 [data_sources.desktop_cohort_daily_retention]
 from_expression = """`moz-fx-data-shared-prod.telemetry.desktop_cohort_daily_retention`"""
-submission_date_column = "first_seen_date"
+submission_date_column = "submission_date"
 description = "Retention Outcomes of Desktop New Profiles Over their First 112 Days"
 friendly_name = "Desktop Cohorts Daily Retention"
 client_id_column = "client_id"

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1811,6 +1811,7 @@ from_expression = """`moz-fx-data-shared-prod.telemetry.desktop_cohort_daily_ret
 submission_date_column = "submission_date"
 description = "Retention Outcomes of Desktop New Profiles Over their First 112 Days"
 friendly_name = "Desktop Cohorts Daily Retention"
+client_id_column = "NULL"
 
 [segments]
 

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1541,30 +1541,38 @@ data_source = "metrics"
 [metrics.repeat_first_month_user]
 select_expression = "LOGICAL_OR(COALESCE(qualified_second_day, FALSE))"
 data_source = "clients_first_seen_28_days_later"
+friendly_name = "Repeat First Month Users"
+description = "Clients that were DAU at least once between their 2nd and 28th days, inclusive (first day = Day 1).
 
 [metrics.new_profile_retained_week4]
 select_expression = "LOGICAL_OR(COALESCE(qualified_week4, FALSE))"
 data_source = "clients_first_seen_28_days_later"
+friendly_name = "Week 4 Retained Users"
+description = "Clients that were DAU at least once between their 22nd and 28th days, inclusive (first day = Day 1).
 
 [metrics.cohort_clients_in_cohort]
 select_expression = "SUM(COALESCE(num_clients_in_cohort, 0))"
 data_source = "desktop_cohort_daily_retention"
 friendly_name = "Number of Clients in Daily Cohort of New Users"
+description = "The number of new profiles per day (using method from clients_first_seen_v2)"
 
 [metrics.cohort_clients_active_on_day]
 select_expression = "SUM(COALESCE(num_clients_dau_on_day, 0))"
 data_source = "desktop_cohort_daily_retention"
 friendly_name = "Number of Clients Retained on Day"
+description = "Number of Clients Retained (Qualifying as DAU) on each day"
 
 [metrics.cohort_clients_active_in_week]
 select_expression = "SUM(COALESCE(num_clients_dau_active_atleastonce_in_last_7_days, 0))"
 data_source = "desktop_cohort_daily_retention"
 friendly_name = "Number of Clients Retained in Last Week"
+description = "Number of Clients Retained (Qualifying as DAU) in previous 7 days (current day inclusive)"
 
 [metrics.cohort_clients_active_in_month]
 select_expression = "SUM(COALESCE(num_clients_dau_active_atleastonce_in_last_28_days, 0))"
 data_source = "desktop_cohort_daily_retention"
 friendly_name = "Number of Clients Retained in Last Month"
+description = "Number of Clients Retained (Qualifying as DAU) in previous 28 days (current day inclusive)"
 
 
 [dimensions]

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1568,13 +1568,13 @@ data_source = "desktop_cohort_daily_retention"
 description = "Days Since Client Was New - Used for N-Day Retention"
 
 [dimensions.cohort_retention_week]
-select_expression = IF(MOD(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 7) = 0, SAFE_DIVIDE(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 7), NULL)"
+select_expression = "IF(MOD(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 7) = 0, SAFE_DIVIDE(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 7), NULL)"
 friendly_name = "Retention Week"
 data_source = "desktop_cohort_daily_retention"
 description = "Weeks Since Client was New (Even 7 Day Periods Only)"
 
 [dimensions.cohort_retention_month]
-select_expression = IF(MOD(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 28) = 0, SAFE_DIVIDE(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 28), NULL)"
+select_expression = "IF(MOD(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 28) = 0, SAFE_DIVIDE(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 28), NULL)"
 friendly_name = "Retention Month"
 data_source = "desktop_cohort_daily_retention"
 description = "Months Since Client was New (Even 28 Day Periods Only)"

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1514,6 +1514,27 @@ data_source = "clients_first_seen_28_days_later"
 select_expression = "LOGICAL_OR(COALESCE(qualified_week4, FALSE))"
 data_source = "clients_first_seen_28_days_later"
 
+[metrics.cohort_clients_in_cohort]
+select_expression = "SUM(COALESCE(num_clients_in_cohort, 0))"
+data_source = "desktop_cohort_daily_retention"
+friendly_name = "Number of Clients in Daily Cohort of New Users"
+
+[metrics.cohort_clients_active_on_day]
+select_expression = "SUM(COALESCE(num_clients_dau_on_day, 0))"
+data_source = "desktop_cohort_daily_retention"
+friendly_name = "Number of Clients Retained on Day"
+
+[metrics.cohort_clients_active_in_week]
+select_expression = "SUM(COALESCE(num_clients_dau_active_atleastonce_in_last_7_days, 0))"
+data_source = "desktop_cohort_daily_retention"
+friendly_name = "Number of Clients Retained in Last Week"
+
+[metrics.cohort_clients_active_in_month]
+select_expression = "SUM(COALESCE(num_clients_dau_active_atleastonce_in_last_28_days, 0))"
+data_source = "desktop_cohort_daily_retention"
+friendly_name = "Number of Clients Retained in Last Month"
+
+
 [dimensions]
 
 [dimensions.os]
@@ -1540,6 +1561,23 @@ select_expression = "normalized_country_code"
 friendly_name = "Country"
 description = "Normalized Country Code"
 
+[dimensions.cohort_retention_day]
+select_expression = "DATE_DIFF(submission_date, first_seen_date, DAY)"
+friendly_name = "Retention Day"
+data_source = "desktop_cohort_daily_retention"
+description = "Days Since Client Was New - Used for N-Day Retention"
+
+[dimensions.cohort_retention_week]
+select_expression = IF(MOD(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 7) = 0, SAFE_DIVIDE(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 7), NULL)"
+friendly_name = "Retention Week"
+data_source = "desktop_cohort_daily_retention"
+description = "Weeks Since Client was New (Even 7 Day Periods Only)"
+
+[dimensions.cohort_retention_month]
+select_expression = IF(MOD(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 28) = 0, SAFE_DIVIDE(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 28), NULL)"
+friendly_name = "Retention Month"
+data_source = "desktop_cohort_daily_retention"
+description = "Months Since Client was New (Even 28 Day Periods Only)"
 
 [data_sources]
 
@@ -1766,6 +1804,13 @@ from_expression = """`moz-fx-data-shared-prod.telemetry.clients_first_seen_28_da
 submission_date_column = "first_seen_date"
 description = "Retention Outcomes of Desktop New Profiles 28 Days after being new"
 friendly_name = "Clients First Seen 28 Days Later"
+client_id_column = "client_id"
+
+[data_sources.desktop_cohort_daily_retention]
+from_expression = """`moz-fx-data-shared-prod.telemetry.desktop_cohort_daily_retention`"""
+submission_date_column = "first_seen_date"
+description = "Retention Outcomes of Desktop New Profiles Over their First 112 Days"
+friendly_name = "Desktop Cohorts Daily Retention"
 client_id_column = "client_id"
 
 [segments]

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1686,6 +1686,13 @@ client_id_column = "client_id"
 friendly_name = "Clients Daily"
 description = "Clients Daily"
 
+[data_sources.clients_last_seen]
+from_expression = "mozdata.telemetry.clients_last_seen"
+submission_date_column = "submission_date"
+client_id_column = "client_id"
+friendly_name = "Clients Last Seen"
+description = "Clients Last Seen"
+
 [data_sources.search_clients_daily]
 from_expression = "mozdata.search.search_clients_engines_sources_daily"
 experiments_column_type = "none"

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1506,6 +1506,14 @@ select_expression = """(
 )"""
 data_source = "metrics"
 
+[metrics.repeat_first_month_user]
+select_expression = LOGICAL_OR(COALESCE(qualified_second_day, FALSE))
+data_source = "clients_first_seen_28_days_later"'
+
+[metrics.new_profile_retained_week4]
+select_expression = LOGICAL_OR(COALESCE(qualified_week4, FALSE))
+data_source = "clients_first_seen_28_days_later"
+
 [dimensions]
 
 [dimensions.os]
@@ -1753,6 +1761,12 @@ description = "Pocket Tiles Visit Activity Daily"
 friendly_name = "Pocket Tiles Visit Activity Daily"
 client_id_column = "legacy_telemetry_client_id"
 
+[data_sources.clients_first_seen_28_days_later]
+from_expression = """`moz-fx-data-shared-prod.telemetry.clients_first_seen_28_days_later`"""
+submission_date_column = "first_seen_date"
+description = "Retention Outcomes of Desktop New Profiles 28 Days after being new"
+friendly_name = "Clients First Seen 28 Days Later"
+client_id_column = "client_id"
 
 [segments]
 

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1507,11 +1507,11 @@ select_expression = """(
 data_source = "metrics"
 
 [metrics.repeat_first_month_user]
-select_expression = LOGICAL_OR(COALESCE(qualified_second_day, FALSE))
-data_source = "clients_first_seen_28_days_later"'
+select_expression = "LOGICAL_OR(COALESCE(qualified_second_day, FALSE))"
+data_source = "clients_first_seen_28_days_later"
 
 [metrics.new_profile_retained_week4]
-select_expression = LOGICAL_OR(COALESCE(qualified_week4, FALSE))
+select_expression = "LOGICAL_OR(COALESCE(qualified_week4, FALSE))"
 data_source = "clients_first_seen_28_days_later"
 
 [dimensions]

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1542,13 +1542,13 @@ data_source = "metrics"
 select_expression = "LOGICAL_OR(COALESCE(qualified_second_day, FALSE))"
 data_source = "clients_first_seen_28_days_later"
 friendly_name = "Repeat First Month Users"
-description = "Clients that were DAU at least once between their 2nd and 28th days, inclusive (first day = Day 1).
+description = "Clients that were DAU at least once between their 2nd and 28th days, inclusive (first day = Day 1)."
 
 [metrics.new_profile_retained_week4]
 select_expression = "LOGICAL_OR(COALESCE(qualified_week4, FALSE))"
 data_source = "clients_first_seen_28_days_later"
 friendly_name = "Week 4 Retained Users"
-description = "Clients that were DAU at least once between their 22nd and 28th days, inclusive (first day = Day 1).
+description = "Clients that were DAU at least once between their 22nd and 28th days, inclusive (first day = Day 1)."
 
 [metrics.cohort_clients_in_cohort]
 select_expression = "SUM(COALESCE(num_clients_in_cohort, 0))"


### PR DESCRIPTION
This adds the new profile retention outcomes that we have agreed upon for the desktop funnel:

* repeat first month user: whether the client was DAU at least once sometime between their 2-28th days.
* retained week 4 user: whether the client was DAU at least once in their fourth week (days 22-28).