### PR TITLE
[ci skip-rerun] fix: update jetstream defaults to use non-deprecated search count

### DIFF
--- a/jetstream/defaults/fenix.toml
+++ b/jetstream/defaults/fenix.toml
@@ -5,7 +5,7 @@ weekly = [
     "active_hours",
     "search_count",
     "serp_ad_clicks",
-    "tagged_sap_searches",
+    "tagged_search_count",
     "total_uri_count",
     "days_of_use",
     "client_level_daily_active_users_v2",

--- a/jetstream/defaults/fenix.toml
+++ b/jetstream/defaults/fenix.toml
@@ -104,7 +104,7 @@ bootstrap_mean = {}
 
 ##
 
-[metrics.tagged_sap_searches.statistics]
+[metrics.tagged_search_count.statistics]
 deciles = {}
 bootstrap_mean = {}
 


### PR DESCRIPTION
fixes #34 

[ci skip-rerun]