### PR TITLE
[DS-4258] add segment definitions to address bar configs

### DIFF
--- a/jetstream/address-bar-update-donoharm.toml
+++ b/jetstream/address-bar-update-donoharm.toml
@@ -171,7 +171,7 @@ description = "Clients in India"
 data_source = "clients_daily"
 
 [segments.row]
-select_expression = "COALESCE(LOGICAL_OR(country NOT IN ('JP', 'IN, 'CA', 'DE', 'FR', 'GB', 'US')), FALSE)"
+select_expression = "COALESCE(LOGICAL_OR(country NOT IN ('JP', 'IN', 'CA', 'DE', 'FR', 'GB', 'US')), FALSE)"
 description = "Clients in countries not covered by previous country segments"
 data_source = "clients_daily"
 

--- a/jetstream/address-bar-update-donoharm.toml
+++ b/jetstream/address-bar-update-donoharm.toml
@@ -1,5 +1,18 @@
 [experiment]
-end_date = "2025-03-31"
+end_date = "2025-05-02"
+
+segments = [
+  "google_default_search",
+  "bing_default_search",
+  "ddg_default_search",
+  "baidu_default_search",
+  "qwant_default_search",
+  "ecosia_default_search",
+  "us",
+  "marketing_tier1_countries",
+  "in",
+  "row",
+]
 
 [metrics]
 weekly = ['search_engine_default_change', 'non_default_search_engine_search']
