### PR TITLE
removed segments and added dates to data sources

### DIFF
--- a/jetstream/perplexity-secondary-search-initial-part2.toml
+++ b/jetstream/perplexity-secondary-search-initial-part2.toml
@@ -70,7 +70,7 @@ from_expression = """(
    FROM `mozdata.firefox_desktop.events_stream`
    WHERE
       event_category = 'sap'
-      AND event_name = 'sap.counts'
+    AND event_name = 'sap.counts'
     AND DATE(submission_timestamp) BETWEEN DATE("2025-06-10") AND DATE("2025-07-16")
 )"""
 analysis_units = ["profile_group_id", "client_id"]
@@ -89,7 +89,7 @@ from_expression = """(
    FROM `mozdata.firefox_desktop.events_stream`
    WHERE
       event = 'search.engine.default.changed'
-   DATE(submission_timestamp) BETWEEN DATE("2025-06-10") AND DATE("2025-07-16") 
+   AND DATE(submission_timestamp) BETWEEN DATE("2025-06-10") AND DATE("2025-07-16") 
 )"""
 analysis_units = ["profile_group_id", "client_id"]
 description = "Glean events_stream dataset filtered for engine default changed"


### PR DESCRIPTION
removed existing users and new users segments and added dates to the data sources to limit the amount of data being pulled to prevent timeout errors in second perplexity experiment.