### PR TITLE
Update client-side-relevance-ranking-for-enhanced-firefox-suggest-pha…

### DIFF
--- a/jetstream/client-side-relevance-ranking-for-enhanced-firefox-suggest-phase-2.toml
+++ b/jetstream/client-side-relevance-ranking-for-enhanced-firefox-suggest-phase-2.toml
@@ -2,33 +2,28 @@
 enrollment_period = 7
 
 [metrics]
-weekly = ["merino_wikipedia_impressions", "rust_adm_nonsponsored_impressions", "merino_adm_sponsored_impressions", "search_suggestion_impressions", 
-"merino_wikipedia_clicks", "rust_adm_nonsponsored_clicks", "merino_adm_sponsored_clicks", "search_suggestion_clicks", "merino_wikipedia_ctr", "rust_adm_nonsponsored_ctr", "merino_adm_sponsored_ctr", 
+weekly = ["wikipedia_dynamic_impressions", "wikipedia_enhanced_impressions", "admarketplace_sponsored_impressions", "search_suggestion_impressions", 
+"wikipedia_dynamic_clicks", "wikipedia_enhanced_clicks", "admarketplace_sponsored_clicks", "search_suggestion_clicks", "wikipedia_dynamic_ctr", "wikipedia_enhanced_ctr", "admarketplace_sponsored_ctr", 
 "search_suggestion_ctr"]
-overall = ["merino_wikipedia_impressions", "rust_adm_nonsponsored_impressions", "merino_adm_sponsored_impressions", "search_suggestion_impressions", 
-"merino_wikipedia_clicks", "rust_adm_nonsponsored_clicks", "merino_adm_sponsored_clicks", "search_suggestion_clicks", "merino_wikipedia_ctr", "rust_adm_nonsponsored_ctr", "merino_adm_sponsored_ctr", 
+overall = ["wikipedia_dynamic_impressions", "wikipedia_enhanced_impressions", "admarketplace_sponsored_impressions", "search_suggestion_impressions", 
+"wikipedia_dynamic_clicks", "wikipedia_enhanced_clicks", "admarketplace_sponsored_clicks", "search_suggestion_clicks", "wikipedia_dynamic_ctr", "wikipedia_enhanced_ctr", "admarketplace_sponsored_ctr", 
 "search_suggestion_ctr"]
 
 ## Impressions
-[metrics.merino_wikipedia_impressions]
-select_expression = "SUM(IF(product_result_type = 'merino_wikipedia', urlbar_impressions, 0))"
+[metrics.wikipedia_dynamic_impressions]
+select_expression = "SUM(IF(product_result_type = 'wikipedia_dynamic', urlbar_impressions, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.merino_wikipedia_impressions.statistics.bootstrap_mean]
+[metrics.wikipedia_dynamic_impressions.statistics.bootstrap_mean]
 
-[metrics.rust_adm_nonsponsored_impressions]
-select_expression = "SUM(IF(product_result_type = 'rust_adm_nonsponsored', urlbar_impressions, 0))"
+[metrics.wikipedia_enhanced_impressions]
+select_expression = "SUM(IF(product_result_type = 'wikipedia_enhanced', urlbar_impressions, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.rust_adm_nonsponsored_impressions.statistics.bootstrap_mean]
+[metrics.wikipedia_enhanced_impressions.statistics.bootstrap_mean]
 
-[metrics.merino_adm_sponsored_impressions]
-select_expression = "SUM(IF(product_result_type = 'merino_adm_sponsored', urlbar_impressions, 0))"
+[metrics.admarketplace_sponsored_impressions]
+select_expression = "SUM(IF(product_result_type = 'admarketplace_sponsored', urlbar_impressions, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.merino_adm_sponsored_impressions.statistics.bootstrap_mean]
-
-[metrics.rust_adm_sponsored_impressions]
-select_expression = "SUM(IF(product_result_type = 'rust_adm_sponsored', urlbar_impressions, 0))"
-data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.rust_adm_sponsored_impressions.statistics.bootstrap_mean]
+[metrics.admarketplace_sponsored_impressions.statistics.bootstrap_mean]
 
 [metrics.search_suggestion_impressions]
 select_expression = "SUM(IF(product_result_type = 'default_partner_search_suggestion', urlbar_impressions, 0))"
@@ -38,25 +33,20 @@ data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 [metrics.urlbar_impressions_suggest.statistics.bootstrap_mean]
 
 ## Clicks
-[metrics.merino_wikipedia_clicks]
-select_expression = "SUM(IF(product_result_type = 'merino_wikipedia', urlbar_clicks, 0))"
+[metrics.wikipedia_dynamic_clicks]
+select_expression = "SUM(IF(product_result_type = 'wikipedia_dynamic', urlbar_clicks, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.merino_wikipedia_clicks.statistics.bootstrap_mean]
+[metrics.wikipedia_dynamic_clicks.statistics.bootstrap_mean]
 
-[metrics.rust_adm_nonsponsored_clicks]
-select_expression = "SUM(IF(product_result_type = 'rust_adm_nonsponsored', urlbar_clicks, 0))"
+[metrics.wikipedia_enhanced_clicks]
+select_expression = "SUM(IF(product_result_type = 'wikipedia_enhanced', urlbar_clicks, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.rust_adm_nonsponsored_clicks.statistics.bootstrap_mean]
+[metrics.wikipedia_enhanced_clicks.statistics.bootstrap_mean]
 
-[metrics.merino_adm_sponsored_clicks]
-select_expression = "SUM(IF(product_result_type = 'merino_adm_sponsored', urlbar_clicks, 0))"
+[metrics.admarketplace_sponsored_clicks]
+select_expression = "SUM(IF(product_result_type = 'admarketplace_sponsored', urlbar_clicks, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.merino_adm_sponsored_clicks.statistics.bootstrap_mean]
-
-[metrics.rust_adm_sponsored_clicks]
-select_expression = "SUM(IF(product_result_type = 'rust_adm_sponsored', urlbar_clicks, 0))"
-data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.rust_adm_sponsored_clicks.statistics.bootstrap_mean]
+[metrics.admarketplace_sponsored_clicks.statistics.bootstrap_mean]
 
 [metrics.search_suggestion_clicks]
 select_expression = "SUM(IF(product_result_type = 'default_partner_search_suggestion', urlbar_clicks, 0))"
