### PR TITLE
[DENG-9079] Use moz-fx-data-shared-prod dryrun function for validation + authenticate in CI

### DIFF
--- a/.circleci/validation-config.yml
+++ b/.circleci/validation-config.yml
@@ -68,6 +68,7 @@ jobs:
       REVISION_COMMIT: << pipeline.git.revision >>
     steps:
     - checkout
+    - *authenticate
     - run:
         name: Validate OpMon config files
         command: |
@@ -83,6 +84,7 @@ jobs:
       REVISION_COMMIT: << pipeline.git.revision >>
     steps:
     - checkout
+    - *authenticate
     - run:
         name: Validate jetstream config files
         command: |


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-9079

Jestream and OpMon will use the moz-fx-data-shared-prod dryrun function for validation in CI. This function requires authentication.