### PR TITLE
custom configs for traffic-impact-studies

### DIFF
--- a/jetstream/traffic-impact-study-1.toml
+++ b/jetstream/traffic-impact-study-1.toml
@@ -1,0 +1,4 @@
+[metrics]
+weekly = ['sponsored_tile_impressions', 'sponsored_tile_clicks', 'sponsored_tile_ctr', 'sponsored_tiles_disabled', 'sponsored_tiles_dismissals']
+
+overall = ['sponsored_tile_impressions', 'sponsored_tile_clicks', 'sponsored_tile_ctr', 'sponsored_tiles_disabled', 'sponsored_tiles_dismissals']

--- a/jetstream/traffic-impact-study-2.toml
+++ b/jetstream/traffic-impact-study-2.toml
@@ -1,0 +1,4 @@
+[metrics]
+weekly = ['sponsored_tile_impressions', 'sponsored_tile_clicks', 'sponsored_tile_ctr', 'sponsored_tiles_disabled', 'sponsored_tiles_dismissals']
+
+overall = ['sponsored_tile_impressions', 'sponsored_tile_clicks', 'sponsored_tile_ctr', 'sponsored_tiles_disabled', 'sponsored_tiles_dismissals']

--- a/jetstream/traffic-impact-study-3.toml
+++ b/jetstream/traffic-impact-study-3.toml
@@ -1,0 +1,4 @@
+[metrics]
+weekly = ['sponsored_tile_impressions', 'sponsored_tile_clicks', 'sponsored_tile_ctr', 'sponsored_tiles_disabled', 'sponsored_tiles_dismissals']
+
+overall = ['sponsored_tile_impressions', 'sponsored_tile_clicks', 'sponsored_tile_ctr', 'sponsored_tiles_disabled', 'sponsored_tiles_dismissals']


### PR DESCRIPTION
Creates custom configs for these experiments ([traffic-impact-study-1](https://experimenter.services.mozilla.com/nimbus/traffic-impact-study-1), [2](https://experimenter.services.mozilla.com/nimbus/traffic-impact-study-2/summary/), [3](https://experimenter.services.mozilla.com/nimbus/traffic-impact-study-3/summary/)) so we can rerun the results on a smaller subset of relevant metrics