@@ -23,10 +36,8 @@ select_expression = """
 data_source = "metrics_unnested_urlbar_searchmode_searchbutton"
 
 
-
 [metrics.search_engine_default_change.statistics.binomial]
 [metrics.non_default_search_engine_search.statistics.binomial]
-
 
 
 [data_sources.metrics_unnested_urlbar_searchmode_searchbutton]
@@ -51,3 +62,95 @@ description = "Glean events_stream dataset filtered to event_category 'search.en
 friendly_name = "Glean Events Stream filtered to event_category 'search.engine.default'"
 experiments_column_type = "none"
 client_id_column = "legacy_telemetry_client_id"
+
+[segments]
+
+[segments.google_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'Google'
+        ), FALSE
+    )"""
+description = "Clients with Google as default search engine"
+data_source = "clients_daily"
+
+[segments.bing_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'Bing'
+        ), FALSE
+    )"""
+description = "Clients with Bing as default search engine"
+data_source = "clients_daily"
+
+[segments.ddg_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'DuckDuckGo'
+        ), FALSE
+    )"""
+description = "Clients with DDG as default search engine"
+data_source = "clients_daily"
+
+[segments.baidu_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'Baidu'
+        ), FALSE
+    )"""
+description = "Clients with Baidu as default search engine"
+data_source = "clients_daily"
+
+[segments.qwant_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'Qwant'
+        ), FALSE
+    )"""
+description = "Clients with Qwant as default search engine"
+data_source = "clients_daily"
+
+[segments.ecosia_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'Ecosia'
+        ), FALSE
+    )"""
+description = "Clients with Ecosia as default search engine"
+data_source = "clients_daily"
+
+[segments.us]
+select_expression = "COALESCE(LOGICAL_OR(country = 'US'), FALSE)"
+description = "Clients in US"
+data_source = "clients_daily"
+
+[segments.marketing_tier1_countries]
+select_expression = "COALESCE(LOGICAL_OR(country IN ('CA', 'DE', 'FR', 'GB', 'US')), FALSE)"
+description = "Clients in marketing Tier 1 countries"
+data_source = "clients_daily"
+
+[segments.jp]
+select_expression = "COALESCE(LOGICAL_OR(country = 'JP'), FALSE)"
+description = "Clients in Japan"
+data_source = "clients_daily"
+
+[segments.in]
+select_expression = "COALESCE(LOGICAL_OR(country = 'IN'), FALSE)"
+description = "Clients in India"
+data_source = "clients_daily"
+
+[segments.row]
+select_expression = "COALESCE(LOGICAL_OR(country NOT IN ('JP', 'IN, 'CA', 'DE', 'FR', 'GB', 'US')), FALSE)"
+description = "Clients in countries not covered by previous country segments"
+data_source = "clients_daily"
+
+[segments.data_sources.clients_daily]
+from_expression = "mozdata.telemetry.clients_daily"
+window_start = 0
+window_end = 0

--- a/jetstream/address-bar-update-donoharm.toml
+++ b/jetstream/address-bar-update-donoharm.toml
@@ -9,8 +9,13 @@ segments = [
   "qwant_default_search",
   "ecosia_default_search",
   "us",
-  "marketing_tier1_countries",
+  "ca",
+  "fr",
+  "de",
+  "jp",
+  "gb",
   "india",
+  "marketing_tier1_countries",
   "row",
 ]
 
@@ -128,6 +133,26 @@ data_source = "clients_daily"
 [segments.us]
 select_expression = "COALESCE(LOGICAL_OR(country = 'US'), FALSE)"
 description = "Clients in US"
+data_source = "clients_daily"
+
+[segments.ca]
+select_expression = "COALESCE(LOGICAL_OR(country = 'CA'), FALSE)"
+description = "Clients in Canada"
+data_source = "clients_daily"
+
+[segments.de]
+select_expression = "COALESCE(LOGICAL_OR(country = 'DE'), FALSE)"
+description = "Clients in Germany"
+data_source = "clients_daily"
+
+[segments.fr]
+select_expression = "COALESCE(LOGICAL_OR(country = 'FR'), FALSE)"
+description = "Clients in France"
+data_source = "clients_daily"
+
+[segments.gb]
+select_expression = "COALESCE(LOGICAL_OR(country = 'GB'), FALSE)"
+description = "Clients in GB"
 data_source = "clients_daily"
 
 [segments.marketing_tier1_countries]

--- a/jetstream/address-bar-update-donoharm.toml
+++ b/jetstream/address-bar-update-donoharm.toml
@@ -10,7 +10,7 @@ segments = [
   "ecosia_default_search",
   "us",
   "marketing_tier1_countries",
-  "in",
+  "india",
   "row",
 ]
 
@@ -140,7 +140,7 @@ select_expression = "COALESCE(LOGICAL_OR(country = 'JP'), FALSE)"
 description = "Clients in Japan"
 data_source = "clients_daily"
 
-[segments.in]
+[segments.india]
 select_expression = "COALESCE(LOGICAL_OR(country = 'IN'), FALSE)"
 description = "Clients in India"
 data_source = "clients_daily"

--- a/jetstream/address-bar-update-launch-extention.toml
+++ b/jetstream/address-bar-update-launch-extention.toml
@@ -1,2 +1,108 @@
 [experiment]
 enrollment_period = 7
+end_date = "2025-05-02"
+
+segments = [
+    "google_default_search",
+    "bing_default_search",
+    "ddg_default_search",
+    "baidu_default_search",
+    "qwant_default_search",
+    "ecosia_default_search",
+    "us",
+    "marketing_tier1_countries",
+    "in",
+    "row",
+]
+
+[segments]
+
+[segments.google_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'Google'
+        ), FALSE
+    )"""
+description = "Clients with Google as default search engine"
+data_source = "clients_daily"
+
+[segments.bing_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'Bing'
+        ), FALSE
+    )"""
+description = "Clients with Bing as default search engine"
+data_source = "clients_daily"
+
+[segments.ddg_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'DuckDuckGo'
+        ), FALSE
+    )"""
+description = "Clients with DDG as default search engine"
+data_source = "clients_daily"
+
+[segments.baidu_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'Baidu'
+        ), FALSE
+    )"""
+description = "Clients with Baidu as default search engine"
+data_source = "clients_daily"
+
+[segments.qwant_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'Qwant'
+        ), FALSE
+    )"""
+description = "Clients with Qwant as default search engine"
+data_source = "clients_daily"
+
+[segments.ecosia_default_search]
+select_expression = """
+    COALESCE(
+        LOGICAL_OR(
+            `moz-fx-data-shared-prod`.udf.normalize_search_engine(default_search_engine) = 'Ecosia'
+        ), FALSE
+    )"""
+description = "Clients with Ecosia as default search engine"
+data_source = "clients_daily"
+
+[segments.us]
+select_expression = "COALESCE(LOGICAL_OR(country = 'US'), FALSE)"
+description = "Clients in US"
+data_source = "clients_daily"
+
+[segments.marketing_tier1_countries]
+select_expression = "COALESCE(LOGICAL_OR(country IN ('CA', 'DE', 'FR', 'GB', 'US')), FALSE)"
+description = "Clients in marketing Tier 1 countries"
+data_source = "clients_daily"
+
+[segments.jp]
+select_expression = "COALESCE(LOGICAL_OR(country = 'JP'), FALSE)"
+description = "Clients in Japan"
+data_source = "clients_daily"
+
+[segments.in]
+select_expression = "COALESCE(LOGICAL_OR(country = 'IN'), FALSE)"
+description = "Clients in India"
+data_source = "clients_daily"
+
+[segments.row]
+select_expression = "COALESCE(LOGICAL_OR(country NOT IN ('JP', 'IN, 'CA', 'DE', 'FR', 'GB', 'US')), FALSE)"
+description = "Clients in countries not covered by previous country segments"
+data_source = "clients_daily"
+
+[segments.data_sources.clients_daily]
+from_expression = "mozdata.telemetry.clients_daily"
+window_start = 0
+window_end = 0

