### PR TITLE
Implement segment retrieval function in metric-config-parser

### DIFF
--- a/lib/metric-config-parser/metric_config_parser/config.py
+++ b/lib/metric-config-parser/metric_config_parser/config.py
@@ -680,6 +680,15 @@ class ConfigCollection:
 
         return None
 
+    def get_all_app_segments(self, app_name: str) -> Optional[List[SegmentDefinition]]:
+        segments: List[SegmentDefinition] = []
+        for definition in self.definitions:
+            if app_name == definition.platform:
+                if not isinstance(definition.spec, MonitoringSpec):
+                    segments.extend(definition.spec.segments.definitions.values())
+
+        return segments
+
     def get_metrics_sql(
         self,
         metrics: List[str],

--- a/lib/metric-config-parser/metric_config_parser/config.py
+++ b/lib/metric-config-parser/metric_config_parser/config.py
@@ -683,9 +683,8 @@ class ConfigCollection:
     def get_segments_for_app(self, app_name: str) -> Optional[List[SegmentDefinition]]:
         segments: List[SegmentDefinition] = []
         for definition in self.definitions:
-            if app_name == definition.platform:
-                if not isinstance(definition.spec, MonitoringSpec):
-                    segments.extend(definition.spec.segments.definitions.values())
+            if app_name == definition.platform and not isinstance(definition.spec, MonitoringSpec):
+                segments.extend(definition.spec.segments.definitions.values())
 
         return segments
 

--- a/lib/metric-config-parser/metric_config_parser/config.py
+++ b/lib/metric-config-parser/metric_config_parser/config.py
@@ -680,7 +680,7 @@ class ConfigCollection:
 
         return None
 
-    def get_all_app_segments(self, app_name: str) -> Optional[List[SegmentDefinition]]:
+    def get_segments_for_app(self, app_name: str) -> Optional[List[SegmentDefinition]]:
         segments: List[SegmentDefinition] = []
         for definition in self.definitions:
             if app_name == definition.platform:

--- a/lib/metric-config-parser/metric_config_parser/tests/integration/test_config_integration.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/integration/test_config_integration.py
@@ -70,7 +70,7 @@ class TestConfigIntegration:
             config_collection.get_segment_definition("regular_users_v3", "firefox_desktop")
             is not None
         )
-        assert config_collection.get_all_app_segments("firefox_desktop") is not None
+        assert config_collection.get_segments_for_app("firefox_desktop") is not None
 
     def test_configs_from_multiple_repos(self):
         config_collection = ConfigCollection.from_github_repos(

--- a/lib/metric-config-parser/metric_config_parser/tests/integration/test_config_integration.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/integration/test_config_integration.py
@@ -70,6 +70,7 @@ class TestConfigIntegration:
             config_collection.get_segment_definition("regular_users_v3", "firefox_desktop")
             is not None
         )
+        assert config_collection.get_all_app_segments("firefox_desktop") is not None
 
     def test_configs_from_multiple_repos(self):
         config_collection = ConfigCollection.from_github_repos(

--- a/lib/metric-config-parser/pyproject.toml
+++ b/lib/metric-config-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-metric-config-parser"
-version = "2024.10.1"
+version = "2024.10.2"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Parses metric configuration files"
 readme = "README.md"


### PR DESCRIPTION
Added a new function in metric-config-parser that retrieves and returns all available segments based on application.