### PR TITLE
Update ads.toml - remove create_title and creative_url

### DIFF
--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -53,8 +53,6 @@ from_expression = """
     campaign_name,
     targeted_country,
     rate_type,
-    creative_title as title,
-    creative_url as url,
     image_url as image,
     SUM(impressions) AS impressions,
     SUM(clicks) AS clicks,
@@ -66,8 +64,6 @@ from_expression = """
     campaign_name,
     targeted_country,
     rate_type,
-    creative_title,
-    creative_url,
     image_url
 )
 """


### PR DESCRIPTION
The view moz-fx-data-shared-prod.ads.consolidated_ad_metrics_hourly got updated and `creative_title` and `creative_url` got removed