### PR TITLE
add and use filtered events datasource

### DIFF
--- a/jetstream/certificate-transparency.toml
+++ b/jetstream/certificate-transparency.toml
@@ -11,7 +11,7 @@ select_expression = """(
         AND event_object = 'aboutcerterror' 
         AND event_method = 'load'), 0)
 )"""
-data_source = "events"
+data_source = "events_certerror"
 
 [metrics.cert_errors.statistics.bootstrap_mean]
 
@@ -26,7 +26,7 @@ data_source = "tls_metrics"
 [data_sources.tls_metrics]
 friendly_name = "TLS glean metrics"
 description = "The glean metric ping with metrics.timing_distribution.network_tls_handshake.values unnested"
-from_expression =  """(
+from_expression = """(
     SELECT 
         m.client_info.client_id,
         DATE(m.submission_timestamp) AS submission_date,
@@ -37,8 +37,22 @@ from_expression =  """(
     WHERE
         DATE(m.submission_timestamp) >= "2024-12-04"
         AND m.normalized_channel = 'release'
- )"""
- experiments_column_type = "glean"
+)"""
+experiments_column_type = "glean"
+
+[data_sources.events_certerror]
+from_expression = """
+    (
+        SELECT
+            *
+        FROM `mozdata.telemetry.events`
+        WHERE 
+            event_category = 'security.ui.certerror'
+    )
+"""
+friendly_name = "Certerror events"
+description = "Cert Error related events"
+experiments_column_type = "native"
 
 # modified the data sources from this example in android review checker experiment
 # [data_sources.glean_metrics_ping]


### PR DESCRIPTION
Adding this filter cuts the bytes processed estimate down by ~40x, so hopefully this will take care of the resource issues we were seeing.

Of note, this same data source is also defined in an outcome [here](https://github.com/mozilla/metric-hub/blob/main/jetstream/outcomes/firefox_desktop/networking.toml#L385-L402) (er, kind of twice), so we should consider putting this into the base desktop definitions.