### PR TITLE
fix: try to make metrics query less complex

### DIFF
--- a/jetstream/first-time-wallpaper-newtab.toml
+++ b/jetstream/first-time-wallpaper-newtab.toml
@@ -15,3 +15,45 @@ select_expression = 'SUM(0)'
 select_expression = 'SUM(0)'
 [metrics.new_tab_enabled_on_new_tabs]
 select_expression = 'SUM(0)'
+
+
+[data_sources.main]
+from_expression = """(
+    SELECT
+        client_id,
+        DATE(submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.telemetry_stable.main_v5`
+    WHERE DATE(submission_timestamp) = '2025-03-04'
+)"""
+experiments_column_type = "none"
+friendly_name = "Main no-op"
+description = "Main ping table without meaningful metrics"
+
+[data_sources.as_sessions]
+from_expression = """(
+    SELECT
+        client_id,
+        DATE(submission_timestamp) AS submission_date
+    FROM mozdata.activity_stream.sessions
+        WHERE DATE(submission_timestamp) = '2025-03-04'
+    )"""
+experiments_column_type = "none"
+friendly_name = "Activity Stream Sessions no-op"
+description = "Activity Stream Sessions without meaningful metrics"
+
+[data_sources.newtab_visits_topsite_tile_interactions]
+from_expression = """(
+    SELECT
+        e.* EXCEPT (topsite_tile_interactions),
+        topsite_tile_interactions
+    FROM
+        `moz-fx-data-shared-prod.telemetry.newtab_visits` e
+    CROSS JOIN
+        UNNEST(e.topsite_tile_interactions) AS topsite_tile_interactions
+    WHERE channel = 'release'
+)"""
+submission_date_column = "submission_date"
+description = "Topsite Tiles Visit Activity Daily"
+friendly_name = "Topsite Tiles Visit Activity Daily"
+client_id_column = "legacy_telemetry_client_id"
+experiments_column_type = "native"


### PR DESCRIPTION
In the cases where we're doing no-ops for their metrics, we change the data sources themselves to essentially no-ops as well (date filter to a single day outside of the experiment window, only select client_id and submission_date).

I also added a channel filter to the `newtab_visits_topsite_tile_interactions` data source because it's a cluster field. I don't expect a big difference, but it did cut down a tiny bit on the expected data to be processed. If we need to optimize further, we should eliminate that data_source altogether.