### PR TITLE
Fix desktop new profiles segment

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -2352,7 +2352,7 @@ description = """
 
 [segments.new_unique_profiles]
 data_source = "clients_last_seen"
-select_expression = "COALESCE(ANY_VALUE(first_seen_date) >= submission_date, TRUE)"
+select_expression = "COALESCE(LOGICAL_OR(first_seen_date = submission_date), FALSE)"
 friendly_name = "New unique profiles"
 description = """
     Clients that enrolled the first date their client_id ever appeared

--- a/jetstream/tab-groups-10-experiment-with-onboarding.toml
+++ b/jetstream/tab-groups-10-experiment-with-onboarding.toml
@@ -1,7 +1,7 @@
 [experiment]
 end_date = "2025-05-06"
 enrollment_period = 7
-segments = ["regular_users_v3", "new_or_resurrected_v3"]
+segments = ["regular_users_v3", "new_or_resurrected_v3", "new_unique_profiles"]
 
 [experiment.exposure_signal]
 name = "contextual_reach"


### PR DESCRIPTION
Previous definition was returning the error
```
SELECT list expression references column submission_date which is neither grouped nor aggregated 
```

Updating to fix the error and adding it to the Tab Groups experiment.