### PR TITLE
[ci rerun-skip] Remove dismissal metrics which used newtab_visits table

### DIFF
--- a/jetstream/traffic-impact-study-1.toml
+++ b/jetstream/traffic-impact-study-1.toml
@@ -62,6 +62,18 @@ data_source = "noop_source"
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 
+[metrics.sponsored_tiles_dismissals]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+
+[metrics.any_sponsored_tiles_dismissals]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+
+[metrics.sponsored_tiles_dismissals_pos1_2]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+
 [data_sources.noop_source]
 from_expression = """(
     SELECT

--- a/jetstream/traffic-impact-study-2.toml
+++ b/jetstream/traffic-impact-study-2.toml
@@ -62,6 +62,18 @@ data_source = "noop_source"
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 
+[metrics.sponsored_tiles_dismissals]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+
+[metrics.any_sponsored_tiles_dismissals]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+
+[metrics.sponsored_tiles_dismissals_pos1_2]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+
 [data_sources.noop_source]
 from_expression = """(
     SELECT

--- a/jetstream/traffic-impact-study-3.toml
+++ b/jetstream/traffic-impact-study-3.toml
@@ -62,6 +62,18 @@ data_source = "noop_source"
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 
+[metrics.sponsored_tiles_dismissals]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+
+[metrics.any_sponsored_tiles_dismissals]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+
+[metrics.sponsored_tiles_dismissals_pos1_2]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+
 [data_sources.noop_source]
 from_expression = """(
     SELECT


### PR DESCRIPTION
Updated custom configs for these experiments ([traffic-impact-study-1](https://experimenter.services.mozilla.com/nimbus/traffic-impact-study-1), [2](https://experimenter.services.mozilla.com/nimbus/traffic-impact-study-2/summary/), [3](https://experimenter.services.mozilla.com/nimbus/traffic-impact-study-3/summary/)) removing the following metrics so we can rerun the results on a smaller subset of relevant metrics.

- sponsored_tiles_dismissals
- any_sponsored_tiles_dismissals
- sponsored_tiles_dismissals_pos1_2