### PR TITLE
Update firefox_desktop.toml

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -999,6 +999,19 @@ description = """
 Was Firefox pinned to the Windows Taskbar at any point during the interval?
 """
 
+[metrics.urlbar_last_position_click_count]
+data_source = "urlbar_events"
+select_expression = """COUNTIF(
+    event_action = 'engaged' AND 
+    is_terminal = true AND 
+    selected_position = 10
+)"""
+friendly_name = "Urlbar Last Position Click Count"
+type = "scalar"
+description = """
+Count of clicks that occur in the final position of the urlbar
+"""
+
 ########################### START OF NEW TAB METRICS ###########################
 
 [metrics.newtab_searches]

--- a/looker/definitions/firefox_desktop.toml
+++ b/looker/definitions/firefox_desktop.toml
@@ -31,7 +31,3 @@ select_expression = "SUM(urlbar_clicks)"
 data_source = "urlbar_events_daily"
 friendly_name = "Urlbar Click Count"
 description = "Number of Urlbar clicks."
-
-[metrics.urlbar_ctr.statistics.ratio]
-numerator = "urlbar_clicks"
-denominator = "urlbar_impressions"

--- a/looker/definitions/firefox_desktop.toml
+++ b/looker/definitions/firefox_desktop.toml
@@ -7,3 +7,31 @@
 [metrics.socket_crash_count_v1.statistics.ratio]
 numerator = "socket_crash_count_v1.sum"
 denominator = "socket_crash_active_hours_v1.sum"
+
+[metrics.urlbar_impressions]
+select_expression = "SUM(urlbar_impressions)"
+data_source = "urlbar_events_daily"
+friendly_name = "Urlbar Impression Count"
+description = "Number of Urlbar impressions."
+
+[metrics.urlbar_sessions]
+select_expression = "SUM(urlbar_sessions)"
+data_source = "urlbar_events_daily"
+friendly_name = "Urlbar Session Count"
+description = "Number of Urlbar sessions."
+
+[metrics.urlbar_annoyances]
+select_expression = "SUM(urlbar_annoyances)"
+data_source = "urlbar_events_daily"
+friendly_name = "Urlbar Annoyance Count"
+description = "Number of Urlbar annoyances."
+
+[metrics.urlbar_clicks]
+select_expression = "SUM(urlbar_clicks)"
+data_source = "urlbar_events_daily"
+friendly_name = "Urlbar Click Count"
+description = "Number of Urlbar clicks."
+
+[metrics.urlbar_ctr.statistics.ratio]
+numerator = "urlbar_clicks"
+denominator = "urlbar_impressions"


### PR DESCRIPTION
Adding urlbar metrics to metric-hub Looker. 

Out of curiosity, how will filtering work on these metrics in Looker? Does the generated LookML have an understanding of the originating table to allow appropriate filters to be added?