### PR TITLE
[ci rerun-skip] Update firefox-android-tab-strip-on-tablets-v2.toml

### DIFF
--- a/jetstream/firefox-android-tab-strip-on-tablets-v2.toml
+++ b/jetstream/firefox-android-tab-strip-on-tablets-v2.toml
@@ -1,3 +1,4 @@
 [experiment]
+enrollment_period = 9
 
 segments = ["new_users", "new_and_repeat_users"]


### PR DESCRIPTION
added a no-op enrollment period to kick off analysis again.