### PR TITLE
bug: cert_storage_memory should be histogram mean

### DIFF
--- a/jetstream/definitions/functions.toml
+++ b/jetstream/definitions/functions.toml
@@ -13,3 +13,11 @@ definition = """
         SUM((SELECT SUM(value) FROM UNNEST(mozfun.hist.extract({select_expr}).values)))
     )
 """
+
+[functions.agg_histogram_mean_glean]
+definition = """
+    SAFE_DIVIDE(
+        SUM({select_expr}.sum),
+        SUM((SELECT SUM(value) FROM UNNEST({select_expr}.values)))
+    )
+"""

--- a/jetstream/outcomes/firefox_desktop/crlite.toml
+++ b/jetstream/outcomes/firefox_desktop/crlite.toml
@@ -3,10 +3,10 @@ description = "Metrics for the CRLite certificate revocation checking system"
 
 [metrics.cert_storage_memory]
 data_source = "metrics"
-select_expression = "ARRAY_AGG(metrics.memory_distribution.cert_storage_memory IGNORE NULLS)"
+select_expression = "{{agg_histogram_mean('metrics.memory_distribution.cert_storage_memory')}}"
 friendly_name = "Certificate storage memory usage (bytes)"
 description = "Heap memory usage of cert_storage::SecurityState. This includes CRLite artifacts and preloaded intermediate certificates."
-type = "histogram"
+type = "scalar"
 
 [metrics.cert_storage_memory.statistics.deciles]
 

--- a/jetstream/outcomes/firefox_desktop/crlite.toml
+++ b/jetstream/outcomes/firefox_desktop/crlite.toml
@@ -3,7 +3,7 @@ description = "Metrics for the CRLite certificate revocation checking system"
 
 [metrics.cert_storage_memory]
 data_source = "metrics"
-select_expression = "{{agg_histogram_mean('metrics.memory_distribution.cert_storage_memory')}}"
+select_expression = "{{agg_histogram_mean_glean('metrics.memory_distribution.cert_storage_memory')}}"
 friendly_name = "Certificate storage memory usage (bytes)"
 description = "Heap memory usage of cert_storage::SecurityState. This includes CRLite artifacts and preloaded intermediate certificates."
 type = "scalar"


### PR DESCRIPTION
Experiment owner requested that we use a mean here because Jetstream doesn't support histogram metrics.

Tried to follow existing usage of `agg_histogram_mean`, but not totally sure if this is correct so please check my work here!