### PR TITLE
Add crash metric outcomes for USER_RESTRICTED

### DIFF
--- a/jetstream/outcomes/firefox_desktop/content_process_stability.toml
+++ b/jetstream/outcomes/firefox_desktop/content_process_stability.toml
@@ -1,5 +1,5 @@
 friendly_name = "Content process stability"
 description = "Crash metrics relating to the content process."
 
-[metrics.content_crashes]
-[metrics.content_shutdown_crashes]
+[metrics.content_crashes.statistics.sum]
+[metrics.content_shutdown_crashes.statistics.sum]

--- a/jetstream/outcomes/firefox_desktop/content_process_stability.toml
+++ b/jetstream/outcomes/firefox_desktop/content_process_stability.toml
@@ -1,0 +1,5 @@
+friendly_name = "Content process stability"
+description = "Crash metrics relating to the content process."
+
+[metrics.content_crashes]
+[metrics.content_shutdown_crashes]

--- a/jetstream/outcomes/firefox_desktop/main_process_stability.toml
+++ b/jetstream/outcomes/firefox_desktop/main_process_stability.toml
@@ -1,0 +1,6 @@
+friendly_name = "Main process stability"
+description = "Crash and hang metrics relating to the main process."
+
+[metrics.main_crashes]
+[metrics.startup_crashes]
+[metrics.shutdown_hangs]

--- a/jetstream/outcomes/firefox_desktop/main_process_stability.toml
+++ b/jetstream/outcomes/firefox_desktop/main_process_stability.toml
@@ -1,6 +1,6 @@
 friendly_name = "Main process stability"
 description = "Crash and hang metrics relating to the main process."
 
-[metrics.main_crashes]
-[metrics.startup_crashes]
-[metrics.shutdown_hangs]
+[metrics.main_crashes.statistics.sum]
+[metrics.startup_crashes.statistics.sum]
+[metrics.shutdown_hangs.statistics.sum]


### PR DESCRIPTION
We want to monitor crash metrics for content and main processes for the USER_RESTRICTED experiment. There's a fair chance that these metric groupings will be useful for other experiments, so I'm adding them as outcomes.