### PR TITLE
[ci skip-rerun] Revert "[ci skip-rerun] Enable linear-model based mean inferences"

### DIFF
--- a/jetstream/defaults/fenix.toml
+++ b/jetstream/defaults/fenix.toml
@@ -59,21 +59,12 @@ binomial = {}
 deciles = {}
 bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
-[metrics.days_of_use.statistics.linear_model_mean]
-drop_highest = 0.0
-[metrics.days_of_use.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
-
-
 
 ##
 
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.active_hours.statistics.linear_model_mean]
-[metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
@@ -84,9 +75,6 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.serp_ad_clicks.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.serp_ad_clicks.statistics.linear_model_mean]
-[metrics.serp_ad_clicks.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
@@ -97,19 +85,12 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.organic_searches.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.organic_searches.statistics.linear_model_mean]
-[metrics.organic_searches.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
-
 
 ##
 
 [metrics.search_count.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.search_count.statistics.linear_model_mean]
-[metrics.search_count.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
@@ -120,19 +101,12 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.searches_with_ads.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.searches_with_ads.statistics.linear_model_mean]
-[metrics.searches_with_ads.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
-
 
 ##
 
 [metrics.tagged_search_count.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.tagged_search_count.statistics.linear_model_mean]
-[metrics.tagged_search_count.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
@@ -143,9 +117,6 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.tagged_follow_on_searches.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.tagged_follow_on_searches.statistics.linear_model_mean]
-[metrics.tagged_follow_on_searches.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
@@ -156,9 +127,6 @@ data_source = "metrics"
 [metrics.total_uri_count.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.total_uri_count.statistics.linear_model_mean]
-[metrics.total_uri_count.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 [metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]
 pre_treatments = ['normalize_over_analysis_period']

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -60,92 +60,46 @@ preenrollment_days28 = [
   "client_level_daily_active_users_v1",
 ]
 
+
 [metrics.active_hours.statistics.bootstrap_mean]
-[metrics.active_hours.statistics.linear_model_mean]
-[metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 [metrics.active_hours.statistics.deciles]
 
-
 [metrics.ad_clicks.statistics.bootstrap_mean]
-[metrics.ad_clicks.statistics.linear_model_mean]
-[metrics.ad_clicks.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 [metrics.ad_clicks.statistics.deciles]
 
-
 [metrics.days_of_use.statistics.bootstrap_mean]
-drop_highest = 0.0
-[metrics.days_of_use.statistics.linear_model_mean]
-drop_highest = 0.0
-[metrics.days_of_use.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
+drop_highest = 0
+
 [metrics.days_of_use.statistics.deciles]
 [metrics.days_of_use.statistics.empirical_cdf]
 
-
 [metrics.organic_search_count.statistics.bootstrap_mean]
-[metrics.organic_search_count.statistics.linear_model_mean]
-[metrics.organic_search_count.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 [metrics.organic_search_count.statistics.deciles]
-
 
 [metrics.retained.statistics.binomial]
 
-
 [metrics.uri_count.statistics.bootstrap_mean]
-[metrics.uri_count.statistics.linear_model_mean]
-[metrics.uri_count.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 [metrics.uri_count.statistics.deciles]
 
-
 [metrics.search_count.statistics.bootstrap_mean]
-[metrics.search_count.statistics.linear_model_mean]
-[metrics.search_count.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 [metrics.search_count.statistics.deciles]
 
-
 [metrics.searches_with_ads.statistics.bootstrap_mean]
-[metrics.searches_with_ads.statistics.linear_model_mean]
-[metrics.searches_with_ads.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 [metrics.searches_with_ads.statistics.deciles]
 
-
 [metrics.tagged_search_count.statistics.bootstrap_mean]
-[metrics.tagged_search_count.statistics.linear_model_mean]
-[metrics.tagged_search_count.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 [metrics.tagged_search_count.statistics.deciles]
 
-
 [metrics.tagged_follow_on_search_count.statistics.bootstrap_mean]
-[metrics.tagged_follow_on_search_count.statistics.linear_model_mean]
-[metrics.tagged_follow_on_search_count.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 [metrics.tagged_follow_on_search_count.statistics.deciles]
-
 
 [metrics.unenroll.statistics.binomial]
 
-
 [metrics.qualified_cumulative_days_of_use.statistics.bootstrap_mean]
-drop_highest = 0.0
-[metrics.qualified_cumulative_days_of_use.statistics.linear_model_mean]
-drop_highest = 0.0
-[metrics.qualified_cumulative_days_of_use.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 [metrics.qualified_cumulative_days_of_use.statistics.deciles]
 
-
 [metrics.is_default_browser.statistics.binomial]
-
-
 [metrics.is_pinned.statistics.binomial]
-
 
 [metrics.client_level_daily_active_users_v1.statistics.per_client_dau_impact]
 pre_treatments = ['normalize_over_analysis_period']

--- a/jetstream/defaults/firefox_ios.toml
+++ b/jetstream/defaults/firefox_ios.toml
@@ -44,9 +44,6 @@ binomial = {}
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.active_hours.statistics.linear_model_mean]
-[metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
@@ -54,19 +51,12 @@ period = "preenrollment_week"
 deciles = {}
 bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
-[metrics.days_of_use.statistics.linear_model_mean]
-drop_highest = 0.0
-[metrics.days_of_use.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
 [metrics.search_count.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.search_count.statistics.linear_model_mean]
-[metrics.search_count.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
@@ -79,9 +69,6 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.serp_ad_clicks.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.serp_ad_clicks.statistics.linear_model_mean]
-[metrics.serp_ad_clicks.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 [metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]
 pre_treatments = ['normalize_over_analysis_period']

--- a/jetstream/defaults/focus_android.toml
+++ b/jetstream/defaults/focus_android.toml
@@ -33,9 +33,6 @@ binomial = {}
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.active_hours.statistics.linear_model_mean]
-[metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
@@ -43,19 +40,12 @@ period = "preenrollment_week"
 deciles = {}
 bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
-[metrics.days_of_use.statistics.linear_model_mean]
-drop_highest = 0.0
-[metrics.days_of_use.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
 [metrics.search_count.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.search_count.statistics.linear_model_mean]
-[metrics.search_count.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
@@ -68,9 +58,6 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.serp_ad_clicks.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.serp_ad_clicks.statistics.linear_model_mean]
-[metrics.serp_ad_clicks.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 ##
 
 [metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]

--- a/jetstream/defaults/focus_ios.toml
+++ b/jetstream/defaults/focus_ios.toml
@@ -17,9 +17,6 @@ binomial = {}
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
-[metrics.active_hours.statistics.linear_model_mean]
-[metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 ##
 
@@ -27,10 +24,6 @@ period = "preenrollment_week"
 deciles = {}
 bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
-[metrics.days_of_use.statistics.linear_model_mean]
-drop_highest = 0.0
-[metrics.days_of_use.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
 
 [metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]
 pre_treatments = ['normalize_over_analysis_period']


### PR DESCRIPTION
Reverts mozilla/metric-hub#491