### PR TITLE
Skip new-toolbar-ios-ios-redesign-beta-rollout

### DIFF
--- a/opmon/new-toolbar-ios-ios-redesign-beta-rollout.toml
+++ b/opmon/new-toolbar-ios-ios-redesign-beta-rollout.toml
@@ -1,0 +1,3 @@
+[project]
+
+skip = true


### PR DESCRIPTION
Skip due to it breaking Looker generation: https://workflow.telemetry.mozilla.org/dags/looker/grid?search=looker&dag_run_id=manual__2025-03-31T06%3A39%3A23.046259%2B00%3A00&task_id=lookml_generator_staging&tab=logs

The rollout is misconfigured and was replaced by `new-toolbar-ios-ios-redesign-beta-roll-out`