### PR TITLE
Fix ratio statistics naming and remove unused metrics

### DIFF
--- a/definitions/ads.toml
+++ b/definitions/ads.toml
@@ -71,20 +71,6 @@ type = "scalar"
 friendly_name = "Revenue"
 description = "Ad revenue"
 
-[metrics.ecpm]
-depends_on = ['revenue', 'milli_impressions']
-data_source = "ad_metrics_daily"
-type = "scalar"
-friendly_name = "eCPM"
-description = "effective CPM, calculated as average revenue per thousand impressions"
-
-[metrics.click_through_rate]
-depends_on = ['clicks', 'impressions']
-data_source = "ad_metrics_daily"
-type = "scalar"
-friendly_name = "Click Through Rate"
-description = "Ratio of ad clicks to ad impressions"
-
 [metrics.milli_impressions]
 select_expression = "SUM(impressions)/1000"
 data_source = "ad_metrics_daily"

--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -165,17 +165,37 @@ data_source = "ad_metrics_daily"
 friendly_name = "Ads Count"
 description = "Number of unique ads served"
 
+[metrics.revenue_per_ad]
+select_expression = SUM(1)
+data_source = "ad_metrics_daily"
+friendly_name =  "Revenue Per Ad"
+description = "Revenue Per Ad"
+
+[metrics.ecpm]
+select_expression = SUM(1)
+data_source = "ad_metrics_daily"
+type = "scalar"
+friendly_name = "eCPM"
+description = "effective CPM, calculated as average revenue per thousand impressions"
+
+[metrics.click_through_rate]
+select_expression = SUM(1)
+data_source = "ad_metrics_daily"
+type = "scalar"
+friendly_name = "Click Through Rate"
+description = "Ratio of ad clicks to ad impressions"
+
 [metrics.ad_metrics_ad_impressions.statistics.sum]
 [metrics.ad_metrics_ad_clicks.statistics.sum]
 [metrics.revenue.statistics.sum]
 [metrics.milli_impressions.statistics.sum]
-[metrics.milli_impressions.statistics.ratio]
+[metrics.ecpm.statistics.ratio]
 numerator = "revenue.sum"
 denominator = "milli_impressions.sum"
-[metrics.clicks.statistics.ratio]
+[metrics.click_through_rate.statistics.ratio]
 numerator = "clicks.sum"
 denominator = "impressions.sum"
-[metrics.ads_count.statistics.ratio]
+[metrics.revenue_per_ad.statistics.ratio]
 numerator = "revenue.sum"
 denominator = "ads_count.sum"
 

--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -166,20 +166,20 @@ friendly_name = "Ads Count"
 description = "Number of unique ads served"
 
 [metrics.revenue_per_ad]
-select_expression = SUM(1)
+select_expression = "SUM(1)"
 data_source = "ad_metrics_daily"
 friendly_name =  "Revenue Per Ad"
 description = "Revenue Per Ad"
 
 [metrics.ecpm]
-select_expression = SUM(1)
+select_expression = "SUM(1)"
 data_source = "ad_metrics_daily"
 type = "scalar"
 friendly_name = "eCPM"
 description = "effective CPM, calculated as average revenue per thousand impressions"
 
 [metrics.click_through_rate]
-select_expression = SUM(1)
+select_expression = "SUM(1)"
 data_source = "ad_metrics_daily"
 type = "scalar"
 friendly_name = "Click Through Rate"

--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -165,25 +165,19 @@ data_source = "ad_metrics_daily"
 friendly_name = "Ads Count"
 description = "Number of unique ads served"
 
-[metrics.revenue_per_ad]
-depends_on = ['ads_count', 'revenue']
-data_source = "ad_metrics_daily"
-friendly_name =  "Revenue Per Ad"
-description = "Revenue Per Ad"
-
 [metrics.ad_metrics_ad_impressions.statistics.sum]
 [metrics.ad_metrics_ad_clicks.statistics.sum]
 [metrics.revenue.statistics.sum]
 [metrics.milli_impressions.statistics.sum]
-[metrics.ecpm.statistics.ratio]
-numerator = 'revenue.sum'
-denominator = 'milli_impressions.sum'
-[metrics.click_through_rate.statistics.ratio]
-numerator = 'clicks.sum'
-denominator = 'impressions.sum'
-[metrics.revenue_per_ad.statistics.ratio]
-numerator = 'revenue.sum'
-denominator = 'ads_count.sum'
+[metrics.milli_impressions.statistics.ratio]
+numerator = "revenue.sum"
+denominator = "milli_impressions.sum"
+[metrics.clicks.statistics.ratio]
+numerator = "clicks.sum"
+denominator = "impressions.sum"
+[metrics.ads_count.statistics.ratio]
+numerator = "revenue.sum"
+denominator = "ads_count.sum"
 
 [data_sources.consolidated_ads_spocs]
 from_expression = """

--- a/looker/definitions/firefox_desktop.toml
+++ b/looker/definitions/firefox_desktop.toml
@@ -382,18 +382,13 @@ description = "Count of clients with others engagement"
 [metrics.sponsored_impressions.statistics.client_count]
 
 [metrics.sponsored_tile_clicks.statistics.ratio]
-numerator = "sponsored_tile_clicks.sum'
-denominator = "sponsored_tile_impressions.sum'
+numerator = "sponsored_tile_clicks.sum"
+denominator = "sponsored_tile_impressions.sum"
 
 [metrics.sponsored_pocket_clicks.statistics.ratio]
-numerator = "sponsored_pocket_clicks.sum'
-denominator = "sponsored_pocket_impressions.sum'
+numerator = "sponsored_pocket_clicks.sum"
+denominator = "sponsored_pocket_impressions.sum"
 
-[metrics.client_count]
-data_source = "newtab_clients_daily"
-select_expression = "COUNT(DISTINCT client_id)"
-friendly_name = "Client Count"
-description = "Count of clients"
 
 [metrics.sponsored_pocket_impressions_per_client]
 data_source = "newtab_clients_daily"

--- a/looker/definitions/firefox_desktop.toml
+++ b/looker/definitions/firefox_desktop.toml
@@ -392,7 +392,7 @@ denominator = "sponsored_pocket_impressions.sum"
 
 [metrics.sponsored_pocket_impressions_per_client]
 data_source = "newtab_clients_daily"
-select_expression = SUM(1)
+select_expression = "SUM(1)"
 friendly_name = "Sponsored Pocket Impressions Per Client"
 description = """
 Number of sponsored content impressions divided by number of clients
