### PR TITLE
[ci skip-rerun] fix: change desktop default DAU metric to v2

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -2147,6 +2147,18 @@ friendly_name = "Glean Events Stream"
 experiments_column_type = "none"
 client_id_column = "legacy_telemetry_client_id"
 
+[data_sources.firefox_desktop_active_users_view]
+friendly_name = "Firefox Desktop Active Users"
+description = "Client-level table that indicates whether a client meets 'active user' criteria on a given submission_date."
+from_expression = """(
+    SELECT *
+     FROM `moz-fx-data-shared-prod.telemetry.desktop_active_users`
+    WHERE is_desktop
+)"""
+submission_date_column = "submission_date"
+client_id_column = "client_id"
+experiments_column_type = "none"
+deprecated = false
 
 
 [segments]
@@ -2296,15 +2308,3 @@ from_expression = """(
 )"""
 window_start = 0
 window_end = 0
-
-[data_sources.firefox_desktop_active_users_view]
-friendly_name = "Firefox Desktop Active Users"
-description = "Client-level table that indicates whether a client meets 'active user' criteria on a given submission_date."
-from_expression = """(
-    SELECT *
-     FROM `moz-fx-data-shared-prod.telemetry.desktop_active_users`
-    WHERE is_desktop
-)"""
-submission_date_column = "submission_date"
-client_id_column = "client_id"
-deprecated = false

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -1,7 +1,7 @@
 # This defines the default metrics and statistics calculated for each experiment
 
 [metrics]
-daily = ["retained", "unenroll", "client_level_daily_active_users_v1"]
+daily = ["retained", "unenroll", "client_level_daily_active_users_v2"]
 
 weekly = [
   "active_hours",
@@ -12,7 +12,7 @@ weekly = [
   "search_count",
   "qualified_cumulative_days_of_use",
   "is_default_browser",
-  "client_level_daily_active_users_v1",
+  "client_level_daily_active_users_v2",
 ]
 
 overall = [
@@ -27,7 +27,7 @@ overall = [
   "uri_count",
   "qualified_cumulative_days_of_use",
   "is_default_browser",
-  "client_level_daily_active_users_v1",
+  "client_level_daily_active_users_v2",
 ]
 
 preenrollment_weekly = [
@@ -42,7 +42,7 @@ preenrollment_weekly = [
   "uri_count",
   "qualified_cumulative_days_of_use",
   "is_default_browser",
-  "client_level_daily_active_users_v1",
+  "client_level_daily_active_users_v2",
 ]
 
 preenrollment_days28 = [
@@ -57,7 +57,7 @@ preenrollment_days28 = [
   "uri_count",
   "qualified_cumulative_days_of_use",
   "is_default_browser",
-  "client_level_daily_active_users_v1",
+  "client_level_daily_active_users_v2",
 ]
 
 [metrics.active_hours.statistics.bootstrap_mean]
@@ -147,5 +147,5 @@ period = "preenrollment_week"
 [metrics.is_pinned.statistics.binomial]
 
 
-[metrics.client_level_daily_active_users_v1.statistics.per_client_dau_impact]
+[metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]
 pre_treatments = ['normalize_over_analysis_period']


### PR DESCRIPTION
* change the default DAU metric for experiments to the non-deprecated `_v2` version
* also matches with mobile, which is helpful for changing the guardrails in Experimenter
* skip rerunning jetstream for all desktop experiments