### PR TITLE
ETP and webcompat reporter statistics should be binomial

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1847,17 +1847,17 @@ type = "scalar"
 description = "Did a desktop user sync to mobile"
 
 [metrics.site_breakage_impressions]
-select_expression = "COALESCE(COUNTIF(event_name = 'opened'), 0)"
+select_expression = "COALESCE(LOGICAL_OR(event_name = 'opened'), FALSE)"
 data_source = "site_breakage_events"
 friendly_name = "Webcompat Reporting Panel Impressions"
 
 [metrics.site_breakage_uses]
-select_expression = "COALESCE(COUNTIF(event_name = 'send' OR event_name = 'send_more_info'), 0)"
+select_expression = "COALESCE(LOGICAL_OR(event_name = 'send' OR event_name = 'send_more_info'), FALSE)"
 data_source = "site_breakage_events"
 friendly_name = "Webcompat Reporting Panel Uses"
 
 [metrics.etp_disablement]
-select_expression = "COALESCE(COUNTIF(event_name  = 'click_etp_toggle_off'), 0)"
+select_expression = "COALESCE(LOGICAL_OR(event_name  = 'click_etp_toggle_off'), FALSE)"
 data_source = "protections_popup_events"
 friendly_name = "ETP Disablement"
 

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -2222,7 +2222,7 @@ deprecated = false
 [data_sources.site_breakage_events]
 from_expression = """(
     SELECT
-        client_id,
+        legacy_telemetry_client_id as client_id,
         DATE(submission_timestamp) AS submission_date,
         experiments,
         event_name,
@@ -2238,7 +2238,7 @@ description = "Webcompat 'Report Broken Site' pings"
 [data_sources.protections_popup_events]
 from_expression = """(
     SELECT
-        client_id,
+        legacy_telemetry_client_id as client_id,
         DATE(submission_timestamp) AS submission_date,
         experiments,
         event_name,

--- a/jetstream/outcomes/firefox_desktop/webcompat.toml
+++ b/jetstream/outcomes/firefox_desktop/webcompat.toml
@@ -6,14 +6,7 @@ webcompat reporting panel impressions,
 and webcompat reporting panel uses.
 """
 
-[metrics.etp_disablement.statistics.bootstrap_mean]
-[metrics.etp_disablement.statistics.deciles]
-
+[metrics.etp_disablement.statistics.binomial]
 [metrics.tab_reload_count.statistics.bootstrap_mean]
-[metrics.tab_reload_count.statistics.deciles]
-
-[metrics.site_breakage_impressions.statistics.bootstrap_mean]
-[metrics.site_breakage_impressions.statistics.deciles]
-
-[metrics.site_breakage_uses.statistics.bootstrap_mean]
-[metrics.site_breakage_uses.statistics.deciles]
+[metrics.site_breakage_impressions.statistics.binomial]
+[metrics.site_breakage_uses.statistics.binomial]

--- a/jetstream/storage-access-grant-heuristic-restriction.toml
+++ b/jetstream/storage-access-grant-heuristic-restriction.toml
@@ -7,17 +7,12 @@ and webcompat reporting panel uses.
 """
 
 [metrics]
+daily = ["etp_disablement", "tab_reload_count", "site_breakage_impressions", "site_breakage_uses"]
 weekly = ["etp_disablement", "tab_reload_count", "site_breakage_impressions", "site_breakage_uses"]
 overall = ["etp_disablement", "tab_reload_count", "site_breakage_impressions", "site_breakage_uses"]
 
-[metrics.etp_disablement.statistics.bootstrap_mean]
-[metrics.etp_disablement.statistics.deciles]
-
+[metrics.etp_disablement.statistics.binomial]
 [metrics.tab_reload_count.statistics.bootstrap_mean]
 [metrics.tab_reload_count.statistics.deciles]
-
-[metrics.site_breakage_impressions.statistics.bootstrap_mean]
-[metrics.site_breakage_impressions.statistics.deciles]
-
-[metrics.site_breakage_uses.statistics.bootstrap_mean]
-[metrics.site_breakage_uses.statistics.deciles]
+[metrics.site_breakage_impressions.statistics.binomial]
+[metrics.site_breakage_uses.statistics.binomial]


### PR DESCRIPTION
Bootstrap means don't work because the data is driven by outliers. We want to look for a surge in outliers, not ignore them!