### PR TITLE
add sponsored tiles outcome metrics to shortcuts-visual-refresh

### DIFF
--- a/jetstream/shortcuts-visual-refresh.toml
+++ b/jetstream/shortcuts-visual-refresh.toml
@@ -1,0 +1,15 @@
+# Copied from jetstream/outcomes/firefox_desktop/sponsored_tiles.toml
+[metrics.sponsored_tiles_disabled.statistics.binomial]
+[metrics.any_sponsored_tiles_dismissals.statistics.binomial]
+
+[metrics.sponsored_tiles_dismissals.statistics.bootstrap_mean]
+[metrics.sponsored_tiles_dismissals.statistics.deciles]
+
+[metrics.sponsored_tiles_dismissals_pos1_2.statistics.bootstrap_mean]
+[metrics.sponsored_tiles_dismissals_pos1_2.statistics.deciles]
+
+[metrics.sponsored_tile_clicks.statistics.bootstrap_mean]
+[metrics.sponsored_tile_clicks.statistics.deciles]
+
+[metrics.sponsored_tile_impressions.statistics.bootstrap_mean]
+[metrics.sponsored_tile_impressions.statistics.deciles]


### PR DESCRIPTION
Per request from experiment owner

/cc @ilanasegall
