### PR TITLE
add toml file

### DIFF
--- a/jetstream/ios-sent-from-firefox.toml
+++ b/jetstream/ios-sent-from-firefox.toml
@@ -61,6 +61,7 @@ analysis_bases = ["enrollments"]
 
 [data_sources.ios_events]
 from_expression = """
+(
   SELECT
     client_id,
     DATE(submission_timestamp) AS submission_date,
@@ -68,6 +69,7 @@ from_expression = """
   FROM `mozdata.org_mozilla_ios_firefox.events_stream`
   WHERE event = 'share_sheet.shared_to'
     AND event_category = 'share_sheet'
+)
 """
 experiments_column_type = "none"
 analysis_units = ["client_id"]

--- a/jetstream/ios-sent-from-firefox.toml
+++ b/jetstream/ios-sent-from-firefox.toml
@@ -60,6 +60,14 @@ analysis_bases = ["enrollments"]
 [metrics.any_whatsapp_share.statistics.binomial]
 
 [data_sources.ios_events]
-from_expression = "mozdata.org_mozilla_ios_firefox.events_stream"
+from_expression = """
+  SELECT
+    client_id,
+    DATE(submission_timestamp) AS submission_date,
+    event_extra
+  FROM `mozdata.org_mozilla_ios_firefox.events_stream`
+  WHERE event = 'share_sheet.shared_to'
+    AND event_category = 'share_sheet'
+"""
 experiments_column_type = "none"
 analysis_units = ["client_id"]

--- a/jetstream/ios-sent-from-firefox.toml
+++ b/jetstream/ios-sent-from-firefox.toml
@@ -1,0 +1,65 @@
+friendly_name = "Sent From Firefox - iOS"
+description = "Track tab shares to WhatsApp and overall sharing behavior from enrolled and opted-in users."
+
+[experiment]
+enrollment_period = 14
+
+[metrics]
+overall = ["total_tab_shares", "whatsapp_share_count", "any_whatsapp_share"]
+
+[metrics.total_tab_shares]
+select_expression = """
+    COUNTIF(
+        JSON_VALUE(event_extra["share_type"]) = 'tab'
+        AND JSON_VALUE(event_extra["is_enrolled_in_sent_from_firefox"]) = 'true'
+        AND JSON_VALUE(event_extra["is_opted_in_sent_from_firefox"]) = 'true'
+    )
+"""
+data_source = "ios_events"
+friendly_name = "Total tab shares (all destinations)"
+description = "Total number of tabs shared by enrolled and opted-in users, regardless of destination."
+analysis_bases = ["enrollments"]
+bigger_is_better = true
+
+[metrics.total_tab_shares.statistics.bootstrap_mean]
+
+[metrics.whatsapp_share_count]
+select_expression = """
+    COUNTIF(
+        JSON_VALUE(event_extra["activity_identifier"]) = 'net.whatsapp.WhatsApp.ShareExtension'
+        AND JSON_VALUE(event_extra["share_type"]) = 'tab'
+        AND JSON_VALUE(event_extra["is_enrolled_in_sent_from_firefox"]) = 'true'
+        AND JSON_VALUE(event_extra["is_opted_in_sent_from_firefox"]) = 'true'
+    )
+"""
+data_source = "ios_events"
+friendly_name = "WhatsApp tab share count"
+description = "Number of times enrolled and opted-in users shared a tab to WhatsApp."
+analysis_bases = ["enrollments"]
+bigger_is_better = true
+
+[metrics.whatsapp_share_count.statistics.bootstrap_mean]
+[metrics.whatsapp_share_count.statistics.deciles]
+
+[metrics.any_whatsapp_share]
+select_expression = """
+    CAST(
+        COUNTIF(
+            JSON_VALUE(event_extra["activity_identifier"]) = 'net.whatsapp.WhatsApp.ShareExtension'
+            AND JSON_VALUE(event_extra["share_type"]) = 'tab'
+            AND JSON_VALUE(event_extra["is_enrolled_in_sent_from_firefox"]) = 'true'
+            AND JSON_VALUE(event_extra["is_opted_in_sent_from_firefox"]) = 'true'
+        ) > 0 AS INT64
+    )
+"""
+data_source = "ios_events"
+friendly_name = "Any WhatsApp tab share"
+description = "Proportion of enrolled and opted-in users who shared at least one tab to WhatsApp."
+analysis_bases = ["enrollments"]
+
+[metrics.any_whatsapp_share.statistics.binomial]
+
+[data_sources.ios_events]
+from_expression = "mozdata.org_mozilla_ios_firefox.events_stream"
+experiments_column_type = "none"
+analysis_units = ["client_id"]


### PR DESCRIPTION
For [DS-3907](https://mozilla-hub.atlassian.net/browse/DS-3907) - Sent from Firefox - iOS

Query to reproduce logic:
```sql
WITH events AS (
  SELECT
    event_timestamp,
    event_extra,
    JSON_VALUE(event_extra["activity_identifier"]) AS activity_identifier,
    JSON_VALUE(event_extra["share_type"]) AS share_type,
    JSON_VALUE(event_extra["is_enrolled_in_sent_from_firefox"]) AS enrolled,
    JSON_VALUE(event_extra["is_opted_in_sent_from_firefox"]) AS opted_in,
    client_id AS client_id
  FROM
    `mozdata.org_mozilla_ios_firefox.events_stream`
  WHERE
    DATE(submission_timestamp) >= DATE_SUB(CURRENT_DATE(), INTERVAL 14 DAY)
    AND event = 'share_sheet.shared_to'
    AND event_category = 'share_sheet'
)

-- Summarize metric logic
SELECT
  COUNTIF(
    share_type = 'tab'
    AND enrolled = 'true'
    AND opted_in = 'true'
  ) AS total_tab_shares,

  COUNTIF(
    activity_identifier = 'net.whatsapp.WhatsApp.ShareExtension'
    AND share_type = 'tab'
    AND enrolled = 'true'
    AND opted_in = 'true'
  ) AS whatsapp_share_count,

  COUNT(DISTINCT CASE
    WHEN
      activity_identifier = 'net.whatsapp.WhatsApp.ShareExtension'
      AND share_type = 'tab'
      AND enrolled = 'true'
      AND opted_in = 'true'
    THEN client_id ELSE NULL END
  ) AS whatsapp_sharing_users

  FROM events
```
