### PR TITLE
Update mozilla-vpn-suggestions-holdback.toml

### DIFF
--- a/jetstream/mozilla-vpn-suggestions-holdback.toml
+++ b/jetstream/mozilla-vpn-suggestions-holdback.toml
@@ -10,18 +10,18 @@ data_source =  "urlbar_events_daily_engagement_by_product_result_type_v1"
 window_end = "analysis_window_end"
 
 [metrics]
-weekly = ["vpn_impressions", "search_suggestion_impressions", 
-"vpn_clicks", "search_suggestion_clicks", "vpn_ctr",  
+weekly = ["rust_vpn_impressions", "search_suggestion_impressions", 
+"rust_vpn_clicks", "search_suggestion_clicks", "rust_vpn_ctr",  
 "search_suggestion_ctr"]
-overall = ["vpn_impressions", "search_suggestion_impressions",
-"vpn_clicks", "search_suggestion_clicks", "vpn_ctr", 
+overall = ["rust_vpn_impressions", "search_suggestion_impressions",
+"rust_vpn_clicks", "search_suggestion_clicks", "rust_vpn_ctr", 
 "search_suggestion_ctr"]
 
 ## Impressions
-[metrics.vpn_impressions]
+[metrics.rust_vpn_impressions]
 select_expression = "SUM(IF(product_result_type = 'rust_vpn', urlbar_impressions, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.vpn_impressions.statistics.bootstrap_mean]
+[metrics.rust_vpn_impressions.statistics.bootstrap_mean]
 
 
 [metrics.search_suggestion_impressions]
@@ -32,10 +32,10 @@ data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 [metrics.urlbar_impressions_suggest.statistics.bootstrap_mean]
 
 ## Clicks
-[metrics.vpn_clicks]
+[metrics.rust_vpn_clicks]
 select_expression = "SUM(IF(product_result_type = 'rust_vpn', urlbar_clicks, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.vpn_clicks.statistics.bootstrap_mean]
+[metrics.rust_vpn_clicks.statistics.bootstrap_mean]
 
 [metrics.search_suggestion_clicks]
 select_expression = "SUM(IF(product_result_type = 'default_partner_search_suggestion', urlbar_clicks, 0))"
@@ -43,14 +43,14 @@ data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 [metrics.search_suggestion_clicks.statistics.bootstrap_mean]
 
 ## CTR
-[metrics.vpn_ctr]
-depends_on = ["vpn_clicks", "vpn_impressions"]
+[metrics.rust_vpn_ctr]
+depends_on = ["rust_vpn_clicks", "rust_vpn_impressions"]
 friendly_name = "VPN CTR"
-description = "Proportion of urlbar sessions where suggestion from VPN, out of all urlbar sessions where one was shown (not available on control)"
+description = "Proportion of urlbar sessions where suggestion from rust_VPN, out of all urlbar sessions where one was shown (not available on control)"
 
-[metrics.vpn_ctr.statistics.population_ratio]
-numerator = "vpn_clicks"
-denominator = "vpn_impressions"
+[metrics.rust_vpn_ctr.statistics.population_ratio]
+numerator = "rust_vpn_clicks"
+denominator = "rust_vpn_impressions"
 
 
 [metrics.search_suggestion_ctr]


### PR DESCRIPTION
these ran with NAN - I think sometimes we used VPN alone in the metric name when it needed to be rust_VPN.  so i replaced all VPN in anything code with the exact product result type rust_vpn