### PR TITLE
Filter spocs generated explore to only SPOCs

### DIFF
--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -60,6 +60,7 @@ from_expression = """
     SUM(clicks) AS clicks,
     SUM(revenue) AS revenue
   FROM `mozdata.ads.consolidated_ad_metrics_hourly`
+  WHERE product = 'SPOCs'
   GROUP BY
     submission_date,
     advertiser,


### PR DESCRIPTION
I was looking at this metric definition and I'm confused about why we didn't filter this to just SPOCs -- currently this will return metrics for both SPOC ads and Tiles ads. Was this an oversight?