### PR TITLE
[ci rerun-skip] fix: noop everything non-default

### DIFF
--- a/jetstream/first-time-wallpaper-newtab.toml
+++ b/jetstream/first-time-wallpaper-newtab.toml
@@ -1,100 +1,88 @@
 [experiment]
 reference_branch = "control"
 
-#overwriting metrics that likely caused crash
-#(ones that use the main ping) with a no-op
+# overwrite all non-default metrics with no-op
 
 [metrics]
 
 [metrics.newtab_sessions]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.saw_newtab]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.new_tab_enabled_in_new_windows]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.new_tab_enabled_on_new_tabs]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 
 [metrics.organic_pocket_clicks]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.newtab_searches]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.newtab_pocket_enabled]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.newtab_sponsored_pocket_stories_enabled]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.organic_pocket_impressions]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.sponsored_pocket_ctr]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.sponsored_tiles_disabled]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.any_sponsored_tiles_dismissals]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.sponsored_tiles_dismissals]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.sponsored_tiles_dismissals_pos1_2]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.newtab_any_searches]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.newtab_gt4_searches]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.sponsored_tile_clicks]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.sponsored_tile_impressions]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.newtab_organic_topsite_clicks]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.newtab_organic_topsite_impressions]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.sponsored_pocket_clicks]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.sponsored_pocket_impressions]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 [metrics.sponsored_tile_ctr]
 select_expression = 'SUM(0)'
+data_source = "noop_source"
 
 
-data_source = "main"
-
-
-[data_sources.main]
+[data_sources.noop_source]
 from_expression = """(
     SELECT
-        client_id,
-        DATE(submission_timestamp) AS submission_date
-    FROM `moz-fx-data-shared-prod.telemetry_stable.main_v5`
-    WHERE DATE(submission_timestamp) = '2025-03-04'
+        '1234' AS client_id,
+        DATE('2022-01-01') AS submission_date
 )"""
 experiments_column_type = "none"
-friendly_name = "Main no-op"
-description = "Main ping table without meaningful metrics"
-
-[data_sources.as_sessions]
-from_expression = """(
-    SELECT
-        client_id,
-        DATE(submission_timestamp) AS submission_date
-    FROM mozdata.activity_stream.sessions
-        WHERE DATE(submission_timestamp) = '2025-03-04'
-    )"""
-experiments_column_type = "none"
-friendly_name = "Activity Stream Sessions no-op"
-description = "Activity Stream Sessions without meaningful metrics"
-
-[data_sources.newtab_visits_topsite_tile_interactions]
-from_expression = """(
-    SELECT
-        e.* EXCEPT (topsite_tile_interactions),
-        topsite_tile_interactions
-    FROM
-        `moz-fx-data-shared-prod.telemetry.newtab_visits` e
-    CROSS JOIN
-        UNNEST(e.topsite_tile_interactions) AS topsite_tile_interactions
-    WHERE channel = 'release'
-)"""
-submission_date_column = "submission_date"
-description = "Topsite Tiles Visit Activity Daily"
-friendly_name = "Topsite Tiles Visit Activity Daily"
-client_id_column = "legacy_telemetry_client_id"
-experiments_column_type = "native"
+friendly_name = "No-Op"
+description = "No-op that creates the required columns"


### PR DESCRIPTION
This should overwrite every non-default metric with `SUM(0)` and use a no-op data source that only creates the required columns and does not reference any tables.