### PR TITLE
update all the single quote ratios to double quotes

### DIFF
--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -176,14 +176,14 @@ description = "Revenue Per Ad"
 [metrics.revenue.statistics.sum]
 [metrics.milli_impressions.statistics.sum]
 [metrics.ecpm.statistics.ratio]
-numerator = 'revenue.sum'
-denominator = 'milli_impressions.sum'
+numerator = "revenue.sum"
+denominator = "milli_impressions.sum"
 [metrics.click_through_rate.statistics.ratio]
-numerator = 'clicks.sum'
-denominator = 'impressions.sum'
+numerator = "clicks.sum"
+denominator = "impressions.sum"
 [metrics.revenue_per_ad.statistics.ratio]
-numerator = 'revenue.sum'
-denominator = 'ads_count.sum'
+numerator = "revenue.sum"
+denominator = "ads_count.sum"
 
 [data_sources.consolidated_ads_spocs]
 from_expression = """

--- a/looker/definitions/firefox_desktop.toml
+++ b/looker/definitions/firefox_desktop.toml
@@ -382,12 +382,12 @@ description = "Count of clients with others engagement"
 [metrics.sponsored_impressions.statistics.client_count]
 
 [metrics.sponsored_tile_ctr.statistics.ratio]
-numerator='sponsored_tile_clicks.sum'
-denominator='sponsored_tile_impressions.sum'
+numerator="sponsored_tile_clicks.sum"
+denominator="sponsored_tile_impressions.sum"
 
 [metrics.sponsored_pocket_ctr.statistics.ratio]
-numerator='sponsored_pocket_clicks.sum'
-denominator='sponsored_pocket_impressions.sum'
+numerator="sponsored_pocket_clicks.sum"
+denominator="sponsored_pocket_impressions.sum"
 
 [metrics.client_count]
 data_source = "newtab_clients_daily"
@@ -417,16 +417,16 @@ Number of sponsored impressions (content and tiles on New Tab) divided by number
 """
 
 [metrics.sponsored_pocket_impressions_per_client.statistics.ratio]
-numerator='sponsored_pocket_impressions.sum'
-denominator='client_count.sum'
+numerator="sponsored_pocket_impressions.sum"
+denominator="client_count.sum"
 
 [metrics.sponsored_topsite_tile_impressions_per_client.statistics.ratio]
-numerator='sponsored_topsite_tile_impressions.sum'
-denominator='client_count.sum'
+numerator="sponsored_topsite_tile_impressions.sum"
+denominator="client_count.sum"
 
 [metrics.sponsored_impressions_per_client.statistics.ratio]
-numerator='sponsored_impressions.sum'
-denominator='client_count.sum'
+numerator="sponsored_impressions.sum"
+denominator="client_count.sum"
 # Data sources
 
 [data_sources.looker_base_fields]

--- a/looker/definitions/firefox_desktop.toml
+++ b/looker/definitions/firefox_desktop.toml
@@ -389,12 +389,6 @@ denominator="sponsored_tile_impressions.sum"
 numerator="sponsored_pocket_clicks.sum"
 denominator="sponsored_pocket_impressions.sum"
 
-[metrics.client_count]
-data_source = "newtab_clients_daily"
-select_expression = "COUNT(DISTINCT client_id)"
-friendly_name = "Client Count"
-description = "Count of clients"
-
 [metrics.sponsored_pocket_impressions_per_client]
 depends_on=['sponsored_pocket_impressions', 'client_count']
 friendly_name = "Sponsored Pocket Impressions Per Client"
@@ -418,15 +412,15 @@ Number of sponsored impressions (content and tiles on New Tab) divided by number
 
 [metrics.sponsored_pocket_impressions_per_client.statistics.ratio]
 numerator="sponsored_pocket_impressions.sum"
-denominator="client_count.sum"
+denominator="sponsored_pocket_impressions.client_count"
 
 [metrics.sponsored_topsite_tile_impressions_per_client.statistics.ratio]
 numerator="sponsored_topsite_tile_impressions.sum"
-denominator="client_count.sum"
+denominator="csponsored_topsite_tile_impressions.client_count"
 
 [metrics.sponsored_impressions_per_client.statistics.ratio]
 numerator="sponsored_impressions.sum"
-denominator="client_count.sum"
+denominator="sponsored_impressions.client_count"
 # Data sources
 
 [data_sources.looker_base_fields]


### PR DESCRIPTION
The ratio statistics are still not showing up in Looker, maybe it's not expecting single quotes so I'm updating these to double quotes to see if that'll fix the problem. If not, then it suggests my initial concern with the naming of the statistics might be the problem