### PR TITLE
fix onboarding metric definition

### DIFF
--- a/jetstream/outcomes/firefox_ios/onboarding.toml
+++ b/jetstream/outcomes/firefox_ios/onboarding.toml
@@ -1,6 +1,7 @@
 friendly_name = "Onboarding"
 description = "Metrics relevant to onboarding (default browser rate)"
 
+
 [metrics.opened_as_default]
 friendly_name = "Opened as default browser"
 description = """
@@ -17,6 +18,7 @@ friendly_name = "Go To Settings clicks via onboarding card"
 description = """
     Number of clicks on Go To Settings from the default browser onboarding card
 """
-select_expression = "SUM(metrics.counter.default_browser_card_go_to_settings_pressed)"
+select_expression = "SUM(metrics.counter.default_browser_onboarding_go_to_settings_pressed)"
 data_source = "metrics"
 statistics = { bootstrap_mean = { pre_treatments = ["remove_nulls"] }, deciles = { pre_treatments = ["remove_nulls"] } }
+


### PR DESCRIPTION
These metrics are defined in the Default Browser outcome as well, and one of the definitions in Onboarding are out of date. To avoid this in the future, we should remove the duplicate definitions so they can be updated in only one place.