@@ -64,41 +54,32 @@ data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 [metrics.search_suggestion_clicks.statistics.bootstrap_mean]
 
 ## CTR
-[metrics.merino_wikipedia_ctr]
-depends_on = ["merino_wikipedia_clicks", "merino_wikipedia_impressions"]
-friendly_name = "merino_wikipedia CTR"
-description = "Proportion of urlbar sessions where suggestion from the user's browsing merino_wikipedia was clicked, out of all urlbar sessions where one was shown (not available on control)"
+[metrics.wikipedia_dynamic_ctr]
+depends_on = ["wikipedia_dynamic_clicks", "wikipedia_dynamic_impressions"]
+friendly_name = "wikipedia_dynamic CTR"
+description = "Proportion of urlbar sessions where suggestion from the user's browsing wikipedia_dynamic was clicked, out of all urlbar sessions where one was shown (not available on control)"
 
-[metrics.merino_wikipedia_ctr.statistics.population_ratio]
-numerator = "merino_wikipedia_clicks"
-denominator = "merino_wikipedia_impressions"
+[metrics.wikipedia_dynamic_ctr.statistics.population_ratio]
+numerator = "wikipedia_dynamic_clicks"
+denominator = "wikipedia_dynamic_impressions"
 
-[metrics.rust_adm_nonsponsored_ctr]
-depends_on = ["rust_adm_nonsponsored_clicks", "rust_adm_nonsponsored_impressions"]
-friendly_name = "rust_adm_nonsponsored CTR"
-description = "Proportion of urlbar sessions where suggestion from the user's rust_adm_nonsponsoreds was clicked, out of all urlbar sessions where one was shown (not available on control)"
+[metrics.wikipedia_enhanced_ctr]
+depends_on = ["wikipedia_enhanced_clicks", "wikipedia_enhanced_impressions"]
+friendly_name = "wikipedia_enhanced CTR"
+description = "Proportion of urlbar sessions where suggestion from the user's wikipedia_enhanceds was clicked, out of all urlbar sessions where one was shown (not available on control)"
 
-[metrics.rust_adm_nonsponsored_ctr.statistics.population_ratio]
-numerator = "rust_adm_nonsponsored_clicks"
-denominator = "rust_adm_nonsponsored_impressions"
+[metrics.wikipedia_enhanced_ctr.statistics.population_ratio]
+numerator = "wikipedia_enhanced_clicks"
+denominator = "wikipedia_enhanced_impressions"
 
-[metrics.merino_adm_sponsored_ctr]
-depends_on = ["merino_adm_sponsored_clicks", "merino_adm_sponsored_impressions"]
-friendly_name = "merino_adm_sponsored CTR"
-description = "Proportion of urlbar sessions where suggestion from the user's merino_adm_sponsoreds was clicked, out of all urlbar sessions where one was shown (not available on control)"
+[metrics.admarketplace_sponsored_ctr]
+depends_on = ["admarketplace_sponsored_clicks", "admarketplace_sponsored_impressions"]
+friendly_name = "admarketplace_sponsored CTR"
+description = "Proportion of urlbar sessions where suggestion from the user's admarketplace_sponsoreds was clicked, out of all urlbar sessions where one was shown (not available on control)"
 
-[metrics.merino_adm_sponsored_ctr.statistics.population_ratio]
-numerator = "merino_adm_sponsored_clicks"
-denominator = "merino_adm_sponsored_impressions"
-
-[metrics.rust_adm_sponsored_ctr]
-depends_on = ["rust_adm_sponsored_clicks", "rust_adm_sponsored_impressions"]
-friendly_name = "rust_adm_sponsored CTR"
-description = "Proportion of urlbar sessions where suggestion from the user's rust_adm_sponsoreds was clicked, out of all urlbar sessions where one was shown (not available on control)"
-
-[metrics.rust_adm_sponsored_ctr.statistics.population_ratio]
-numerator = "rust_adm_sponsored_clicks"
-denominator = "rust_adm_sponsored_impressions"
+[metrics.admarketplace_sponsored_ctr.statistics.population_ratio]
+numerator = "admarketplace_sponsored_clicks"
+denominator = "admarketplace_sponsored_impressions"
 
 [metrics.search_suggestion_ctr]
 depends_on = ["search_suggestion_clicks", "search_suggestion_impressions"]


### PR DESCRIPTION
…se-2.toml

learned that the exact product result type names cannot be used - because there is a transform that happens. https://github.com/mozilla/bigquery-etl/blob/generated-sql/sql/mozfun/norm/result_type_to_product_name/udf.sql

mapped up Wikipedia: merino_wikipedia (for online suggestions)  - wikipedia_dynamic? rust_adm_nonsponsored (for offline) - wikipedia_enhanced? merino_adm_sponsored (online) - admarketplace_sponsored rust_adm_sponsored (offline) admarketplace_sponsored