### PR TITLE
[ci rerun-skip] add default-ui-experiment config to end analysis now

### DIFF
--- a/jetstream/default-ui-experiment.toml
+++ b/jetstream/default-ui-experiment.toml
@@ -1,0 +1,2 @@
+[experiment]
+end_date = "2024-12-19"


### PR DESCRIPTION
Automated analysis results are not being used for this experiment, so let's just artificially end the experiment so we don't need to run analysis anymore.

- ci rerun-skip so we don't do a rerun for the stuff we've already computed