### PR TITLE
Mobile adoption promo configs

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1815,6 +1815,7 @@ level = "bronze"
 friendly_name = "Desktop Sync to Mobile"
 data_source = "clients_daily"
 select_expression = "COALESCE(sync_count_mobile_mean > 0, FALSE)"
+type = "scalar"
 description = "Did a desktop user sync to mobile"
 
 

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1811,6 +1811,13 @@ owner = ["vsabino@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 level = "bronze"
 
+[metrics.sync_to_mobile]
+friendly_name = "Desktop Sync to Mobile"
+data_source = "clients_daily"
+select_expression = "COALESCE(sync_count_mobile_mean > 0, FALSE)"
+description = "Did a desktop user sync to mobile"
+
+
 [dimensions]
 
 [dimensions.os]

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1814,7 +1814,7 @@ level = "bronze"
 [metrics.sync_to_mobile]
 friendly_name = "Desktop Sync to Mobile"
 data_source = "clients_daily"
-select_expression = "COALESCE(sync_count_mobile_mean > 0, FALSE)"
+select_expression = "LOGICAL_OR(COALESCE(sync_count_mobile_mean > 0, FALSE))"
 type = "scalar"
 description = "Did a desktop user sync to mobile"
 

--- a/jetstream/desktop-feature-callout-signed-into-account.toml
+++ b/jetstream/desktop-feature-callout-signed-into-account.toml
@@ -1,0 +1,5 @@
+[metrics]
+weekly = ["sync_to_mobile"]
+overall = ["sync_to_mobile"]
+
+[metrics.sync_to_mobile.statistics.binomial]

--- a/jetstream/desktop-to-mobile-adoption-promo-signed-into-account-eu.toml
+++ b/jetstream/desktop-to-mobile-adoption-promo-signed-into-account-eu.toml
@@ -1,0 +1,5 @@
+[metrics]
+weekly = ["sync_to_mobile"]
+overall = ["sync_to_mobile"]
+
+[metrics.sync_to_mobile.statistics.binomial]


### PR DESCRIPTION
add custom configs to desktop-feature-callout-signed-into-account and desktop-to-mobile-adoption-promo-signed-into-account-eu experiments