@@ -400,7 +400,7 @@ Number of sponsored content impressions divided by number of clients
 
 [metrics.sponsored_topsite_tile_impressions_per_client]
 data_source = "newtab_clients_daily"
-select_expression = SUM(1)
+select_expression = "SUM(1)"
 friendly_name = "Sponsored Topsite Tile Impressions Per Client"
 description = """
 Number of sponsored topsite tile impressions divided by number of clients
@@ -408,7 +408,7 @@ Number of sponsored topsite tile impressions divided by number of clients
 
 [metrics.sponsored_impressions_per_client]
 data_source = "newtab_clients_daily"
-select_expression = SUM(1)
+select_expression = "SUM(1)"
 friendly_name = "Sponsored Impressions Per Client"
 description = """
 Number of sponsored impressions (content and tiles on New Tab) divided by number of clients

--- a/looker/definitions/firefox_desktop.toml
+++ b/looker/definitions/firefox_desktop.toml
@@ -381,13 +381,13 @@ description = "Count of clients with others engagement"
 [metrics.sponsored_pocket_clicks.statistics.client_count]
 [metrics.sponsored_impressions.statistics.client_count]
 
-[metrics.sponsored_tile_ctr.statistics.ratio]
-numerator='sponsored_tile_clicks.sum'
-denominator='sponsored_tile_impressions.sum'
+[metrics.sponsored_tile_clicks.statistics.ratio]
+numerator = "sponsored_tile_clicks.sum'
+denominator = "sponsored_tile_impressions.sum'
 
-[metrics.sponsored_pocket_ctr.statistics.ratio]
-numerator='sponsored_pocket_clicks.sum'
-denominator='sponsored_pocket_impressions.sum'
+[metrics.sponsored_pocket_clicks.statistics.ratio]
+numerator = "sponsored_pocket_clicks.sum'
+denominator = "sponsored_pocket_impressions.sum'
 
 [metrics.client_count]
 data_source = "newtab_clients_daily"
@@ -396,37 +396,40 @@ friendly_name = "Client Count"
 description = "Count of clients"
 
 [metrics.sponsored_pocket_impressions_per_client]
-depends_on=['sponsored_pocket_impressions', 'client_count']
+data_source = "newtab_clients_daily"
+select_expression = SUM(1)
 friendly_name = "Sponsored Pocket Impressions Per Client"
 description = """
 Number of sponsored content impressions divided by number of clients
 """
 
 [metrics.sponsored_topsite_tile_impressions_per_client]
-depends_on=['sponsored_topsite_tile_impressions', 'client_count']
+data_source = "newtab_clients_daily"
+select_expression = SUM(1)
 friendly_name = "Sponsored Topsite Tile Impressions Per Client"
 description = """
 Number of sponsored topsite tile impressions divided by number of clients
 """
 
 [metrics.sponsored_impressions_per_client]
-depends_on=['sponsored_impressions', 'client_count']
+data_source = "newtab_clients_daily"
+select_expression = SUM(1)
 friendly_name = "Sponsored Impressions Per Client"
 description = """
 Number of sponsored impressions (content and tiles on New Tab) divided by number of clients
 """
 
 [metrics.sponsored_pocket_impressions_per_client.statistics.ratio]
-numerator='sponsored_pocket_impressions.sum'
-denominator='client_count.sum'
+numerator = "sponsored_pocket_impressions.sum"
+denominator = "sponsored_impressions.client_count"
 
 [metrics.sponsored_topsite_tile_impressions_per_client.statistics.ratio]
-numerator='sponsored_topsite_tile_impressions.sum'
-denominator='client_count.sum'
+numerator = "sponsored_topsite_tile_impressions.sum"
+denominator = "sponsored_impressions.client_count"
 
 [metrics.sponsored_impressions_per_client.statistics.ratio]
-numerator='sponsored_impressions.sum'
-denominator='client_count.sum'
+numerator = "sponsored_impressions.sum"
+denominator = "sponsored_impressions.client_count"
 # Data sources
 
 [data_sources.looker_base_fields]


### PR DESCRIPTION
The problem with these statistics was that we weren't able to surface the metric before, the `depends_on` functionality was not yet live so this is a workaround to surface the metrics so we can create ratio statistics with them. The reason to go this route and not just name the ratio after the numerator is because we have some ratios that use the same numerator and would not be able to share a name. Some naming conventions though are actually commonly used, like clicks.ratio is common for CTR, so those seemed ok to keep. 

My general approach was to only use SUM(1) in the looker layer metric definitions because it's solely for looker purposes. 

For the future, if `depends_on` does become live, we can change all SUM(1) instances back to `depends_on`