### PR TITLE
feat: set default analysis_units by app

### DIFF
--- a/lib/metric-config-parser/metric_config_parser/data_source.py
+++ b/lib/metric-config-parser/metric_config_parser/data_source.py
@@ -200,9 +200,13 @@ class DataSourceDefinition:
 
         default_analysis_units = [AnalysisUnit.CLIENT]
         app_name = ""
-        if conf and conf.app_name:
+        if getattr(conf, "app_name", None):
+            if TYPE_CHECKING:
+                assert isinstance(conf, ProjectConfiguration)
             app_name = conf.app_name
-        elif conf and conf.experiment:
+        elif getattr(conf, "experiment", None):
+            if TYPE_CHECKING:
+                assert isinstance(conf, ExperimentConfiguration)
             app_name = conf.experiment.app_name
 
         if app_name == "firefox_desktop":

--- a/lib/metric-config-parser/metric_config_parser/metric.py
+++ b/lib/metric-config-parser/metric_config_parser/metric.py
@@ -100,7 +100,8 @@ class Metric:
     owner: Optional[List[str]] = None
     deprecated: bool = False
     level: Optional[MetricLevel] = None
-    analysis_units: List[AnalysisUnit] = None
+    # Default to client for most apps, client+group for desktop (set elsewhere)
+    analysis_units: List[AnalysisUnit] = [AnalysisUnit.CLIENT]
 
 
 @attr.s(auto_attribs=True)

--- a/lib/metric-config-parser/metric_config_parser/tests/test_analysis.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_analysis.py
@@ -914,5 +914,7 @@ class TestAnalysisSpec:
 
         spec = AnalysisSpec.from_dict(toml.loads(config_str))
 
-        with pytest.raises(ValueError, match="data_source eggs does not support"):
+        with pytest.raises(
+            ValueError, match="data_source eggs \(app: firefox_desktop\) does not support"
+        ):
             spec.resolve(experiments[0], config_collection)

--- a/lib/metric-config-parser/metric_config_parser/tests/test_analysis.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_analysis.py
@@ -919,6 +919,6 @@ class TestAnalysisSpec:
         spec = AnalysisSpec.from_dict(toml.loads(config_str))
 
         with pytest.raises(
-            ValueError, match="data_source eggs \(app: firefox_desktop\) does not support"
+            ValueError, match=r"data_source eggs \(app: firefox_desktop\) does not support"
         ):
             spec.resolve(experiments[0], config_collection)

--- a/lib/metric-config-parser/metric_config_parser/tests/test_analysis.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_analysis.py
@@ -448,7 +448,11 @@ class TestAnalysisSpec:
 
         assert cfg.experiment.exposure_signal == ExposureSignal(
             name="ad_exposure",
-            data_source=DataSource(name="main", from_expression="(SELECT 1)"),
+            data_source=DataSource(
+                name="main",
+                from_expression="(SELECT 1)",
+                analysis_units=[AnalysisUnit.CLIENT, AnalysisUnit.PROFILE_GROUP],
+            ),
             select_expression="ad_click > 0",
             friendly_name="Ad exposure",
             description="Clients have clicked on ad",

--- a/lib/metric-config-parser/pyproject.toml
+++ b/lib/metric-config-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-metric-config-parser"
-version = "2025.4.1"
+version = "2025.5.1"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Parses metric configuration files"
 readme = "README.md"


### PR DESCRIPTION
Only desktop has groups, so we should only default to assuming support for both client and group in desktop, and only client otherwise.