### PR TITLE
[ci skip-rerun] re-enable covariate adjustment

### DIFF
--- a/jetstream/defaults/fenix.toml
+++ b/jetstream/defaults/fenix.toml
@@ -59,12 +59,21 @@ binomial = {}
 deciles = {}
 bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
+[metrics.days_of_use.statistics.linear_model_mean]
+drop_highest = 0.0
+[metrics.days_of_use.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
+
+
 
 ##
 
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.active_hours.statistics.linear_model_mean]
+[metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -75,6 +84,9 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.serp_ad_clicks.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.serp_ad_clicks.statistics.linear_model_mean]
+[metrics.serp_ad_clicks.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -85,12 +97,19 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.organic_searches.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.organic_searches.statistics.linear_model_mean]
+[metrics.organic_searches.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
+
 
 ##
 
 [metrics.search_count.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.search_count.statistics.linear_model_mean]
+[metrics.search_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -101,12 +120,19 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.searches_with_ads.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.searches_with_ads.statistics.linear_model_mean]
+[metrics.searches_with_ads.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
+
 
 ##
 
 [metrics.tagged_search_count.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.tagged_search_count.statistics.linear_model_mean]
+[metrics.tagged_search_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -117,6 +143,9 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.tagged_follow_on_searches.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.tagged_follow_on_searches.statistics.linear_model_mean]
+[metrics.tagged_follow_on_searches.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -127,6 +156,9 @@ data_source = "metrics"
 [metrics.total_uri_count.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.total_uri_count.statistics.linear_model_mean]
+[metrics.total_uri_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 [metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]
 pre_treatments = ['normalize_over_analysis_period']

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -60,46 +60,92 @@ preenrollment_days28 = [
   "client_level_daily_active_users_v1",
 ]
 
-
 [metrics.active_hours.statistics.bootstrap_mean]
+[metrics.active_hours.statistics.linear_model_mean]
+[metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 [metrics.active_hours.statistics.deciles]
 
+
 [metrics.ad_clicks.statistics.bootstrap_mean]
+[metrics.ad_clicks.statistics.linear_model_mean]
+[metrics.ad_clicks.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 [metrics.ad_clicks.statistics.deciles]
 
-[metrics.days_of_use.statistics.bootstrap_mean]
-drop_highest = 0
 
+[metrics.days_of_use.statistics.bootstrap_mean]
+drop_highest = 0.0
+[metrics.days_of_use.statistics.linear_model_mean]
+drop_highest = 0.0
+[metrics.days_of_use.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 [metrics.days_of_use.statistics.deciles]
 [metrics.days_of_use.statistics.empirical_cdf]
 
+
 [metrics.organic_search_count.statistics.bootstrap_mean]
+[metrics.organic_search_count.statistics.linear_model_mean]
+[metrics.organic_search_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 [metrics.organic_search_count.statistics.deciles]
+
 
 [metrics.retained.statistics.binomial]
 
+
 [metrics.uri_count.statistics.bootstrap_mean]
+[metrics.uri_count.statistics.linear_model_mean]
+[metrics.uri_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 [metrics.uri_count.statistics.deciles]
 
+
 [metrics.search_count.statistics.bootstrap_mean]
+[metrics.search_count.statistics.linear_model_mean]
+[metrics.search_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 [metrics.search_count.statistics.deciles]
 
+
 [metrics.searches_with_ads.statistics.bootstrap_mean]
+[metrics.searches_with_ads.statistics.linear_model_mean]
+[metrics.searches_with_ads.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 [metrics.searches_with_ads.statistics.deciles]
 
+
 [metrics.tagged_search_count.statistics.bootstrap_mean]
+[metrics.tagged_search_count.statistics.linear_model_mean]
+[metrics.tagged_search_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 [metrics.tagged_search_count.statistics.deciles]
 
+
 [metrics.tagged_follow_on_search_count.statistics.bootstrap_mean]
+[metrics.tagged_follow_on_search_count.statistics.linear_model_mean]
+[metrics.tagged_follow_on_search_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 [metrics.tagged_follow_on_search_count.statistics.deciles]
+
 
 [metrics.unenroll.statistics.binomial]
 
+
 [metrics.qualified_cumulative_days_of_use.statistics.bootstrap_mean]
+drop_highest = 0.0
+[metrics.qualified_cumulative_days_of_use.statistics.linear_model_mean]
+drop_highest = 0.0
+[metrics.qualified_cumulative_days_of_use.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 [metrics.qualified_cumulative_days_of_use.statistics.deciles]
 
+
 [metrics.is_default_browser.statistics.binomial]
+
+
 [metrics.is_pinned.statistics.binomial]
+
 
 [metrics.client_level_daily_active_users_v1.statistics.per_client_dau_impact]
 pre_treatments = ['normalize_over_analysis_period']

--- a/jetstream/defaults/firefox_ios.toml
+++ b/jetstream/defaults/firefox_ios.toml
@@ -44,6 +44,9 @@ binomial = {}
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.active_hours.statistics.linear_model_mean]
+[metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -51,12 +54,19 @@ bootstrap_mean = {}
 deciles = {}
 bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
+[metrics.days_of_use.statistics.linear_model_mean]
+drop_highest = 0.0
+[metrics.days_of_use.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
 [metrics.search_count.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.search_count.statistics.linear_model_mean]
+[metrics.search_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -69,6 +79,9 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.serp_ad_clicks.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.serp_ad_clicks.statistics.linear_model_mean]
+[metrics.serp_ad_clicks.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 [metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]
 pre_treatments = ['normalize_over_analysis_period']

--- a/jetstream/defaults/focus_android.toml
+++ b/jetstream/defaults/focus_android.toml
@@ -33,6 +33,9 @@ binomial = {}
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.active_hours.statistics.linear_model_mean]
+[metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -40,12 +43,19 @@ bootstrap_mean = {}
 deciles = {}
 bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
+[metrics.days_of_use.statistics.linear_model_mean]
+drop_highest = 0.0
+[metrics.days_of_use.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
 [metrics.search_count.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.search_count.statistics.linear_model_mean]
+[metrics.search_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -58,6 +68,9 @@ data_source = "mobile_search_clients_engines_sources_daily"
 [metrics.serp_ad_clicks.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.serp_ad_clicks.statistics.linear_model_mean]
+[metrics.serp_ad_clicks.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 ##
 
 [metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]

--- a/jetstream/defaults/focus_ios.toml
+++ b/jetstream/defaults/focus_ios.toml
@@ -17,6 +17,9 @@ binomial = {}
 [metrics.active_hours.statistics]
 deciles = {}
 bootstrap_mean = {}
+[metrics.active_hours.statistics.linear_model_mean]
+[metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -24,6 +27,10 @@ bootstrap_mean = {}
 deciles = {}
 bootstrap_mean = { drop_highest = 0 }
 empirical_cdf = {}
+[metrics.days_of_use.statistics.linear_model_mean]
+drop_highest = 0.0
+[metrics.days_of_use.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
 
 [metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]
 pre_treatments = ['normalize_over_analysis_period']


### PR DESCRIPTION
Reverts mozilla/metric-hub#498. 

When we previously pushed this, we encountered some errors. Those were largely fixed in https://github.com/mozilla/mozanalysis/pull/266. However, when an experiment is rerun, there is now a race condition between the analysis periods. Later analysis periods (e.g., week & overall) will depend on prior analysis periods (i.e., preenrollment_week) which may or may not have completed. In the case where covariate adjustment using preenrollment_week was specified but preenrollment_week is not available, we will now fall back (https://github.com/mozilla/mozanalysis/pull/268) to unadjusted inferences and emit a warning.  Since these improvements are now in Jetstream (https://github.com/mozilla/jetstream/pull/2085), we can attempt to reenable the inferences. 

Once the Jetstream rearchitecture is complete, we expect to be able to specify dependencies between periods and avoid the need to fallback. 