### PR TITLE
feat: add support for new events_stream experiments_column_type

### DIFF
--- a/lib/metric-config-parser/metric_config_parser/data_source.py
+++ b/lib/metric-config-parser/metric_config_parser/data_source.py
@@ -64,6 +64,12 @@ class DataSource:
               (experiment_slug:str -> struct) map, where the struct
               contains a ``branch`` field, which is the branch as a
               string.
+            * 'glean': There is an ``experiments`` column inside ping_info,
+              which is an (experiment_slug:str -> struct) map, where the
+              struct contains a ``branch`` field, which is the branch as a
+              string.
+            * 'events_stream': There is an ``experiment`` within a JSON
+              column ``event_extra``. ``branch`` is in the same column.
             * None: There is no ``experiments`` column, so skip the
               sanity checks that rely on it. We'll also be unable to
               filter out pre-enrollment data from day 0 in the
@@ -116,7 +122,7 @@ class DataSource:
     glean_client_id_column = attr.ib(default=None, type=str)
     legacy_client_id_column = attr.ib(default=None, type=str)
 
-    EXPERIMENT_COLUMN_TYPES = (None, "simple", "native", "glean")
+    EXPERIMENT_COLUMN_TYPES = (None, "simple", "native", "glean", "events_stream")
 
     @experiments_column_type.validator
     def _check_experiments_column_type(self, attribute, value):

--- a/lib/metric-config-parser/pyproject.toml
+++ b/lib/metric-config-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-metric-config-parser"
-version = "2025.5.2"
+version = "2025.5.3"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Parses metric configuration files"
 readme = "README.md"


### PR DESCRIPTION
@relud recently added support for `events_stream` as an `experiments_column_type`, but in order to configure that it needs to be in metric-config-parser as well. This adds that support (along with doc update).