### PR TITLE
Adding median and p95 to hnt visit duration

### DIFF
--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -143,8 +143,20 @@ denominator = "ad_impressions.sum"
 [metrics.avg_visit_duration]
 select_expression = "AVG(avg_duration_seconds)"
 data_source = "newtab_visit_duration"
-friendly_name = "HNT visit duration (seconds)"
+friendly_name = "Avg HNT visit duration (seconds)"
 description ="Home Newtab (HNT) average visit duration in seconds"
+
+[metrics.p50_visit_duration]
+select_expression = "AVG(p50_duration_seconds)"
+data_source = "newtab_visit_duration"
+friendly_name = "Median HNT visit duration (seconds)"
+description ="Home Newtab (HNT) median / p50 visit duration in seconds"
+
+[metrics.p95_visit_duration]
+select_expression = "AVG(p95_duration_seconds)"
+data_source = "newtab_visit_duration"
+friendly_name = "P95 HNT visit duration (seconds)"
+description ="Home Newtab (HNT) p95 visit duration in seconds"
 
 ### data_sources.ad_metrics_daily
 [metrics.ads_count]

--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -139,6 +139,12 @@ description ="Ad spend"
 numerator = "ad_clicks.sum"
 denominator = "ad_impressions.sum"
 
+### data_sources.newtab_visit_duration
+[metrics.avg_visit_duration]
+select_expression = "AVG(avg_duration_seconds)"
+data_source = "newtab_visit_duration"
+friendly_name = "HNT visit duration (seconds)"
+description ="HNT visit duration in seconds"
 
 [data_sources.consolidated_ads_spocs]
 from_expression = """
@@ -226,3 +232,9 @@ columns_as_dimensions = true
 submission_date_column = "submission_date"
 client_id_column = "NULL"
 
+#Temporary reporting requirement while HNT P2 metrics are finalized
+[data_sources.newtab_visit_duration]
+from_expression = "moz-fx-data-shared-prod.ads.newtab_visit_duration"
+submission_date_column = "week"
+client_id_column = "NULL"
+columns_as_dimensions = true


### PR DESCRIPTION
Adding median and p95 as metric to HNT visit duration after raising concerns about the right-skewness of distribution and the larger-than-expected averages.