### PR TITLE
Add sponsored impressions in jetstream metric definition

### DIFF
--- a/jetstream/definitions/firefox_desktop.toml
+++ b/jetstream/definitions/firefox_desktop.toml
@@ -50,6 +50,7 @@
 
 [metrics.pocket_rec_clicks.statistics.bootstrap_mean]
 
+[metrics.sponsored_pocket_impressions.statistics.bootstrap_mean]
 
 [metrics.pocket_spoc_clicks.statistics.bootstrap_mean]
 


### PR DESCRIPTION
Adding sponsored impressions as a metric in jetstream definition for an upcoming [experiment](https://mozilla-hub.atlassian.net/browse/HNT-104) on New Tab. 