### PR TITLE
feat(DENG-2431): Update new_profile_activation source definition to point to the new activation table

### DIFF
--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -250,7 +250,7 @@ description = "Number of times Contile Sponsored Tiles setting is flipped."
 owner = "xluo-all@mozilla.com"
 
 [metrics.new_profile_activation]
-select_expression = "COALESCE(SUM(activated))"
+select_expression = "COUNTIF(is_activated)"
 data_source = "new_profile_activation"
 friendly_name = "New Profile Activation"
 description = "A new profile is counted as activated one week after creation if it meets the following conditions: 1) at least 3 days of use during first week 2) at least one search between days 4-7."
@@ -441,7 +441,7 @@ client_id_column = "client_id"
 submission_date_column = "submission_date"
 
 [data_sources.new_profile_activation]
-from_expression = "`moz-fx-data-shared-prod.firefox_ios.new_profile_activation`"
+from_expression = "`mozdata.firefox_ios.clients_activation`"
 experiments_column_type = "none"
 
 [data_sources.special_onboarding_events]

--- a/jetstream/ios-search-bar-placement-impact-assessment.toml
+++ b/jetstream/ios-search-bar-placement-impact-assessment.toml
@@ -6,12 +6,12 @@ overall = ["new_profile_activation"]
 
 [metrics.new_profile_activation]
 data_source = "new_profile_activation"
-select_expression = "COALESCE(SUM(activated))"
+select_expression = "COUNTIF(is_activated)"
 
 [metrics.new_profile_activation.statistics.binomial]
 
 [data_sources]
 
 [data_sources.new_profile_activation]
-from_expression = "`moz-fx-data-shared-prod.firefox_ios.new_profile_activation`"
+from_expression = "`mozdata.firefox_ios.clients_activation`"
 experiments_column_type = "none"


### PR DESCRIPTION
# feat(DENG-2431): Update new_profile_activation source definition to point to the new activation table

`firefox_ios.new_profile_activation` has been replaced by a more reliable `firefox_ios.clients_activation`. This is just a follow up to that change to make sure the correct table is used.

blocks: https://github.com/mozilla/bigquery-etl/pull/5149