### PR TITLE
Add ios beta health dashboard in opmon

### DIFF
--- a/opmon/firefox-ios-beta-health.toml
+++ b/opmon/firefox-ios-beta-health.toml
@@ -1,0 +1,58 @@
+[project]
+
+name = "Firefox iOS Beta Health"
+platform = "firefox_ios"
+xaxis = "submission_date"
+start_date = "2023-01-01"
+skip_default_metrics = true
+metrics = ['dirty_startup', 'large_file_write', 'hang_exception', 'cpu_exception', 'total_baseline_pings']
+
+[project.population]
+data_source = "baseline_v2"
+monitor_entire_population = true
+channel = "beta"
+
+[metrics.total_baseline_pings.statistics.sum]
+
+[metrics.large_file_write.statistics.total_ratio]
+denominator_metric = "total_baseline_pings"
+[metrics.hang_exception.statistics.total_ratio]
+denominator_metric = "total_baseline_pings"
+[metrics.cpu_exception.statistics.total_ratio]
+denominator_metric = "total_baseline_pings"
+[metrics.dirty_startup.statistics.total_ratio]
+denominator_metric = "total_baseline_pings"
+
+[metrics.dirty_startup]
+select_expression = """COALESCE(COUNTIF(ping_info.reason = "dirty_startup"), 0)"""
+data_source = "baseline_v2"
+friendly_name = "Dirty startup"
+description = "The amount of times baseline ping was sent due to dirty_startup"
+owner = "efilho@mozilla.com"
+
+[metrics.large_file_write]
+select_expression = """COALESCE(COUNTIF(event.name = "large_file_write"), 0)"""
+data_source = "events"
+friendly_name = "Large file write"
+description = "The amount of times a very large file was written to disk"
+owner = "efilho@mozilla.com"
+
+[metrics.hang_exception]
+select_expression = """COALESCE(COUNTIF(event.name = "hang_exception"), 0)"""
+data_source = "events"
+friendly_name = "Hang exception"
+description = "The amount of times the main thread hangs"
+owner = "omitchell@mozilla.com"
+
+[metrics.cpu_exception]
+select_expression = """COALESCE(COUNTIF(event.name = "cpu_exception"), 0)"""
+data_source = "events"
+friendly_name = "CPU exception"
+description = "The amount of times a CPU exception is thrown by the OS"
+owner = "omitchell@mozilla.com"
+
+[metrics.total_baseline_pings]
+select_expression = "COUNT(*)"
+data_source = "baseline_v2"
+friendly_name = "Total number of baseline pings"
+description = "Total number of baseline pings sent by clients"


### PR DESCRIPTION
Adding a copy of the firefox-ios-health dashboard to observe the beta channel only.