### PR TITLE
Create fxa_access_method.toml

### DIFF
--- a/jetstream/outcomes/firefox_desktop/fxa_access_method.toml
+++ b/jetstream/outcomes/firefox_desktop/fxa_access_method.toml
@@ -1,5 +1,6 @@
 friendly_name = "FxA Access Method"
 description = "Did they use the Account Icon or Menu to open FxA"
+default_metrics = ["fxa_toolbar_menu_button_users_clicks", "fxa_avatar_menu_clicks"]
 
 [metrics.fxa_toolbar_menu_button_users_clicks]
 select_expression = """(

--- a/jetstream/outcomes/firefox_desktop/fxa_access_method.toml
+++ b/jetstream/outcomes/firefox_desktop/fxa_access_method.toml
@@ -1,0 +1,34 @@
+friendly_name = "FxA Access Method"
+description = "Did they use the Account Icon or Menu to open FxA"
+
+[metrics]
+weekly = ['fxa_toolbar_menu_button_users_clicks', 'fxa_avatar_menu_clicks']
+overall = ['fxa_toolbar_menu_button_users_clicks', 'fxa_avatar_menu_clicks']
+
+[metrics.fxa_toolbar_menu_button_users_clicks]
+select_expression = """(
+  SUM(
+    COALESCE(mozfun.map.get_key(payload.processes.parent.keyed_scalars.browser_ui_interaction_nav_bar, 'fxa-toolbar-menu-button'),0) 
+  )
+)"""
+data_source = "main"
+friendly_name = "Clicks on the account button from users"
+description = """
+   Counts the number of times  user clicks on the account button
+"""
+
+[metrics.fxa_toolbar_menu_button_users_clicks.statistics.bootstrap_mean]
+
+
+[metrics.fxa_avatar_menu_clicks]
+friendly_name = "Clicks on the sign in option on the PXI panel"
+description = "Number of times user clicks on fxa_avatar_menu"
+select_expression = """
+      COALESCE(COUNTIF(
+         event_method= 'click'
+         AND event_object = 'login'
+         AND event_category = 'fxa_avatar_menu'
+      ),0)
+"""
+data_source = "fxa_avatar_menu_events"
+statistics = { bootstrap_mean = {} }

--- a/jetstream/outcomes/firefox_desktop/fxa_access_method.toml
+++ b/jetstream/outcomes/firefox_desktop/fxa_access_method.toml
@@ -28,3 +28,11 @@ select_expression = """
 """
 data_source = "fxa_avatar_menu_events"
 statistics = { bootstrap_mean = {} }
+
+[data_sources]
+
+[data_sources.fxa_avatar_menu_events]
+from_expression = '''(SELECT * FROM `mozdata.telemetry.events` WHERE event_category = 'fxa_avatar_menu')'''
+experiments_column_type = "native"
+friendly_name = "FxA Avatar Menu Events"
+description = "Events Ping filtered to only include FxA Avatar Menu event category"

--- a/jetstream/outcomes/firefox_desktop/fxa_access_method.toml
+++ b/jetstream/outcomes/firefox_desktop/fxa_access_method.toml
@@ -1,10 +1,6 @@
 friendly_name = "FxA Access Method"
 description = "Did they use the Account Icon or Menu to open FxA"
 
-[metrics]
-weekly = ['fxa_toolbar_menu_button_users_clicks', 'fxa_avatar_menu_clicks']
-overall = ['fxa_toolbar_menu_button_users_clicks', 'fxa_avatar_menu_clicks']
-
 [metrics.fxa_toolbar_menu_button_users_clicks]
 select_expression = """(
   SUM(

--- a/jetstream/outcomes/firefox_desktop/fxa_access_method.toml
+++ b/jetstream/outcomes/firefox_desktop/fxa_access_method.toml
@@ -1,6 +1,5 @@
 friendly_name = "FxA Access Method"
 description = "Did they use the Account Icon or Menu to open FxA"
-default_metrics = ["fxa_toolbar_menu_button_users_clicks", "fxa_avatar_menu_clicks"]
 
 [metrics.fxa_toolbar_menu_button_users_clicks]
 select_expression = """(


### PR DESCRIPTION
Taking 2 metrics on FxA access method from https://github.com/mozilla/metric-hub/blob/main/jetstream/device-migration-accounts-toolbar-icon.toml and adding to an outcome