### PR TITLE
chore: update path-filtering orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@0.1.3
+  path-filtering: circleci/path-filtering@1.1.0
 
 workflows:
   filter-paths-main:


### PR DESCRIPTION
not broken, but I had to update Jetstream's gcp-gcr orb due to circleci image expirations so thought I'd also take a look at mozanalysis and metric-hub