### PR TITLE
[jetstream] Adds enrollment query for Whats New Notification Sidebar/Vertical tabs experiment

### DIFF
--- a/jetstream/whats-new-notification-sidebarvertical-tabs.toml
+++ b/jetstream/whats-new-notification-sidebarvertical-tabs.toml
@@ -33,7 +33,7 @@ SELECT * FROM
 
 (
 SELECT
-    events.metrics.uuid.background_update_client_id AS client_id,
+    events.metrics.uuid.background_update_client_id AS analysis_id,
     mozfun.map.get_key(event.extra, 'branch') AS branch,
     MIN(DATE(events.submission_timestamp)) AS enrollment_date,
     COUNT(events.submission_timestamp) AS num_enrollment_events
@@ -54,14 +54,14 @@ WHERE
     AND mozfun.map.get_key(event.extra, 'experiment') = '{{experiment.normandy_slug}}'
     -- This should never happen, but belt-and-braces.
     AND events.metrics.uuid.background_update_client_id IS NOT NULL
-GROUP BY client_id, branch
+GROUP BY analysis_id, branch
 )
 
 UNION ALL
 
 (
 SELECT
-    m.metrics.uuid.background_update_client_id AS client_id,
+    m.metrics.uuid.background_update_client_id AS analysis_id,
     experiment.value.branch AS branch,
     MIN(DATE(submission_timestamp)) AS enrollment_date,
     -- These aren't discrete events, it makes no sense to count them.
@@ -83,14 +83,14 @@ WHERE
         '{{experiment.last_enrollment_date_str}}'
     -- The background update experiment slug is exact.
     AND experiment.key = '{{experiment.normandy_slug}}'
-GROUP BY client_id, branch
+GROUP BY analysis_id, branch
 )
 
 UNION ALL
 
 (
 SELECT
-    client_id AS client_id,
+    client_id AS analysis_id,
     -- Post [Bug 1804988](https://bugzilla.mozilla.org/show_bug.cgi?id=1804988),
     -- this name looks like 'slug:branch'.
     SPLIT(mozfun.map.get_key(event_map_values, 'name'), ':')[SAFE_OFFSET(1)] AS branch,
@@ -111,11 +111,11 @@ WHERE
     -- this name looks like 'slug:branch'.
     AND STARTS_WITH(mozfun.map.get_key(event_map_values, 'name'), '{{experiment.normandy_slug}}:')
 GROUP BY
-    client_id, branch
+    analysis_id, branch
 )
 
 )
