### PR TITLE
DS-3616 Update Metric-Hub DAU and KPI metrics

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -295,7 +295,6 @@ description = """
 
     For questions, please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
-category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = true
 
@@ -311,12 +310,10 @@ description = """
     Whenever possible, this is the preferred DAU reporting definition to use for Desktop.
     This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`,
     it is similar to a "days of use" metric, and not DAU.
-
-    For more information, refer to [the DAU description in Confluence](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/314704478/Daily+Active+Users+DAU+Metric).
-    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
+level = "silver"
 
 [metrics.client_level_daily_active_users_v1]
 data_source = "clients_daily"
@@ -379,19 +376,17 @@ select_expression = "SUM(IF(FORMAT_DATE('%m-%d', submission_date) BETWEEN '11-18
 type = "scalar"
 friendly_name = "Firefox Desktop DAU KPI"
 description = """
-    The average [Firefox Desktop DAU](https://mozilla.github.io/metric-hub/metrics/firefox_desktop/#daily_active_users_v2)
+    The average [Firefox Desktop DAU](https://mozilla.acryl.io/glossaryTerm/urn:li:glossaryTerm:Metric%20Hub.firefox_desktop.daily_active_users_v2/Documentation?is_lineage_mode=false)
     in the 28-day period ending on December 15th. This is the official Desktop DAU KPI reporting definition. The logic is
     [detailed on the Confluence DAU page](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/314704478/Daily+Active+Users+DAU+Metric)
     and is automatically cross-checked, actively monitored, and change controlled.
     To reconstruct the annual Desktop DAU KPI, this metric needs to be aggregated by
     `EXTRACT(YEAR FROM submission_date)`.
-
-    For more information, refer to [the DAU description in Confluence](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/314704478/Daily+Active+Users+DAU+Metric).
-    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
 category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
+level = "silver"
 
 
 [metrics.disable_pocket_clicks]
@@ -1788,6 +1783,7 @@ description = """
 """
 owner = ["vsabino@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
+level = "bronze"
 
 [metrics.retention_rate_v1]
 friendly_name = "Firefox Desktop Retention Rate"
@@ -1799,6 +1795,7 @@ description = """
 """
 owner = ["vsabino@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
+level = "bronze"
 
 [metrics.new_profile_retention_rate_v1]
 friendly_name = "Firefox Desktop New Proflie Retention Rate"
@@ -1812,6 +1809,7 @@ description = """
 """
 owner = ["vsabino@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
+level = "bronze"
 
 [dimensions]
 

--- a/definitions/multi_product.toml
+++ b/definitions/multi_product.toml
@@ -12,12 +12,10 @@ description = """
     Whenever possible, this is the preferred DAU reporting definition to use for Mobile products.
     This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`,
     it is similar to a "days of use" metric, and not DAU.
-    
-    For more information, refer to [the DAU description in Confluence](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/314704478/Daily+Active+Users+DAU+Metric).
-    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
 """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
+level = "silver"
 
 [metrics.mobile_dau_kpi_v1]
 data_source = "mobile_active_users_aggregates_view"
@@ -25,19 +23,17 @@ select_expression = "SUM(IF(FORMAT_DATE('%m-%d', submission_date) BETWEEN '11-18
 type = "scalar"
 friendly_name = "Mobile DAU KPI"
 description = """
-    The average [Mobile DAU](https://mozilla.github.io/metric-hub/metrics/multi_product/#mobile_daily_active_users) in the 28-day period ending on December 15th. This is the official
-    Mobile DAU KPI reporting definition. The logic is
+    The average [Mobile DAU](https://mozilla.acryl.io/glossaryTerm/urn:li:glossaryTerm:Metric%20Hub.multi_product.mobile_daily_active_users_v1/Documentation?is_lineage_mode=false)
+    in the 28-day period ending on December 15th. This is the official Mobile DAU KPI reporting definition. The logic is
     [detailed on the Confluence DAU page](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/314704478/Daily+Active+Users+DAU+Metric)
     and is automatically cross-checked, actively monitored, and change controlled.
     To reconstruct the annual Mobile DAU KPI, this metric needs to be aggregated by
-    `EXTRACT(YEAR FROM submission_date)`.  
-
-    For more information, refer to [the DAU description in Confluence](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/314704478/Daily+Active+Users+DAU+Metric).
-    For questions please contact bochocki@mozilla.com or firefox-kpi@mozilla.com.
+    `EXTRACT(YEAR FROM submission_date)`.
 """
 category = "KPI"
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
+level = "silver"
 
 [metrics.mobile_engagement_rate_v1]
 friendly_name = "Mobile Engagement Rate"
@@ -52,6 +48,7 @@ description = """
 """
 owner = ["vsabino@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
+level = "bronze"
 
 [metrics.mobile_retention_rate_v1]
 friendly_name = "Mobile Retention Rate"
@@ -63,6 +60,7 @@ description = """
 """
 owner = ["vsabino@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
+level = "bronze"
 
 [metrics.mobile_new_profile_retention_rate_v1]
 friendly_name = "Mobile New Proflie Retention Rate"
@@ -76,6 +74,7 @@ description = """
 """
 owner = ["vsabino@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
+level = "bronze"
 
 ##### search revenue forecasting metrics
 


### PR DESCRIPTION
For the 10 metrics in the [Metric Levels Taxonomy](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/620494911/Metrics+Inventory) this PR:

- updates their descriptions (removes email addresses, empty lines, broken links, and non-acryl/datahub
- adds their current taxonomy level
- makes sure only the current, non-deprecated KPIs are tagged as KPIs