### PR TITLE
chore: update path-filtering orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 setup: true
 
 orbs:
-  path-filtering: circleci/path-filtering@1.1.0
+  path-filtering: circleci/path-filtering@1.3.0
 
 workflows:
   filter-paths-main:


### PR DESCRIPTION
Should fix the error with python 3.8 in the filter paths workflow.