### PR TITLE
Fix build docs

### DIFF
--- a/.script/generate_docs.py
+++ b/.script/generate_docs.py
@@ -289,7 +289,12 @@ def generate_outcome_docs(out_dir: Path):
                 deduplicated_metrics.append(metric)
         metrics = deduplicated_metrics
 
-        data_sources = {m.data_source for m in metrics}
+        # deduplicate data source objects by name, but keep the object
+        data_sources = {}
+        for m in metrics:
+            if m.data_source is not None:
+                data_sources[m.data_source.name] = m.data_source
+        data_sources = list(data_sources.values())
 
         statistics_per_metric = {}
         for metric in metrics:
@@ -377,7 +382,12 @@ def generate_default_config_docs(out_dir: Path):
                 if metric.metric not in metrics:
                     metrics.append(metric.metric)
 
-            data_sources = {m.data_source for m in metrics}
+            # deduplicate data source objects by name, but keep the object
+            data_sources = {}
+            for m in metrics:
+                if m.data_source is not None:
+                    data_sources[m.data_source.name] = m.data_source
+            data_sources = list(data_sources.values())
 
             statistics_per_metric = {}
             for metric in metrics:

--- a/lib/metric-config-parser/metric_config_parser/data_source.py
+++ b/lib/metric-config-parser/metric_config_parser/data_source.py
@@ -153,25 +153,6 @@ class DataSource:
                 ) from e
         return self.from_expression.format(dataset=effective_dataset)
 
-    def __hash__(self):
-        return hash((
-            self.name,
-            self.from_expression,
-            self.experiments_column_type,
-            self.client_id_column,
-            self.submission_date_column,
-            self.default_dataset,
-            self.build_id_column,
-            self.friendly_name,
-            self.description,
-            tuple(self.joins) if self.joins is not None else None,
-            self.columns_as_dimensions,
-            tuple(self.analysis_units) if self.analysis_units is not None else None,
-            self.group_id_column,
-            self.glean_client_id_column,
-            self.legacy_client_id_column,
-        ))
-
 
 @attr.s(auto_attribs=True)
 class DataSourceReference:

--- a/lib/metric-config-parser/metric_config_parser/data_source.py
+++ b/lib/metric-config-parser/metric_config_parser/data_source.py
@@ -153,6 +153,25 @@ class DataSource:
                 ) from e
         return self.from_expression.format(dataset=effective_dataset)
 
+    def __hash__(self):
+        return hash((
+            self.name,
+            self.from_expression,
+            self.experiments_column_type,
+            self.client_id_column,
+            self.submission_date_column,
+            self.default_dataset,
+            self.build_id_column,
+            self.friendly_name,
+            self.description,
+            tuple(self.joins) if self.joins is not None else None,
+            self.columns_as_dimensions,
+            tuple(self.analysis_units) if self.analysis_units is not None else None,
+            self.group_id_column,
+            self.glean_client_id_column,
+            self.legacy_client_id_column,
+        ))
+
 
 @attr.s(auto_attribs=True)
 class DataSourceReference:


### PR DESCRIPTION
fixes https://github.com/mozilla/metric-hub/issues/995

`DataSource`s are no longer hasheable, so to get unique data sources the `generate_docs` script builds a dict