### PR TITLE
bug: pop ratio metrics must specify depends_on

### DIFF
--- a/jetstream/outcomes/firefox_desktop/crlite.toml
+++ b/jetstream/outcomes/firefox_desktop/crlite.toml
@@ -32,6 +32,7 @@ select_expression = """
 """
 friendly_name = "CRLite usage"
 description = "Number of revocation checks performed using CRLite."
+depends_on = ["crlite_use_counter", "revocation_check_counter"]
 type = "scalar"
 
 [metrics.crlite_use_counter.statistics.sum]
@@ -48,6 +49,7 @@ select_expression = """
 """
 friendly_name = "OCSP usage"
 description = "Number of revocation checks performed using OCSP."
+depends_on = ["ocsp_use_counter", "revocation_check_counter"]
 type = "scalar"
 
 [metrics.ocsp_use_counter.statistics.sum]

--- a/jetstream/outcomes/firefox_desktop/crlite.toml
+++ b/jetstream/outcomes/firefox_desktop/crlite.toml
@@ -32,12 +32,16 @@ select_expression = """
 """
 friendly_name = "CRLite usage"
 description = "Number of revocation checks performed using CRLite."
-depends_on = ["crlite_use_counter", "revocation_check_counter"]
 type = "scalar"
 
 [metrics.crlite_use_counter.statistics.sum]
 
-[metrics.crlite_use_counter.statistics.population_ratio]
+[metrics.crlite_use_counter_ratio]
+friendly_name = "CRLite usage vs revocation checks"
+description = "Ratio of revocation checks performed using CRLite compared to total."
+depends_on = ["crlite_use_counter", "revocation_check_counter"]
+
+[metrics.crlite_use_counter_ratio.statistics.population_ratio]
 numerator = "crlite_use_counter"
 denominator = "revocation_check_counter"
 
@@ -49,12 +53,17 @@ select_expression = """
 """
 friendly_name = "OCSP usage"
 description = "Number of revocation checks performed using OCSP."
-depends_on = ["ocsp_use_counter", "revocation_check_counter"]
 type = "scalar"
 
 [metrics.ocsp_use_counter.statistics.sum]
 
-[metrics.ocsp_use_counter.statistics.population_ratio]
+
+[metrics.ocsp_use_counter_ratio]
+friendly_name = "OCSP usage vs revocation checks"
+description = "Ratio of revocation checks performed using OCSP compared to total."
+depends_on = ["ocsp_use_counter", "revocation_check_counter"]
+
+[metrics.ocsp_use_counter_ratio.statistics.population_ratio]
 numerator = "ocsp_use_counter"
 denominator = "revocation_check_counter"
 


### PR DESCRIPTION
Getting an error for both of these that `revocation_check_counter` doesn't exist, so guessing we just need to make sure that the `depends_on` is set so the numerator/denominator are available before computing this metric's statistic.