### PR TITLE
macos powersaving release adding custom metrics

### DIFF
--- a/jetstream/macos-background-tab-power-savings-release.toml
+++ b/jetstream/macos-background-tab-power-savings-release.toml
@@ -1,0 +1,130 @@
+[metrics]
+
+overall = [
+	"fx_tab_switch_update_ms",
+	"fx_tab_switch_total_e10s_ms",
+	"fx_tab_switch_composite_e10s_ms",
+	"fx_tab_switch_spinner_visible_ms",
+	"fx_tab_switch_spinner_visible_long_ms",
+	"fx_tab_switch_spinner_visible_trigger",
+	"fx_tab_switch_request_tab_warming_state",
+	"fx_tab_click_ms",
+]
+
+weekly = [
+	"fx_tab_switch_update_ms",
+	"fx_tab_switch_total_e10s_ms",
+	"fx_tab_switch_composite_e10s_ms",
+	"fx_tab_switch_spinner_visible_ms",
+	"fx_tab_switch_spinner_visible_long_ms",
+	"fx_tab_switch_spinner_visible_trigger",
+	"fx_tab_switch_request_tab_warming_state",
+	"fx_tab_click_ms",
+]
+
+[metrics.fx_tab_switch_update_ms]
+data_source = "main_filtered"
+select_expression = "{{agg_histogram_mean('payload.histograms.fx_tab_switch_update_ms')}}"
+
+friendly_name = "Fx Tab Switch Update Ms"
+description = "Firefox: Time in ms spent updating UI in response to a tab switch"
+category = "performance"
+type = "histogram"
+
+[metrics.fx_tab_switch_update_ms.statistics.bootstrap_mean]
+
+
+[metrics.fx_tab_switch_spinner_visible_ms]
+data_source = "main_filtered"
+select_expression = "{{agg_histogram_mean('payload.histograms.fx_tab_switch_spinner_visible_ms')}}"
+
+friendly_name = "Fx Tab Switch Spinner Visible Ms"
+description = "Firefox: If the spinner interstitial displays during tab switching, records the time in ms the graphic is visible"
+category = "performance"
+type = "histogram"
+
+[metrics.fx_tab_switch_spinner_visible_ms.statistics.bootstrap_mean]
+
+[metrics.fx_tab_switch_spinner_visible_long_ms]
+data_source = "main_filtered"
+select_expression = "{{agg_histogram_mean('payload.histograms.fx_tab_switch_spinner_visible_long_ms')}}"
+
+friendly_name = "Fx Tab Switch Spinner Visible Long Ms"
+description = "Firefox: If the spinner interstitial displays during tab switching, records the time in ms the graphic is visible. This probe is similar to FX_TAB_SWITCH_SPINNER_VISIBLE_MS, but is for truly degenerate cases."
+category = "performance"
+type = "histogram"
+
+[metrics.fx_tab_switch_spinner_visible_long_ms.statistics.bootstrap_mean]
+
+[metrics.fx_tab_switch_spinner_visible_trigger]
+data_source = "main_filtered"
+select_expression = "{{agg_histogram_mean('payload.histograms.fx_tab_switch_spinner_visible_trigger')}}"
+
+friendly_name = "Fx Tab Switch Spinner Visible Trigger"
+description = "Firefox: Diagnostic probe to aid in categorizing tab switch spinners. Records what most recently set the loadTimer to null if a spinner was displayed."
+category = "performance"
+type = "histogram"
+
+[metrics.fx_tab_switch_spinner_visible_trigger.statistics.bootstrap_mean]
+
+[metrics.fx_tab_switch_request_tab_warming_state]
+data_source = "main_filtered"
+select_expression = "{{agg_histogram_mean('payload.histograms.fx_tab_switch_request_tab_warming_state')}}"
+
+friendly_name = "Fx Tab Switch Request Tab Warming State"
+description = "Firefox: When a tab is selected, records whether or not the tab was speculatively 'warmed up' to improve tab switch time."
+category = "performance"
+type = "histogram"
+
+[metrics.fx_tab_switch_request_tab_warming_state.statistics.bootstrap_mean]
+
+[metrics.fx_tab_click_ms]
+data_source = "main_filtered"
+
+select_expression = "{{agg_histogram_mean('payload.histograms.fx_tab_click_ms')}}"
+
+friendly_name = "Fx Tab Click Ms"
+description = "Firefox: Time in ms spent on switching tabs in response to a tab click."
+category = "performance"
+type = "histogram"
+
+[metrics.fx_tab_click_ms.statistics.bootstrap_mean]
+
+[metrics.fx_tab_switch_composite_e10s_ms]
+data_source = "main_filtered"
+
+select_expression = "{{agg_histogram_mean('payload.histograms.fx_tab_switch_composite_e10s_ms')}}"
+
+friendly_name = "Fx Tab Click Ms"
+description = "Firefox: Time in ms spent on switching tabs in response to a tab click."
+category = "performance"
+type = "histogram"
+
+[metrics.fx_tab_switch_composite_e10s_ms.statistics.bootstrap_mean]
+
+[metrics.fx_tab_switch_total_e10s_ms]
+data_source = "main_filtered"
+
+select_expression = "{{agg_histogram_mean('payload.histograms.fx_tab_switch_total_e10s_ms')}}"
+
+friendly_name = "Fx Tab Click Ms"
+description = "Firefox: Time in ms spent on switching tabs in response to a tab click."
+category = "performance"
+type = "histogram"
+
+[metrics.fx_tab_switch_total_e10s_ms.statistics.bootstrap_mean]
+
+
+[data_sources]
+[data_sources.main_filtered]
+from_expression = """(
+    SELECT
+        *,
+        DATE(submission_timestamp) AS submission_date,
+        environment.experiments
+    FROM `moz-fx-data-shared-prod.telemetry_stable.main_v5`
+    WHERE mozfun.map.get_key(environment.experiments, 'macos-background-tab-power-savings-release') IS NOT NULL
+)"""
+experiments_column_type = "native"
+friendly_name = "Main"
+description = "Main ping table"


### PR DESCRIPTION
i've copied over the toml from the beta jetstream/macos-background-tab-power-savings.toml to this one so the custom metrics are available for the powersaving relase experiment.  the only thing I changed from the earlier experiment toml file is the experiment name (to the current one) in the datasources select statement in line 126.  not sure if that was strictly necessary.  