### PR TITLE
update suggest experiment templates with client table

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -2016,8 +2016,8 @@ data_source = "protections_popup_events"
 friendly_name = "ETP Disablement"
 
 [metrics.urlbar_impressions]
-select_expression = "COALESCE(COUNTIF(is_terminal), 0)"
-data_source = "urlbar_events"
+select_expression = "SUM(urlbar_impressions)"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 friendly_name = "URL Bar Impressions"
 
 [dimensions]
@@ -2216,6 +2216,16 @@ friendly_name = "Urlbar Events"
 description = "Urlbar Events"
 submission_date_column = "submission_date"
 client_id_column = "legacy_telemetry_client_id"
+experiments_column_type = "native"
+
+[data_sources.urlbar_events_daily_engagement_by_product_result_type_v1]
+from_expression = """(
+    SELECT * FROM `moz-fx-data-shared-prod.firefox_desktop.urlbar_events_daily_engagement_by_product_result_type_v1`
+)"""
+analysis_units = ["profile_group_id", "client_id"]
+friendly_name = "Urlbar Events Clients Daily"
+description = "Urlbar Events Clients Daily"
+submission_date_column = "submission_date"
 experiments_column_type = "native"
 
 [data_sources.urlbar_events_unnested_results]

--- a/jetstream/outcomes/firefox_desktop/firefox_suggest.toml
+++ b/jetstream/outcomes/firefox_desktop/firefox_suggest.toml
@@ -14,18 +14,20 @@ numerator = "ad_clicks"
 denominator = "search_count"
 
 [metrics.urlbar_clicks]
-select_expression = "COUNTIF(is_terminal and event_action = 'engaged')"
-data_source = "urlbar_events"
+select_expression = "SUM(urlbar_clicks)"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 description = "Count of clicks on any result shown in the urlbar dropdown menu"
 friendly_name = "Urlbar engagements"
+analysis_units = ['profile_group_id', 'client_id']
 exposure_basis = ["exposures", "enrollments"]
 statistics = { deciles = {}, bootstrap_mean = {} }
 
 [metrics.urlbar_impressions_suggest]
-select_expression = "COUNTIF(is_terminal)"
-data_source = "urlbar_events"
+select_expression = "SUM(urlbar_impressions)"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 description = "The number of times a user exits the urlbar dropdown menu, either by abandoning the urlbar, engaging with a urlbar result, or selecting an annoyance signal that closes the urlbar dropdown menu"
 friendly_name = "Urlbar search sessions"
+analysis_units = ['profile_group_id', 'client_id']
 exposure_basis = ["exposures", "enrollments"]
 statistics = { deciles = {}, bootstrap_mean = {} }
 
@@ -37,27 +39,28 @@ depends_on = ["urlbar_clicks", "urlbar_impressions_suggest"]
 [metrics.urlbar_ctr.statistics.population_ratio]
 numerator = "urlbar_clicks"
 denominator = "urlbar_impressions_suggest"
+analysis_units = ['profile_group_id', 'client_id']
 
 [metrics.urlbar_annoyances]
-select_expression = "COUNTIF(event_action = 'annoyance')"
-data_source = "urlbar_events"
+select_expression = "SUM(urlbar_annoyances)"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 description = "Count of clicks on annoyance signals across all results shown in the urlbar dropdown menu"
 friendly_name = "Urlbar annoyances"
+analysis_units = ['profile_group_id', 'client_id']
 exposure_basis = ["exposures", "enrollments"]
 statistics = { deciles = {}, bootstrap_mean = {} }
 
 [metrics.search_engine_clicks]
