### PR TITLE
Create ios-splash-screen-timing-test-release.toml

### DIFF
--- a/jetstream/ios-splash-screen-timing-test-release.toml
+++ b/jetstream/ios-splash-screen-timing-test-release.toml
@@ -1,0 +1,3 @@
+[experiment]
+
+enrollment_period = 53


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DS-3658 adjusting enrollment end date to june 11