-QUALIFY ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY enrollment_date ASC) = 1
+QUALIFY ROW_NUMBER() OVER (PARTITION BY analysis_id ORDER BY enrollment_date ASC) = 1
 """
 
 #segment information:https://docs.telemetry.mozilla.org/concepts/segments.html

--- a/jetstream/whats-new-notification-sidebarvertical-tabs.toml
+++ b/jetstream/whats-new-notification-sidebarvertical-tabs.toml
@@ -1,13 +1,6 @@
 
 [experiment]
 
-start_date = "2025-04-08"
-end_date = "2025-05-15"
-enrollment_period = 9
-
-# The two branches "control", "treatment-a"
-reference_branch = "control"
-
 enrollment_query = """
 SELECT * FROM
 (
@@ -33,27 +26,23 @@ SELECT * FROM
 
 (
 SELECT
-    events.metrics.uuid.background_update_client_id AS analysis_id,
-    mozfun.map.get_key(event.extra, 'branch') AS branch,
+    JSON_VALUE(metrics, '$.uuid.background_update_client_id') AS analysis_id,
+    JSON_VALUE(event_extra, '$.branch') AS branch,
     MIN(DATE(events.submission_timestamp)) AS enrollment_date,
     COUNT(events.submission_timestamp) AS num_enrollment_events
--- We need to query from the Glean `background_update` table because pre-[Bug
--- 1794053](https://bugzilla.mozilla.org/show_bug.cgi?id=1794053) (scheduled for
--- Firefox 109) we don't have the legacy client ID in
--- `mozdata.firefox_desktop_background_update.events`.
-FROM `moz-fx-data-shared-prod.firefox_desktop_background_update.background_update` events,
-UNNEST(events.events) AS event
+-- Query from events_stream because it's much more efficient than unnesting events.
+FROM `moz-fx-data-shared-prod.firefox_desktop_background_update.events_stream` events
 WHERE
     DATE(submission_timestamp) BETWEEN
         '{{experiment.start_date_str}}' AND
         -- Here we can restrict to the last enrollment date range.
         '{{experiment.last_enrollment_date_str}}'
-    AND event.category = 'nimbus_events'
-    AND event.name = 'enrollment'
+    AND event_category = 'nimbus_events'
+    AND event_name = 'enrollment'
     -- The background update experiment slug is exact.
-    AND mozfun.map.get_key(event.extra, 'experiment') = '{{experiment.normandy_slug}}'
+    AND JSON_VALUE(event_extra, '$.experiment') = '{{experiment.normandy_slug}}'
     -- This should never happen, but belt-and-braces.
-    AND events.metrics.uuid.background_update_client_id IS NOT NULL
+    AND JSON_VALUE(metrics, '$.uuid.background_update_client_id') IS NOT NULL
 GROUP BY analysis_id, branch
 )
 

--- a/jetstream/whats-new-notification-sidebarvertical-tabs.toml
+++ b/jetstream/whats-new-notification-sidebarvertical-tabs.toml
@@ -1,6 +1,123 @@
 
 [experiment]
 
+start_date = "2025-04-08"
+end_date = "2025-05-15"
+enrollment_period = 9
+
+# The two branches "control", "treatment-a"
+reference_branch = "control"
+
+enrollment_query = """
+SELECT * FROM
+(
+
+-- Early data shows that the 'experiments' annotation is more robust than either
+-- the 'enrollment' or the 'exposure' event in background update telemetry, see
+-- [Bug 1809275](https://bugzilla.mozilla.org/show_bug.cgi?id=1809275).  That
+-- is, some legacy client IDs do not report 'enrollment' or 'exposure' events,
+-- but do appear in `experiments` annotations.  Therefore, we use 'enrollment'
+-- events as our primary enrollment indicator but also look for an 'experiments'
+-- annotation.
+--
+-- But, some legacy client IDs that click the notification do not correspond to
+-- default profile IDs reported by background update pings: these may be due to
+-- multiple profiles, multiple OS-level users, or telemetry errors.  Some amount
+-- of such client IDs are anticipated.  We use a browsing telemetry query for
+-- these legacy client IDs.
+--
+-- Finally, we take the earliest of these two enrollment signals to determine
+-- enrollment date. This will always be before we witness a notification click,
+-- so we should not have a legacy client ID that does not have at least one
+-- analysis window containing a notification click.
+
+(
+SELECT
+    events.metrics.uuid.background_update_client_id AS client_id,
+    mozfun.map.get_key(event.extra, 'branch') AS branch,
+    MIN(DATE(events.submission_timestamp)) AS enrollment_date,
+    COUNT(events.submission_timestamp) AS num_enrollment_events
+-- We need to query from the Glean `background_update` table because pre-[Bug
+-- 1794053](https://bugzilla.mozilla.org/show_bug.cgi?id=1794053) (scheduled for
+-- Firefox 109) we don't have the legacy client ID in
+-- `mozdata.firefox_desktop_background_update.events`.
+FROM `moz-fx-data-shared-prod.firefox_desktop_background_update.background_update` events,
+UNNEST(events.events) AS event
+WHERE
+    DATE(submission_timestamp) BETWEEN
+        '{{experiment.start_date_str}}' AND
+        -- Here we can restrict to the last enrollment date range.
+        '{{experiment.last_enrollment_date_str}}'
+    AND event.category = 'nimbus_events'
+    AND event.name = 'enrollment'
+    -- The background update experiment slug is exact.
+    AND mozfun.map.get_key(event.extra, 'experiment') = '{{experiment.normandy_slug}}'
+    -- This should never happen, but belt-and-braces.
+    AND events.metrics.uuid.background_update_client_id IS NOT NULL
+GROUP BY client_id, branch
+)
+
+UNION ALL
+
+(
+SELECT
+    m.metrics.uuid.background_update_client_id AS client_id,
+    experiment.value.branch AS branch,
+    MIN(DATE(submission_timestamp)) AS enrollment_date,
+    -- These aren't discrete events, it makes no sense to count them.
+    1 AS num_enrollment_events
+-- We need to query from the Glean `background_update` table because pre-[Bug
+-- 1794053](https://bugzilla.mozilla.org/show_bug.cgi?id=1794053) (scheduled for
+-- Firefox 109) we don't have the legacy client ID in
+-- `mozdata.firefox_desktop_background_update.events`.
+FROM `mozdata.firefox_desktop_background_update.background_update` AS m
+CROSS JOIN
+    UNNEST(ping_info.experiments) AS experiment
+WHERE
+    -- Background update telemetry can be delayed, so we accept enrollment
+    -- _submission_ dates during the elongated enrollment period.  It's safer to
+    -- compare submission dates generated server-side than internal ping dates
+    -- generated client-side.
+    DATE(submission_timestamp) BETWEEN
+        '{{experiment.start_date_str}}' AND
+        '{{experiment.last_enrollment_date_str}}'
+    -- The background update experiment slug is exact.
+    AND experiment.key = '{{experiment.normandy_slug}}'
+GROUP BY client_id, branch
+)
+
+UNION ALL
+
+(
+SELECT
+    client_id AS client_id,
+    -- Post [Bug 1804988](https://bugzilla.mozilla.org/show_bug.cgi?id=1804988),
+    -- this name looks like 'slug:branch'.
+    SPLIT(mozfun.map.get_key(event_map_values, 'name'), ':')[SAFE_OFFSET(1)] AS branch,
+    MIN(submission_date) AS enrollment_date,
+    COUNT(submission_date) AS num_enrollment_events
+FROM
+    `mozdata.telemetry.events`
+WHERE
+    -- Browsing telemetry should not be delayed, but notification clicks need
+    -- not coincide with actual enrollment.
+    submission_date BETWEEN
+        '{{experiment.start_date_str}}' AND
+        '{{experiment.last_enrollment_date_str}}'
+    AND event_category = 'browser.launched_to_handle'
+    AND event_method = 'system_notification'
+    AND event_object = 'toast'
+    -- Post [Bug 1804988](https://bugzilla.mozilla.org/show_bug.cgi?id=1804988),
+    -- this name looks like 'slug:branch'.
+    AND STARTS_WITH(mozfun.map.get_key(event_map_values, 'name'), '{{experiment.normandy_slug}}:')
+GROUP BY
+    client_id, branch
+)
+
+)
+QUALIFY ROW_NUMBER() OVER (PARTITION BY client_id ORDER BY enrollment_date ASC) = 1
+"""
+
 #segment information:https://docs.telemetry.mozilla.org/concepts/segments.html
 segments = ["new_or_resurrected_v3", "regular_users_v3"]
 
@@ -30,5 +147,5 @@ description = "1 if the vertical tab count >0 else 0"
 [metrics.notification_clicks.statistics.sum]
 # Click through rate.
 [metrics.notification_clicks.statistics.binomial]
-# Average max number of taps opened. 
+# Average max number of taps opened.
 [metrics.used_vertical_tab.statistics.binomial]


### PR DESCRIPTION
Adds custom enrolment query due to enrollment happening in the [background update task profile](https://dictionary.telemetry.mozilla.org/apps/firefox_desktop_background_update?itemType=pings&page=1).

Copy paste from another Background Task experiment - [backgroundtaskmessage-notification-release-4pct-en](https://github.com/mozilla/metric-hub/blob/cd6e09a1362cb564f719479c90ade9afb53e90a8/jetstream/backgroundtaskmessage-notification-release-4pct-en.toml#L38)


[Experiment brief](https://docs.google.com/document/d/1RtRAwI0rh3SAuFosmAAQ_iVX40ZD2f_bfLgzbnBw2kc/edit?tab=t.0)
[Experiment](https://experimenter.services.mozilla.com/nimbus/whats-new-notification-sidebarvertical-tabs/summary)
[Original enrollment query](https://sql.telemetry.mozilla.org/queries/107085/source)