### PR TITLE
feat: optimize awesomebar outcome with events_stream

### DIFF
--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -595,6 +595,21 @@ friendly_name = "Events"
 description = "Events Ping"
 build_id_column = "REPLACE(CAST(DATE(mozfun.norm.fenix_build_to_datetime(client_info.app_build)) AS STRING), '-', '')"
 
+
+[data_sources.events_stream_awesomebar]
+from_expression = """(
+    SELECT
+        p.*,
+        DATE(p.submission_timestamp) AS submission_date
+    FROM
+        `moz-fx-data-shared-prod.{dataset}.events_stream` p
+    WHERE event_category IN ('urlbar', 'awesomebar')
+)"""
+experiments_column_type = "events_stream"
+default_dataset = "org_mozilla_firefox"
+friendly_name = "Awesomebar Events"
+description = "Glean Awesomebar Events Stream"
+
 [data_sources.metrics]
 from_expression = """(
     SELECT

--- a/jetstream/outcomes/fenix/awesomebar.toml
+++ b/jetstream/outcomes/fenix/awesomebar.toml
@@ -5,16 +5,16 @@ description = "Metrics that describe user interactions with the Awesomebar."
 friendly_name = "Awesomebar Engagement"
 description = "Number of times a user completed their search session by tapping a search result, or entering a URL or a search term."
 select_expression = """
-    COALESCE(COUNTIF((event.category IN ('urlbar', 'awesomebar')) AND (event.name = 'engagement')), 0)
+    COALESCE(COUNTIF(event_name = 'engagement'), 0)
 """
-data_source = "events"
+data_source = "events_stream_awesomebar"
 statistics = { sum = {}, bootstrap_mean = {}, deciles = {} }
 
 [metrics.awesomebar_abandonment]
 friendly_name = "Awesomebar Abandonment"
 description = "Number of times a user dismissed the awesomebar without completing their search."
 select_expression = """
-    COALESCE(COUNTIF((event.category IN ('urlbar', 'awesomebar')) AND (event.name = 'abandonment')), 0)
+    COALESCE(COUNTIF(event_name = 'abandonment'), 0)
 """
-data_source = "events"
+data_source = "events_stream_awesomebar"
 statistics = { sum = {}, bootstrap_mean = {}, deciles = {} }


### PR DESCRIPTION
An experiment using this outcome timed out in bigquery, using `events_stream` here seems like an easy fix.