### PR TITLE
[ci skip-rerun] Enable pre-enrollment bias monitoring

### DIFF
--- a/jetstream/defaults/fenix.toml
+++ b/jetstream/defaults/fenix.toml
@@ -22,6 +22,30 @@ overall = [
     "client_level_daily_active_users_v2",
 ]
 
+week_preenrollment = [
+    "active_hours",
+    "serp_ad_clicks",
+    "organic_searches",
+    "search_count",
+    "searches_with_ads",
+    "tagged_follow_on_searches",
+    "total_uri_count",
+    "days_of_use",
+    "client_level_daily_active_users_v2",
+]
+
+days28_preenrollment = [
+    "active_hours",
+    "serp_ad_clicks",
+    "organic_searches",
+    "search_count",
+    "searches_with_ads",
+    "tagged_follow_on_searches",
+    "total_uri_count",
+    "days_of_use",
+    "client_level_daily_active_users_v2",
+]
+
 [metrics.retained]
 select_expression = "COALESCE(COUNT(document_id), 0) > 0"
 data_source = "baseline"

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -30,6 +30,36 @@ overall = [
   "client_level_daily_active_users_v1",
 ]
 
+week_preenrollment = [
+  "active_hours",
+  "ad_clicks",
+  "days_of_use",
+  "organic_search_count",
+  "search_count",
+  "searches_with_ads",
+  "tagged_search_count",
+  "tagged_follow_on_search_count",
+  "uri_count",
+  "qualified_cumulative_days_of_use",
+  "is_default_browser",
+  "client_level_daily_active_users_v1",
+]
+
+days28_preenrollment = [
+  "active_hours",
+  "ad_clicks",
+  "days_of_use",
+  "organic_search_count",
+  "search_count",
+  "searches_with_ads",
+  "tagged_search_count",
+  "tagged_follow_on_search_count",
+  "uri_count",
+  "qualified_cumulative_days_of_use",
+  "is_default_browser",
+  "client_level_daily_active_users_v1",
+]
+
 
 [metrics.active_hours.statistics.bootstrap_mean]
 [metrics.active_hours.statistics.deciles]

--- a/jetstream/defaults/firefox_ios.toml
+++ b/jetstream/defaults/firefox_ios.toml
@@ -16,6 +16,22 @@ overall = [
     "client_level_daily_active_users_v2",
 ]
 
+week_preenrollment = [
+    "active_hours",
+    "days_of_use",
+    "search_count",
+    "serp_ad_clicks",
+    "client_level_daily_active_users_v2",
+]
+
+days28_preenrollment = [
+    "active_hours",
+    "days_of_use",
+    "search_count",
+    "serp_ad_clicks",
+    "client_level_daily_active_users_v2",
+]
+
 [metrics.retained]
 select_expression = "COALESCE(COUNT(document_id), 0) > 0"
 data_source = "baseline"

--- a/jetstream/defaults/focus_android.toml
+++ b/jetstream/defaults/focus_android.toml
@@ -2,6 +2,8 @@
 daily = ["retained"]
 weekly = ["retained", "active_hours", "days_of_use", "search_count", "serp_ad_clicks"]
 overall = ["active_hours", "days_of_use", "search_count", "serp_ad_clicks"]
+week_preenrollment = ["active_hours", "days_of_use", "search_count", "serp_ad_clicks"]
+days28_preenrollment = ["active_hours", "days_of_use", "search_count", "serp_ad_clicks"]
 
 [metrics.retained]
 select_expression = "COALESCE(COUNT(document_id), 0) > 0"

--- a/jetstream/defaults/focus_ios.toml
+++ b/jetstream/defaults/focus_ios.toml
@@ -2,6 +2,8 @@
 daily = ["retained"]
 weekly = ["retained", "active_hours", "days_of_use"]
 overall = ["active_hours", "days_of_use"]
+week_preenrollment = ["active_hours", "days_of_use"]
+days28_preenrollment = ["active_hours", "days_of_use"]
 
 [metrics.retained]
 select_expression = "COALESCE(COUNT(document_id), 0) > 0"


### PR DESCRIPTION
Pre-enrollment bias is a form of "randomization failure" where, due to chance, branches have observed differences in metrics from pre-experiment periods. Since during-experiment behavior for a client is highly dependent on their pre-experiment behavior, these failures can invalidate simple experiment analyses and require complex or impossible corrections.  Randomization guards against this by making such differences _unlikely_, but does not completely prevent them. For any given experiment, the odds of experiencing this failure are low, but for our growing experiment platform, we will encounter these with increasing frequency. 

Upstream dependencies for this PR have been met in: 
* https://github.com/mozilla/metric-config-parser/pull/353 
  * Adds the pre-enrollment analysis periods and allows those to be configured. 
* https://github.com/mozilla/mozanalysis/pull/197
  * Updates validators to accept pre-enrollment analysis windows
* https://github.com/mozilla/jetstream/pull/2019
  * Links configured pre-enrollment metrics to the actual analysis window definitions. 
  * [Adds an integration test](https://github.com/mozilla/jetstream/pull/2019/files#diff-b1b2630aaef8dceee5ecfc87df2b1a19c8ebc1e3b5b8afd91c0b0bd86902387c) to confirm that a pre-enrollment analysis pulls the appropriate window of underlying data
  
This PR enables calculation of currently default `overall` metrics across 2 pre-enrollment analysis periods (7 and 28 days pre-enrollment) by default. 