### PR TITLE
add custom glean data sources

### DIFF
--- a/jetstream/perplexity-secondary-search-initial-part2.toml
+++ b/jetstream/perplexity-secondary-search-initial-part2.toml
@@ -15,7 +15,7 @@ select_expression = """(
     COALESCE(COUNTIF(event = 'search.engine.default.changed' 
     AND JSON_VALUE(event_extra.new_display_name) = 'Perplexity'), 0)
 )"""
-data_source = "glean_events_stream"
+data_source = "glean_search_engine"
 
 [metrics.switch_to_perplexity.statistics.bootstrap_mean]
 
@@ -26,7 +26,7 @@ select_expression = """(
    COALESCE(COUNTIF(event = 'sap.counts' 
    AND JSON_VALUE(event_extra.provider_name) = 'Perplexity'), 0)
 )"""
-data_source = "glean_events_stream"
+data_source = "glean_sap"
 
 [metrics.perplexity_sap_count.statistics.bootstrap_mean]
 
@@ -37,7 +37,7 @@ select_expression = """(
    COALESCE(COUNTIF(event = 'sap.counts' 
    AND JSON_VALUE(event_extra.provider_name) = 'Google'), 0)
 )"""
-data_source = "glean_events_stream"
+data_source = "glean_sap"
 
 [metrics.google_sap_count.statistics.bootstrap_mean]
 
@@ -61,6 +61,41 @@ from_expression = """(
 experiments_column_type = "none"
 friendly_name = "No-Op"
 description = "No-op that creates the required columns"
+
+[data_sources.glean_sap]
+from_expression = """(
+    SELECT
+      *,  
+      DATE(submission_timestamp) AS submission_date
+   FROM `mozdata.firefox_desktop.events_stream`
+   WHERE
+      event_category = 'sap'
+      AND event_name = 'sap.counts'
+)"""
+analysis_units = ["profile_group_id", "client_id"]
+description = "Glean events_stream dataset filtered for SAP count events"
+friendly_name = "Glean SAP Counts Events Stream"
+experiments_column_type = "none"
+client_id_column = "legacy_telemetry_client_id"
+glean_client_id_column = "client_id"
+legacy_client_id_column = "legacy_telemetry_client_id"
+
+[data_sources.glean_search_engine]
+from_expression = """(
+   SELECT
+      *,  
+      DATE(submission_timestamp) AS submission_date
+   FROM `mozdata.firefox_desktop.events_stream`
+   WHERE
+      event = 'search.engine.default.changed'
+)"""
+analysis_units = ["profile_group_id", "client_id"]
+description = "Glean events_stream dataset filtered for engine default changed"
+friendly_name = "Glean Search Engine Default Changed"
+experiments_column_type = "none"
+client_id_column = "legacy_telemetry_client_id"
+glean_client_id_column = "client_id"
+legacy_client_id_column = "legacy_telemetry_client_id"
 
 [segments]
 


### PR DESCRIPTION
added smaller glean data sources to the toml file for second perplexity experiment to try to prevent experiment analysis timeout issues.