### PR TITLE
Update all metrics on ios health to use ratios

### DIFF
--- a/opmon/firefox-ios-health.toml
+++ b/opmon/firefox-ios-health.toml
@@ -12,6 +12,8 @@ data_source = "baseline_v2"
 monitor_entire_population = true
 channel = "release"
 
+[metrics.total_baseline_pings.statistics.sum]
+
 [metrics.large_file_write.statistics.total_ratio]
 denominator_metric = "total_baseline_pings"
 [metrics.cpu_exception.statistics.total_ratio]

--- a/opmon/firefox-ios-health.toml
+++ b/opmon/firefox-ios-health.toml
@@ -12,14 +12,10 @@ data_source = "baseline_v2"
 monitor_entire_population = true
 channel = "release"
 
-[metrics.dirty_startup.statistics]
-sum = {}
-[metrics.large_file_write.statistics]
-sum = {}
-[metrics.cpu_exception.statistics]
-sum = {}
-[metrics.total_baseline_pings.statistics.sum]
-
+[metrics.large_file_write.statistics.total_ratio]
+denominator_metric = "total_baseline_pings"
+[metrics.cpu_exception.statistics.total_ratio]
+denominator_metric = "total_baseline_pings"
 [metrics.dirty_startup.statistics.total_ratio]
 denominator_metric = "total_baseline_pings"
 


### PR DESCRIPTION
Updated the cpu exception and large file write metrics to use ratios instead.

Removed the total baseline pings and dirty_startup sum visualizations, there should just be 3 charts on the dashboard now. Please let me know if that is not the correct way to achieve that change. 