-select_expression = """COUNTIF(
-  is_terminal
-  AND event_action = 'engaged'
-  AND (
-    product_selected_result IN ('default_partner_search_suggestion', 'search_engine', 'trending_suggestion')
-    OR selected_result IN ('recent_search')
+select_expression = """SUM(
+  IF(
+    product_result_type IN ('default_partner_search_suggestion', 'search_engine', 'trending_suggestion', 'recent_search'), 
+    urlbar_clicks, 0
   )
 )"""
-data_source = "urlbar_events"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 description = "Count of clicks on a result shown in the urlbar dropdown menu leading to a SERP"
 friendly_name = "Urlbar sessions ending on a SERP"
+analysis_units = ['profile_group_id', 'client_id']
 exposure_basis = ["exposures", "enrollments"]
 statistics = { deciles = {}, bootstrap_mean = {} }
 

--- a/jetstream/search-result-de-duplication.toml
+++ b/jetstream/search-result-de-duplication.toml
@@ -5,8 +5,9 @@ enrollment_period = 7
 name = "exposed_session"
 friendly_name = "Exposed"
 description = "The set of clients that typed 5+ characters to trigger an AMP result"
-select_expression = "result.product_result_type = 'history'"
-data_source =  "urlbar_events_unnested_results"
+select_expression = "product_result_type = 'history'"
+data_source =  "urlbar_events_daily_engagement_by_product_result_type_v1"
+analysis_units = ['profile_group_id', 'client_id']
 window_end = "analysis_window_end"
 
 [metrics]
@@ -19,36 +20,42 @@ overall = ["history_impressions", "bookmark_impressions", "search_suggestion_imp
 
 ## Impressions
 [metrics.history_impressions]
-select_expression = "COUNT(DISTINCT IF(is_terminal AND result.product_result_type = 'history', event_id, NULL))"
-data_source = "urlbar_events_unnested_results"
+select_expression = "SUM(IF(product_result_type = 'history', urlbar_impressions, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+analysis_units = ['profile_group_id', 'client_id']
 [metrics.history_impressions.statistics.bootstrap_mean]
 
 [metrics.bookmark_impressions]
-select_expression = "COUNT(DISTINCT IF(is_terminal AND result.product_result_type = 'bookmark', event_id, NULL))"
-data_source = "urlbar_events_unnested_results"
+select_expression = "SUM(IF(product_result_type = 'bookmark', urlbar_impressions, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+analysis_units = ['profile_group_id', 'client_id']
 [metrics.bookmark_impressions.statistics.bootstrap_mean]
 
 [metrics.search_suggestion_impressions]
-select_expression = "COUNT(DISTINCT IF(is_terminal AND result.product_result_type = 'default_partner_search_suggestion', event_id, NULL))"
-data_source = "urlbar_events_unnested_results"
+select_expression = "SUM(IF(product_result_type = 'default_partner_search_suggestion', urlbar_impressions, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+analysis_units = ['profile_group_id', 'client_id']
 [metrics.search_suggestion_impressions.statistics.bootstrap_mean]
 
 [metrics.urlbar_impressions_suggest.statistics.bootstrap_mean]
 
 ## Clicks
 [metrics.history_clicks]
-select_expression = "COUNTIF(is_terminal and event_action = 'engaged' and product_engaged_result_type = 'history')"
-data_source = "urlbar_events"
+select_expression = "SUM(IF(product_result_type = 'history', urlbar_clicks, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+analysis_units = ['profile_group_id', 'client_id']
 [metrics.history_clicks.statistics.bootstrap_mean]
 
 [metrics.bookmark_clicks]
-select_expression = "COUNTIF(is_terminal and event_action = 'engaged' and product_engaged_result_type = 'bookmark')"
-data_source = "urlbar_events"
+select_expression = "SUM(IF(product_result_type = 'bookmark', urlbar_clicks, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+analysis_units = ['profile_group_id', 'client_id']
 [metrics.bookmark_clicks.statistics.bootstrap_mean]
 
 [metrics.search_suggestion_clicks]
-select_expression = "COUNTIF(is_terminal and event_action = 'engaged' and product_engaged_result_type = 'default_partner_search_suggestion')"
-data_source = "urlbar_events"
+select_expression = "SUM(IF(product_result_type = 'default_partner_search_suggestion', urlbar_clicks, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+analysis_units = ['profile_group_id', 'client_id']
 [metrics.search_suggestion_clicks.statistics.bootstrap_mean]
 
 ## CTR
@@ -56,6 +63,7 @@ data_source = "urlbar_events"
 depends_on = ["history_clicks", "history_impressions"]
 friendly_name = "History CTR"
 description = "Proportion of urlbar sessions where suggestion from the user's browsing history was clicked, out of all urlbar sessions where one was shown (not available on control)"
+analysis_units = ['profile_group_id', 'client_id']
 
 [metrics.history_ctr.statistics.population_ratio]
 numerator = "history_clicks"
@@ -65,6 +73,7 @@ denominator = "history_impressions"
 depends_on = ["bookmark_clicks", "bookmark_impressions"]
 friendly_name = "Bookmark CTR"
 description = "Proportion of urlbar sessions where suggestion from the user's bookmarks was clicked, out of all urlbar sessions where one was shown (not available on control)"
+analysis_units = ['profile_group_id', 'client_id']
 
 [metrics.bookmark_ctr.statistics.population_ratio]
 numerator = "bookmark_clicks"
@@ -74,6 +83,7 @@ denominator = "bookmark_impressions"
 depends_on = ["search_suggestion_clicks", "search_suggestion_impressions"]
 friendly_name = "Search Suggestion CTR"
 description = "Proportion of urlbar sessions where suggestion from the default search engine was clicked, out of all urlbar sessions where one was shown (not available on control)"
+analysis_units = ['profile_group_id', 'client_id']
 
 [metrics.search_suggestion_ctr.statistics.population_ratio]
 numerator = "search_suggestion_clicks"


### PR DESCRIPTION
Updating the suggest experiment templates with the new [client grain table](https://github.com/mozilla/bigquery-etl/pull/7801). 
Closes https://mozilla-hub.atlassian.net/browse/AD-926, related to https://mozilla-hub.atlassian.net/browse/DS-4316