### PR TITLE
[ci rerun-skip] certificate-transparency: use legacy id for tls timing

### DIFF
--- a/jetstream/certificate-transparency.toml
+++ b/jetstream/certificate-transparency.toml
@@ -17,8 +17,8 @@ data_source = "events_certerror"
 
 [metrics.tls_timing]
 friendly_name = "TLS timing"
-description = "Amount of time for TLS handshake in miliseconds"
-select_expression = "COALESCE(SUM(CAST(key AS INT64)), 0)"
+description = "Amount of time for TLS handshake in seconds"
+select_expression = "COALESCE(SUM(CAST(key AS INT64)/1000000), 0)"
 data_source = "tls_metrics"
 
 [metrics.tls_timing.statistics.bootstrap_mean]

--- a/jetstream/certificate-transparency.toml
+++ b/jetstream/certificate-transparency.toml
@@ -17,8 +17,8 @@ data_source = "events_certerror"
 
 [metrics.tls_timing]
 friendly_name = "TLS timing"
-description = "Amount of time for TLS handshake in seconds"
-select_expression = "COALESCE(SUM(CAST(key AS INT64)/1000000), 0)"
+description = "Amount of time for TLS handshake in miliseconds"
+select_expression = "COALESCE(SUM(CAST(key AS INT64)), 0)"
 data_source = "tls_metrics"
 
 [metrics.tls_timing.statistics.bootstrap_mean]
@@ -28,7 +28,7 @@ friendly_name = "TLS glean metrics"
 description = "The glean metric ping with metrics.timing_distribution.network_tls_handshake.values unnested"
 from_expression = """(
     SELECT 
-        m.client_info.client_id,
+        m.metrics.uuid.legacy_telemetry_client_id as client_id,
         DATE(m.submission_timestamp) AS submission_date,
         v.key,
         m.ping_info


### PR DESCRIPTION
changed tls timing data source to use legacy client id in experiment toml file.  also removed division in metric 'from' statement since that is what worked in our test query.  