### PR TITLE
[ci rerun-skip] certificate-transparency: add exp filter to tls_metrics ds

### DIFF
--- a/jetstream/certificate-transparency.toml
+++ b/jetstream/certificate-transparency.toml
@@ -35,8 +35,9 @@ from_expression = """(
     FROM `mozdata.firefox_desktop.metrics` AS m
         CROSS JOIN UNNEST(metrics.timing_distribution.network_tls_handshake.values) AS v
     WHERE
-        DATE(m.submission_timestamp) >= "2024-12-04"
+        DATE(m.submission_timestamp) BETWEEN '2024-12-04' AND '2025-01-10'
         AND m.normalized_channel = 'release'
+        AND `mozfun.map.get_key`(m.ping_info.experiments, 'certificate-transparency') IS NOT NULL
 )"""
 experiments_column_type = "glean"
 


### PR DESCRIPTION
Just tested this experiment slug filter and it seemed to run ok, so let's try this.

Also, doing rerun-skip and I'll just manually rerun the couple of dates that failed last time.