### PR TITLE
added pdf handler metrics and outcome

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1667,6 +1667,27 @@ select_expression = """(
 )"""
 data_source = "metrics"
 
+[metrics.pdf_invoked_to_handle]
+select_expression = "COALESCE(SUM(mozfun.map.get_key(payload.processes.parent.keyed_scalars.os_environment_invoked_to_handle, '.pdf')), 0)"
+data_source = "main"
+friendly_name = "PDF Invoked to Handle"
+description = "Firefox was invoked (i.e., was already running and was not launched) to handle a pdf file"
+
+[metrics.pdf_launched_to_handle]
+select_expression = "COALESCE(SUM(mozfun.map.get_key(payload.processes.parent.keyed_scalars.os_environment_launched_to_handle, '.pdf')), 0)"
+data_source = "main"
+friendly_name = "PDF Launched to Handle"
+description = "Firefox was launched afresh (i.e., was not already running) to handle a pdf file"
+
+[metrics.pdf_launched_or_invoked_to_handle]
+select_expression = """
+    COALESCE(SUM(mozfun.map.get_key(payload.processes.parent.keyed_scalars.os_environment_invoked_to_handle, '.pdf')), 0) + 
+    COALESCE(SUM(mozfun.map.get_key(payload.processes.parent.keyed_scalars.os_environment_launched_to_handle, '.pdf')), 0)
+"""
+data_source = "main"
+friendly_name = "PDF Launched or Invoked"
+description = "Firefox was launched or invoked to handle a pdf file"
+
 [metrics.repeat_first_month_user]
 select_expression = "LOGICAL_OR(COALESCE(qualified_second_day, FALSE))"
 data_source = "clients_first_seen_28_days_later"

--- a/jetstream/outcomes/firefox_desktop/pdf_handler.toml
+++ b/jetstream/outcomes/firefox_desktop/pdf_handler.toml
@@ -1,0 +1,7 @@
+friendly_name = "PDF handler"
+description = "Measures if Firefox was launched or invoked to handle a PDF file"
+
+[metrics]
+[metrics.pdf_launched_or_invoked_to_handle.statistics.binomial]
+[metrics.pdf_invoked_to_handle.statistics.binomial]
+[metrics.pdf_launched_to_handle.statistics.binomial]


### PR DESCRIPTION
added metrics for when firefox was invoked or launched and created a new outcome with those metrics.  this work completes the second request in this [ticket](https://mozilla-hub.atlassian.net/browse/DS-3669).