### PR TITLE
Rolling back desktop native join

### DIFF
--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -30,48 +30,45 @@ description = "Daily SPOC revenue"
 
 [metrics.native_spend]
 select_expression = "SUM(spend)"
-data_source = "native_desktop_ad_metrics"
+data_source = "native_desktop_ad_metrics_hourly"
 friendly_name = "Native Spend"
 description ="Native Desktop Metrics spend"
 
 [metrics.native_dismisses]
 select_expression = "SUM(dismisses)"
-data_source = "native_desktop_ad_metrics"
+data_source = "native_desktop_ad_metrics_hourly"
 friendly_name = "Native Dismisses"
 description ="Native Desktop Metrics dismisses"
 
-[metrics.native_impressions]
-select_expression = "SUM(impressions)"
-data_source = "native_desktop_ad_metrics"
-friendly_name = "Native Impressions"
-description ="Native Desktop Metrics impressions"
-
 [metrics.native_clicks]
 select_expression = "SUM(clicks)"
-data_source = "native_desktop_ad_metrics"
+data_source = "native_desktop_ad_metrics_hourly"
 friendly_name = "Native Clicks"
 description ="Native Desktop Metrics clicks"
 
 [metrics.native_saves]
 select_expression = "SUM(saves)"
-data_source = "native_desktop_ad_metrics"
+data_source = "native_desktop_ad_metrics_hourly"
 friendly_name = "Native Saves"
 description ="Native Desktop Metrics saves"
 
-[metrics.native_spend.statistics.sum]
-[metrics.native_dismisses.statistics.sum]
-[metrics.native_impressions.statistics.sum]
-[metrics.native_clicks.statistics.sum]
-[metrics.native_saves.statistics.sum]
-[metrics.native_dismiss_rate.statistics.ratio]
-numerator = "native_dismisses.sum"
-denominator = "native_impressions.sum"
-[metrics.native_click_rate.statistics.ratio]
-numerator = "native_clicks.sum"
-denominator = "native_impressions.sum"
-[metrics.native_save_rate.statistics.ratio]
-numerator = "native_saves.sum"
-denominator = "native_impressions.sum"
+[metrics.native_dismiss_rate]
+select_expression = "AVG(dismiss_rate)"
+data_source = "native_desktop_ad_metrics_hourly"
+friendly_name = "Native Dismiss Rate"
+description ="Native Desktop Metrics dismiss rate"
+
+[metrics.native_click_rate]
+select_expression = "AVG(click_rate)"
+data_source = "native_desktop_ad_metrics_hourly"
+friendly_name = "Native Click Rate"
+description ="Native Desktop Metrics click rate"
+
+[metrics.native_save_rate]
+select_expression = "AVG(save_rate)"
+data_source = "native_desktop_ad_metrics_hourly"
+friendly_name = "Native Desktop Save Rate"
+description ="Native Desktop Metrics save rate"
 
 [data_sources]
 
@@ -119,7 +116,7 @@ columns_as_dimensions = true
 submission_date_column = "submission_date"
 client_id_column = "NULL"
 
-[data_sources.native_desktop_ad_metrics]
+[data_sources.native_desktop_ad_metrics_hourly]
 from_expression = """
 (
   SELECT
@@ -151,9 +148,9 @@ from_expression = """
   FROM `moz-fx-data-shared-prod.ads.native_desktop_ad_metrics_hourly`
 )
 """
-friendly_name = "Native Desktop Ads Metrics Daily"
+friendly_name = "Native Desktop AD Metrics"
 description = """
