### PR TITLE
chore: version 2025.3.1

### DIFF
--- a/.circleci/validation-config.yml
+++ b/.circleci/validation-config.yml
@@ -127,6 +127,7 @@ jobs:
         name: Build
         command: |
           python3.10 -m venv venv/
+          venv/bin/python -m pip install --upgrade pip
           venv/bin/pip install --progress-bar off --upgrade -r requirements.txt
     - run:
         name: PyTest
@@ -165,6 +166,7 @@ jobs:
           name: Build and deploy docs
           command: |
             python3.10 -m venv venv/
+            venv/bin/python -m pip install --upgrade pip
             venv/bin/pip install -r .script/requirements.txt
             venv/bin/python3 .script/generate_docs.py \
               --output_dir=generated_docs/

--- a/lib/metric-config-parser/pyproject.toml
+++ b/lib/metric-config-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-metric-config-parser"
-version = "2024.11.1"
+version = "2025.3.1"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Parses metric configuration files"
 readme = "README.md"


### PR DESCRIPTION
forgot to bump version with last change

Edit to add:

There was a dependency resolution issue in CI that a) I don't know why it popped up now with this version change, and b) was fixed when upgrading pip. This issue was fixed by explicitly upgrading pip during the build step in CI.