### PR TITLE
feat: add support for randomization_unit and analysis_unit in experiment config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode

--- a/lib/metric-config-parser/README.md
+++ b/lib/metric-config-parser/README.md
@@ -6,3 +6,17 @@ This package parses configuration files that are compatible with [jetstream](htt
 
 `pip install mozilla-metric-config-parser`
 
+
+## Testing
+
+### Pytest
+```
+pytest --black --ignore=metric_config_parser/tests/integration/
+```
+
+### Linting and formatting
+```
+flake8 metric_config_parser
+isort --check metric_config_parser
+mypy metric_config_parser
+```

--- a/lib/metric-config-parser/metric_config_parser/tests/conftest.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/conftest.py
@@ -7,7 +7,7 @@ import pytz
 from git import Repo
 
 from metric_config_parser.config import ConfigCollection
-from metric_config_parser.experiment import Branch, BucketConfig, Experiment
+from metric_config_parser.experiment import Branch, Experiment
 
 TEST_DIR = Path(__file__).parent
 
@@ -27,13 +27,6 @@ def experiments():
             reference_branch="b",
             is_high_population=False,
             app_name="firefox_desktop",
-            bucket_config=BucketConfig(
-                randomization_unit="group_id",
-                namespace="testing",
-                start=0,
-                count=10,
-                total=100,
-            ),
         ),
         Experiment(
             experimenter_slug="test_slug",

--- a/lib/metric-config-parser/metric_config_parser/tests/conftest.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/conftest.py
@@ -7,7 +7,7 @@ import pytz
 from git import Repo
 
 from metric_config_parser.config import ConfigCollection
-from metric_config_parser.experiment import Branch, Experiment
+from metric_config_parser.experiment import Branch, BucketConfig, Experiment
 
 TEST_DIR = Path(__file__).parent
 
@@ -27,6 +27,13 @@ def experiments():
             reference_branch="b",
             is_high_population=False,
             app_name="firefox_desktop",
+            bucket_config=BucketConfig(
+                randomization_unit="group_id",
+                namespace="testing",
+                start=0,
+                count=10,
+                total=100,
+            ),
         ),
         Experiment(
             experimenter_slug="test_slug",

--- a/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
@@ -6,7 +6,9 @@ import pytest
 import pytz
 import toml
 from cattrs.errors import ClassValidationError
+from mozilla_nimbus_schemas import RandomizationUnit
 
+from metric_config_parser import AnalysisUnit
 from metric_config_parser.analysis import AnalysisSpec
 from metric_config_parser.errors import NoEndDateException
 from metric_config_parser.metric import AnalysisPeriod
@@ -375,6 +377,30 @@ class TestExperimentConf:
         spec = AnalysisSpec.from_dict(toml.loads(conf))
         cfg = spec.resolve(experiments[7], config_collection)
         assert cfg.experiment.sample_size is None
+
+    def test_analysis_unit_default(self, experiments, config_collection):
+        conf = dedent(
+            """
+            [experiment]
+            enrollment_period = 7
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(conf))
+        cfg = spec.resolve(experiments[1], config_collection)
+        assert cfg.experiment.randomization_unit is None
+        assert cfg.experiment.analysis_unit == AnalysisUnit.CLIENT
+
+    def test_analysis_unit_configured(self, experiments, config_collection):
+        conf = dedent(
+            """
+            [experiment]
+            enrollment_period = 7
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(conf))
+        cfg = spec.resolve(experiments[0], config_collection)
+        assert cfg.experiment.randomization_unit == RandomizationUnit.GROUP_ID
+        assert cfg.experiment.analysis_unit == AnalysisUnit.PROFILE_GROUP
 
 
 class TestDefaultConfiguration:

--- a/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
@@ -1,7 +1,6 @@
 import datetime as dt
 from pathlib import Path
 from textwrap import dedent
-from unittest import TestCase
 
 import pytest
 import pytz

--- a/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
@@ -1,6 +1,7 @@
 import datetime as dt
 from pathlib import Path
 from textwrap import dedent
+from unittest import TestCase
 
 import pytest
 import pytz
@@ -11,6 +12,7 @@ from mozilla_nimbus_schemas import RandomizationUnit
 from metric_config_parser import AnalysisUnit
 from metric_config_parser.analysis import AnalysisSpec
 from metric_config_parser.errors import NoEndDateException
+from metric_config_parser.experiment import Branch, BucketConfig, Experiment
 from metric_config_parser.metric import AnalysisPeriod
 from metric_config_parser.segment import Segment
 
@@ -390,17 +392,81 @@ class TestExperimentConf:
         assert cfg.experiment.randomization_unit is None
         assert cfg.experiment.analysis_unit == AnalysisUnit.CLIENT
 
-    def test_analysis_unit_configured(self, experiments, config_collection):
+    @pytest.mark.parametrize(
+        "randomization_unit", [ru for ru in RandomizationUnit.__members__.values()]
+    )
+    def test_analysis_unit_configured(self, config_collection, randomization_unit):
         conf = dedent(
             """
             [experiment]
             enrollment_period = 7
             """
         )
+        exp = Experiment(
+            experimenter_slug="test_slug",
+            type="pref",
+            status="Complete",
+            start_date=dt.datetime(2019, 12, 1, tzinfo=pytz.utc),
+            end_date=dt.datetime(2020, 3, 1, tzinfo=pytz.utc),
+            proposed_enrollment=7,
+            branches=[Branch(slug="a", ratio=1), Branch(slug="b", ratio=1)],
+            normandy_slug="normandy-test-slug",
+            reference_branch="b",
+            is_high_population=False,
+            app_name="firefox_desktop",
+            bucket_config=BucketConfig(
+                randomization_unit=randomization_unit,
+                namespace="testing",
+                start=0,
+                count=10,
+                total=100,
+            ),
+        )
         spec = AnalysisSpec.from_dict(toml.loads(conf))
-        cfg = spec.resolve(experiments[0], config_collection)
-        assert cfg.experiment.randomization_unit == RandomizationUnit.GROUP_ID
-        assert cfg.experiment.analysis_unit == AnalysisUnit.PROFILE_GROUP
+        cfg = spec.resolve(exp, config_collection)
+        expected_randomization_unit = RandomizationUnit(randomization_unit)
+        expected_analysis_unit = (
+            AnalysisUnit.PROFILE_GROUP
+            if expected_randomization_unit == RandomizationUnit.GROUP_ID
+            else AnalysisUnit.CLIENT
+        )
+        assert cfg.experiment.randomization_unit == expected_randomization_unit
+        assert cfg.experiment.analysis_unit == expected_analysis_unit
+
+    @pytest.mark.parametrize("randomization_unit", [None, "invalid_id"])
+    def test_analysis_unit_invalid(self, config_collection, randomization_unit):
+        conf = dedent(
+            """
+            [experiment]
+            enrollment_period = 7
+            """
+        )
+        exp = Experiment(
+            experimenter_slug="test_slug",
+            type="pref",
+            status="Complete",
+            start_date=dt.datetime(2019, 12, 1, tzinfo=pytz.utc),
+            end_date=dt.datetime(2020, 3, 1, tzinfo=pytz.utc),
+            proposed_enrollment=7,
+            branches=[Branch(slug="a", ratio=1), Branch(slug="b", ratio=1)],
+            normandy_slug="normandy-test-slug",
+            reference_branch="b",
+            is_high_population=False,
+            app_name="firefox_desktop",
+            bucket_config=BucketConfig(
+                randomization_unit=randomization_unit,
+                namespace="testing",
+                start=0,
+                count=10,
+                total=100,
+            ),
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(conf))
+        cfg = spec.resolve(exp, config_collection)
+        with pytest.raises(ValueError):
+            cfg.experiment.randomization_unit
+        with pytest.raises(ValueError):
+            cfg.experiment.analysis_unit
 
 
 class TestDefaultConfiguration:

--- a/lib/metric-config-parser/requirements.in
+++ b/lib/metric-config-parser/requirements.in
@@ -55,7 +55,7 @@ markupsafe==2.1.5
 mccabe==0.7.0
     # via flake8
     # via -r -
-mozilla-nimbus-schemas==2023.10.3
+mozilla-nimbus-schemas==2024.8.2
     # via mozilla-metric-config-parser
 mypy==1.11.1
     # via mozilla-metric-config-parser

--- a/lib/metric-config-parser/requirements.txt
+++ b/lib/metric-config-parser/requirements.txt
@@ -333,9 +333,9 @@ mccabe==0.7.0 \
     # via
     #   -r requirements.in
     #   flake8
-mozilla-nimbus-schemas==2023.10.3 \
-    --hash=sha256:8771344a63b0d197dbebd8d7955ce8034d0f5063a13899f4da7d8a99803a76da \
-    --hash=sha256:d8ce1a60bfe30d7435d0473ea6cda73217389cc22221a0b79c17fa78a23cf8b5
+mozilla-nimbus-schemas==2024.8.2 \
+    --hash=sha256:1df813de597d87db49b527bcafa91417a05052155f2930365209c86b564a87da \
+    --hash=sha256:a7f760043e1e97499890a9c896fbd44d159d3b938c3f1a250eae47690505af29
     # via -r requirements.in
 mypy==1.11.1 \
     --hash=sha256:0624bdb940255d2dd24e829d99a13cfeb72e4e9031f9492148f410ed30bcab54 \

--- a/lib/metric-config-parser/setup.py
+++ b/lib/metric-config-parser/setup.py
@@ -65,5 +65,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2024.8.2",
+    version="2024.9.1",
 )

--- a/lib/metric-config-parser/setup.py
+++ b/lib/metric-config-parser/setup.py
@@ -65,5 +65,5 @@ setup(
         [console_scripts]
         metric-config-parser=metric_config_parser.cli:cli
     """,
-    version="2024.8.1",
+    version="2024.8.2",
 )


### PR DESCRIPTION
- adds a `randomization_unit` property to the experiment config to make it easier to access
- adds a `analysis_unit` property to the experiment config that is derived from `randomization_unit` for use by jetstream