### PR TITLE
Add segments attribute to Experiment object

### DIFF
--- a/lib/metric-config-parser/metric_config_parser/experiment.py
+++ b/lib/metric-config-parser/metric_config_parser/experiment.py
@@ -83,6 +83,7 @@ class Experiment:
     is_enrollment_paused: Optional[bool] = None
     app_id: Optional[str] = None
     outcomes: List[str] = attr.Factory(list)
+    segments: List[str] = attr.Factory(list)
     enrollment_end_date: Optional[dt.datetime] = None
     boolean_pref: Optional[str] = None
     channel: Optional[Channel] = None


### PR DESCRIPTION
Added a new "segments" attribute to the Experiment object. It will be used to store segment data retrieved from the experimenter API in jetstream.