### PR TITLE
remove reports from ad metrics daily

### DIFF
--- a/definitions/ads.toml
+++ b/definitions/ads.toml
@@ -64,13 +64,6 @@ type = "scalar"
 friendly_name = "Ad Clicks"
 description = "Ad clicks"
 
-[metrics.ad_metrics_ad_reports]
-select_expression = "SUM(reports)"
-data_source = "ad_metrics_daily"
-type = "scalar"
-friendly_name = "Ads Reported"
-description = "Number of time ad was reported"
-
 [metrics.revenue]
 select_expression = "SUM(revenue)"
 data_source = "ad_metrics_daily"

--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -187,7 +187,6 @@ description = "Ratio of ad clicks to ad impressions"
 
 [metrics.ad_metrics_ad_impressions.statistics.sum]
 [metrics.ad_metrics_ad_clicks.statistics.sum]
-[metrics.ad_metrics_ad_reports.statistics.sum]
 [metrics.revenue.statistics.sum]
 [metrics.milli_impressions.statistics.sum]
 [metrics.ads_count.statistics.sum]


### PR DESCRIPTION
Removes reports from ad metrics daily in metric hub because it's no longer part of the table and causing the looker explores built on top to fail

CI fails on this problem: https://mozilla-hub.atlassian.net/browse/DENG-9375