-  Tracks Native Desktop Ad Metrics Across Days
+  Tracks Native Desktop Ad Metrics
 """
 columns_as_dimensions = true
 submission_date_column = "submission_date"

--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -30,45 +30,48 @@ description = "Daily SPOC revenue"
 
 [metrics.native_spend]
 select_expression = "SUM(spend)"
-data_source = "native_desktop_ad_metrics_hourly"
+data_source = "native_desktop_ad_metrics"
 friendly_name = "Native Spend"
 description ="Native Desktop Metrics spend"
 
 [metrics.native_dismisses]
 select_expression = "SUM(dismisses)"
-data_source = "native_desktop_ad_metrics_hourly"
+data_source = "native_desktop_ad_metrics"
 friendly_name = "Native Dismisses"
 description ="Native Desktop Metrics dismisses"
 
+[metrics.native_impressions]
+select_expression = "SUM(impressions)"
+data_source = "native_desktop_ad_metrics"
+friendly_name = "Native Impressions"
+description ="Native Desktop Metrics impressions"
+
 [metrics.native_clicks]
 select_expression = "SUM(clicks)"
-data_source = "native_desktop_ad_metrics_hourly"
+data_source = "native_desktop_ad_metrics"
 friendly_name = "Native Clicks"
 description ="Native Desktop Metrics clicks"
 
 [metrics.native_saves]
 select_expression = "SUM(saves)"
-data_source = "native_desktop_ad_metrics_hourly"
+data_source = "native_desktop_ad_metrics"
 friendly_name = "Native Saves"
 description ="Native Desktop Metrics saves"
 
-[metrics.native_dismiss_rate]
-select_expression = "AVG(dismiss_rate)"
-data_source = "native_desktop_ad_metrics_hourly"
-friendly_name = "Native Dismiss Rate"
-description ="Native Desktop Metrics dismiss rate"
-
-[metrics.native_click_rate]
-select_expression = "AVG(click_rate)"
-data_source = "native_desktop_ad_metrics_hourly"
-friendly_name = "Native Click Rate"
-description ="Native Desktop Metrics click rate"
-
-[metrics.native_save_rate]
-select_expression = "AVG(save_rate)"
-data_source = "native_desktop_ad_metrics_hourly"
-friendly_name = "Native Desktop Save Rate"
-description ="Native Desktop Metrics save rate"
+[metrics.native_spend.statistics.sum]
+[metrics.native_dismisses.statistics.sum]
+[metrics.native_impressions.statistics.sum]
+[metrics.native_clicks.statistics.sum]
+[metrics.native_saves.statistics.sum]
+[metrics.native_dismiss_rate.statistics.ratio]
+numerator = "native_dismisses.sum"
+denominator = "native_impressions.sum"
+[metrics.native_click_rate.statistics.ratio]
+numerator = "native_clicks.sum"
+denominator = "native_impressions.sum"
+[metrics.native_save_rate.statistics.ratio]
+numerator = "native_saves.sum"
+denominator = "native_impressions.sum"
 
 [data_sources]
 
@@ -116,7 +119,7 @@ columns_as_dimensions = true
 submission_date_column = "submission_date"
 client_id_column = "NULL"
 
-[data_sources.native_desktop_ad_metrics_hourly]
+[data_sources.native_desktop_ad_metrics]
 from_expression = """
 (
   SELECT
@@ -148,9 +151,9 @@ from_expression = """
   FROM `moz-fx-data-shared-prod.ads.native_desktop_ad_metrics_hourly`
 )
 """
-friendly_name = "Native Desktop AD Metrics"
+friendly_name = "Native Desktop Ads Metrics Daily"
 description = """
-  Tracks Native Desktop Ad Metrics
+  Tracks Native Desktop Ad Metrics Across Days
 """
 columns_as_dimensions = true
 submission_date_column = "submission_date"

--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -125,56 +125,6 @@ friendly_name = "Native Desktop Ads Metrics Daily"
 description = """
   Tracks Native Desktop Ad Metrics Across Days
 """
-columns_as_dimensions = false
-submission_date_column = "submission_date"
-client_id_column = "NULL"
-
-[data_sources.native_desktop_ad_metrics_v1]
-from_expression = """
-(
-  SELECT
-    submission_date,
-    spoc_id,
-    position,
-    advertiser,
-    campaign_name,
-    title,
-    flight_id,
-    creative_type,
-    site_name,
-    zone_name,
-    country,
-    rate_type,
-    pid,
-    ad_url,
-    image_url,
-    external_param,
-    campaign_id
-  FROM `moz-fx-data-shared-prod.ads.native_desktop_ad_metrics_hourly`
-)
-"""
-friendly_name = "Native Desktop Ads Metrics Daily"
-description = """
-  Tracks Native Desktop Ad Metrics Across Days
-"""
 columns_as_dimensions = true
 submission_date_column = "submission_date"
 client_id_column = "NULL"
-
-# The purpose of the below join is to hide metrics from surfacing in Looker as dimensions.
-[data_sources.native_desktop_ad_metrics.joins.native_desktop_ad_metrics_v1]
-relationship = "one_to_one"
-on_expression = """
-  native_desktop_ad_metrics.submission_date = native_desktop_ad_metrics_v1.submission_date
-  AND native_desktop_ad_metrics.spoc_id = native_desktop_ad_metrics_v1.spoc_id
-  AND native_desktop_ad_metrics.position = native_desktop_ad_metrics_v1.position
-  AND native_desktop_ad_metrics.advertiser = native_desktop_ad_metrics_v1.advertiser
-  AND native_desktop_ad_metrics.title = native_desktop_ad_metrics_v1.title
-  AND native_desktop_ad_metrics.flight_id = native_desktop_ad_metrics_v1.flight_id
-  AND native_desktop_ad_metrics.creative_type = native_desktop_ad_metrics_v1.creative_type
-  AND native_desktop_ad_metrics.country = native_desktop_ad_metrics_v1.country
-  AND native_desktop_ad_metrics.rate_type = native_desktop_ad_metrics_v1.rate_type
-  AND native_desktop_ad_metrics.pid = native_desktop_ad_metrics_v1.pid
-  AND native_desktop_ad_metrics.ad_url = native_desktop_ad_metrics_v1.ad_url
-  AND native_desktop_ad_metrics.campaign_id = native_desktop_ad_metrics_v1.campaign_id
- """


### PR DESCRIPTION
Data stopped showing after merging join. Rolling back join but leaving new ratio metrics. Should clean up redundant names later on.