### PR TITLE
Update search-result-de-duplication.toml

### DIFF
--- a/jetstream/search-result-de-duplication.toml
+++ b/jetstream/search-result-de-duplication.toml
@@ -78,31 +78,3 @@ description = "Proportion of urlbar sessions where suggestion from the default s
 [metrics.search_suggestion_ctr.statistics.population_ratio]
 numerator = "search_suggestion_clicks"
 denominator = "search_suggestion_impressions"
-
-## Impression Rate
-[metrics.history_impression_rate]
-depends_on = ["history_impressions", "urlbar_impressions_suggest"]
-friendly_name = "History Impression Rate"
-description = "Proportion of history impressions out of all urlbar sessions (not available on control)"
-
-[metrics.history_impression_rate.statistics.population_ratio]
-numerator = "history_impressions"
-denominator = "urlbar_impressions_suggest"
-
-[metrics.bookmark_impression_rate]
-depends_on = ["bookmark_impressions", "urlbar_impressions_suggest"]
-friendly_name = "Bookmark Impression Rate"
-description = "Proportion of bookmark impressions out of all urlbar sessions (not available on control)"
-
-[metrics.bookmark_impression_rate.statistics.population_ratio]
-numerator = "bookmark_impressions"
-denominator = "urlbar_impressions_suggest"
-
-[metrics.search_suggestion_impression_rate]
-depends_on = ["search_suggestion_impressions", "urlbar_impressions_suggest"]
-friendly_name = "Search suggestion Impression Rate"
-description = "Proportion of search suggestion impressions out of all urlbar sessions (not available on control)"
-
-[metrics.search_suggestion_impression_rate.statistics.population_ratio]
-numerator = "search_suggestion_impressions"
-denominator = "urlbar_impressions_suggest"


### PR DESCRIPTION
the metric would not complete.  the impression rate is the newer metrics - so I removed that.  it could be that 4 metrics for 4 suggestion types is too much?

until the metrics are reworked to optimized tables - i put the impression rate metric info here https://docs.google.com/document/d/1mTN_Rcm9JpyhTkXKvvHEcvwWUVoQ57n0mWo5MFXR_sM/edit?tab=t.0