### PR TITLE
Update sponsored_tiles.toml

### DIFF
--- a/jetstream/outcomes/firefox_desktop/sponsored_tiles.toml
+++ b/jetstream/outcomes/firefox_desktop/sponsored_tiles.toml
@@ -2,6 +2,7 @@ friendly_name = "Sponsored Tiles"
 description = "Interaction metrics for sponsored tiles."
 
 [metrics.sponsored_tiles_disabled.statistics.binomial]
+
 [metrics.any_sponsored_tiles_dismissals.statistics.binomial]
 
 [metrics.sponsored_tiles_dismissals.statistics.bootstrap_mean]


### PR DESCRIPTION
because of the 2 line groupings - it looked like there were 5 metrics there.  

the last 3 are 2 line groupings (metrics with different statistics being run on them.  

the first 2 are SEPARATE metrics.  

Fixing because it's unfriendly to use.