### PR TITLE
[ci rerun-skip] certificate-transparency: remove nulls from tls ratio

### DIFF
--- a/jetstream/certificate-transparency.toml
+++ b/jetstream/certificate-transparency.toml
@@ -35,9 +35,9 @@ friendly_name = "TLS timing ratio"
 description = "TLS timing (in seconds) divided by number of handshakes"
 select_expression = "SAFE_DIVIDE(COALESCE(SUM(CAST(key AS INT64)/1000000), 0), COUNT(key))"
 data_source = "tls_metrics"
-pre_treatments = ["remove_nulls"]
 
 [metrics.timing_ratio.statistics.bootstrap_mean]
+pre_treatments = ["remove_nulls"]
 
 [data_sources.tls_metrics]
 friendly_name = "TLS glean metrics"

--- a/jetstream/certificate-transparency.toml
+++ b/jetstream/certificate-transparency.toml
@@ -33,8 +33,9 @@ data_source = "tls_metrics"
 [metrics.timing_ratio]
 friendly_name = "TLS timing ratio"
 description = "TLS timing (in seconds) divided by number of handshakes"
-select_expression = "COALESCE(SUM(CAST(key AS INT64)/1000000), 0)/COALESCE(COUNT(key), 1)"
+select_expression = "SAFE_DIVIDE(COALESCE(SUM(CAST(key AS INT64)/1000000), 0), COUNT(key))"
 data_source = "tls_metrics"
+pre_treatments = ["remove_nulls"]
 
 [metrics.timing_ratio.statistics.bootstrap_mean]
 


### PR DESCRIPTION
adjusting select statement and pretretment for tls_ratio statistic to ignore nulls so we don't divide by zero