### PR TITLE
removing the enrollment table from the query

### DIFF
--- a/jetstream/ios-felt-privacy-simplified-nav-and-felt-deletion-v2.toml
+++ b/jetstream/ios-felt-privacy-simplified-nav-and-felt-deletion-v2.toml
@@ -17,19 +17,7 @@ select_expression = "exposure_date is not null"
 
 [data_sources.open_private_mode]
 from_expression = """
-    ( WITH bad_cl as (
-        SELECT client_id, count(*) cts
-        FROM `moz-fx-data-experiments.mozanalysis.enrollments_ios_felt_privacy_simplified_nav_and_felt_deletion_v2`
-        GROUP BY 1
-        HAVING cts > 1
-)
-, properly_enrolled as (
-    SELECT *
-    FROM `moz-fx-data-experiments.mozanalysis.enrollments_ios_felt_privacy_simplified_nav_and_felt_deletion_v2`
-    WHERE client_id not in (SELECT client_id FROM bad_cl)
-      AND enrollment_date >= "2024-02-27"
-)
-, exposed as (
+    (
   SELECT events.client_info.client_id
         , MIN(DATE(events.submission_timestamp )) exposure_date
   FROM `mozdata.firefox_ios.events_unnested`  AS events
@@ -41,13 +29,6 @@ from_expression = """
     AND events.normalized_channel  = 'release'
     AND  DATE(events.submission_timestamp) BETWEEN "2024-02-27" AND "2024-03-08"
     group by 1
-)
-SELECT enrolled.client_id, enrolled.branch, enrolled.enrollment_date,  exposed.exposure_date
-FROM properly_enrolled enrolled
-LEFT JOIN exposed
-ON enrolled.client_id = exposed.client_id
-AND enrolled.enrollment_date <= exposed.exposure_date
-GROUP BY 1, 2, 3, 4
     )
     """
-submission_date_column = "enrollment_date"
+submission_date_column = "exposure_date"


### PR DESCRIPTION
The enrollment table caused the pipeline to break and so I am removing it at the expense of being able to filter out clients that were enrolled in both control and test branches. I am comfortable with it because they are very small proportion of the exposed population