### PR TITLE
Fix klar active_users data_sources

### DIFF
--- a/definitions/klar_android.toml
+++ b/definitions/klar_android.toml
@@ -273,7 +273,7 @@ description = "Client-level table that indicates whether a client meets 'active 
 from_expression = """(
     SELECT *
      FROM `moz-fx-data-shared-prod.klar_android.active_users`
-    WHERE is_mobile
+    WHERE app_name = "Klar Android"
 )"""
 submission_date_column = "submission_date"
 client_id_column = "client_id"

--- a/definitions/klar_ios.toml
+++ b/definitions/klar_ios.toml
@@ -277,7 +277,7 @@ description = "Client-level table that indicates whether a client meets 'active 
 from_expression = """(
     SELECT *
      FROM `moz-fx-data-shared-prod.klar_ios.active_users`
-    WHERE is_mobile
+    WHERE app_name = "Klar iOS"
 )"""
 submission_date_column = "submission_date"
 client_id_column = "client_id"


### PR DESCRIPTION
The `active_users_view` for Klar products currently has the filter `is_mobile`. However, Klar is not included as a mobile KPI product, so `is_mobile` will always be `false`.

This PR changes the filter to "Klar iOS" or "Klar Android", which will filter only on valid sources of Klar client_ids (excluding BrowserStack, for example).