### PR TITLE
feat: refactor default browser outcome to use filtered events_stream

### DIFF
--- a/jetstream/outcomes/fenix/default-browser.toml
+++ b/jetstream/outcomes/fenix/default-browser.toml
@@ -30,6 +30,18 @@ description = """
     This only opens a system UI that allows users to change their default browser,
     so not all of these clients will actually change their default browser.
 """
-select_expression = "COUNTIF(event.name = 'default_browser_changed') > 0"
-data_source = "events"
+select_expression = "COUNTIF(event_name = 'default_browser_changed') > 0"
+data_source = "events_stream_events"
 statistics = { binomial = {} }
+
+
+[data_sources.events_stream_events]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date,
+    FROM
+        `moz-fx-data-shared-prod.org_mozilla_firefox.events_stream` p
+    WHERE event_category = 'events'
+)"""
+experiments_column_type = "none"


### PR DESCRIPTION
- the `events` data_source is unfiltered and uses the events table which requires a CROSS JOIN to unnest the event info, and `events_stream` is recommended as an alternative wherever possible
- this outcome appears to be causing an issue with a few experiments timing out in metric queries