### PR TITLE
[ci rerun-skip] Adds tagged_search_count to default overall metrics

### DIFF
--- a/jetstream/defaults/fenix.toml
+++ b/jetstream/defaults/fenix.toml
@@ -13,6 +13,7 @@ weekly = [
 overall = [
     "active_hours",
     "serp_ad_clicks",
+    "tagged_search_count",
     "organic_searches",
     "search_count",
     "searches_with_ads",


### PR DESCRIPTION
    "tagged_search_count", was missing from Overall metrics so not being calculated