--- a/jetstream/address-bar-update-launch-extention.toml
+++ b/jetstream/address-bar-update-launch-extention.toml
@@ -11,7 +11,7 @@ segments = [
     "ecosia_default_search",
     "us",
     "marketing_tier1_countries",
-    "in",
+    "india",
     "row",
 ]
 
@@ -92,7 +92,7 @@ select_expression = "COALESCE(LOGICAL_OR(country = 'JP'), FALSE)"
 description = "Clients in Japan"
 data_source = "clients_daily"
 
-[segments.in]
+[segments.india]
 select_expression = "COALESCE(LOGICAL_OR(country = 'IN'), FALSE)"
 description = "Clients in India"
 data_source = "clients_daily"

--- a/jetstream/address-bar-update-launch-extention.toml
+++ b/jetstream/address-bar-update-launch-extention.toml
@@ -10,8 +10,13 @@ segments = [
     "qwant_default_search",
     "ecosia_default_search",
     "us",
-    "marketing_tier1_countries",
+    "ca",
+    "fr",
+    "de",
+    "jp",
+    "gb",
     "india",
+    "marketing_tier1_countries",
     "row",
 ]
 
@@ -82,11 +87,6 @@ select_expression = "COALESCE(LOGICAL_OR(country = 'US'), FALSE)"
 description = "Clients in US"
 data_source = "clients_daily"
 
-[segments.marketing_tier1_countries]
-select_expression = "COALESCE(LOGICAL_OR(country IN ('CA', 'DE', 'FR', 'GB', 'US')), FALSE)"
-description = "Clients in marketing Tier 1 countries"
-data_source = "clients_daily"
-
 [segments.jp]
 select_expression = "COALESCE(LOGICAL_OR(country = 'JP'), FALSE)"
 description = "Clients in Japan"
@@ -95,6 +95,31 @@ data_source = "clients_daily"
 [segments.india]
 select_expression = "COALESCE(LOGICAL_OR(country = 'IN'), FALSE)"
 description = "Clients in India"
+data_source = "clients_daily"
+
+[segments.ca]
+select_expression = "COALESCE(LOGICAL_OR(country = 'CA'), FALSE)"
+description = "Clients in Canada"
+data_source = "clients_daily"
+
+[segments.de]
+select_expression = "COALESCE(LOGICAL_OR(country = 'DE'), FALSE)"
+description = "Clients in Germany"
+data_source = "clients_daily"
+
+[segments.fr]
+select_expression = "COALESCE(LOGICAL_OR(country = 'FR'), FALSE)"
+description = "Clients in France"
+data_source = "clients_daily"
+
+[segments.gb]
+select_expression = "COALESCE(LOGICAL_OR(country = 'GB'), FALSE)"
+description = "Clients in GB"
+data_source = "clients_daily"
+
+[segments.marketing_tier1_countries]
+select_expression = "COALESCE(LOGICAL_OR(country IN ('CA', 'DE', 'FR', 'GB', 'US')), FALSE)"
+description = "Clients in marketing Tier 1 countries"
 data_source = "clients_daily"
 
 [segments.row]

--- a/jetstream/address-bar-update-launch-extention.toml
+++ b/jetstream/address-bar-update-launch-extention.toml
@@ -123,7 +123,7 @@ description = "Clients in marketing Tier 1 countries"
 data_source = "clients_daily"
 
 [segments.row]
-select_expression = "COALESCE(LOGICAL_OR(country NOT IN ('JP', 'IN, 'CA', 'DE', 'FR', 'GB', 'US')), FALSE)"
+select_expression = "COALESCE(LOGICAL_OR(country NOT IN ('JP', 'IN', 'CA', 'DE', 'FR', 'GB', 'US')), FALSE)"
 description = "Clients in countries not covered by previous country segments"
 data_source = "clients_daily"
 


### PR DESCRIPTION
Adds the requested segments from [DS-4258](https://mozilla-hub.atlassian.net/browse/DS-4258?linkSource=email) to the experiment configs.

Changes the end date to today (2025-05-02) to trigger Jetstream analysis to run tonight.