### PR TITLE
feat(docs): add DS from_expr to metric docs

### DIFF
--- a/.script/templates/metrics.md
+++ b/.script/templates/metrics.md
@@ -19,7 +19,11 @@ Data Source: [`{{ metric.data_source.name }}`](https://mozilla.github.io/metric-
 <summary>Definition:</summary>
 
 ```sql
-{{ metric.select_expression | trim }}
+SELECT
+  {{ metric.select_expression | trim }}
+FROM (
+  {{ metric.data_source.from_expression | trim }}
+)
 ```
 </details>
 


### PR DESCRIPTION
As an example, here's what one of the metric's markdown looks like:

```
### uri_count


**URIs visited**


Counts the number of URIs each client visited

Data Source: [`baseline`](https://mozilla.github.io/metric-hub/data_sources/fenix/#baseline)

<details>
<summary>Definition:</summary>

```sql
SELECT
  {{agg_sum("metrics.counter.events_normal_and_private_uri_count")}}
FROM (
  (
    SELECT
        p.*,
        DATE(p.submission_timestamp) AS submission_date
    FROM `moz-fx-data-shared-prod.{dataset}.baseline` p
)
)
```
</details>
```

whereas before this change, the Definition is just 
```sql
{{agg_sum("metrics.counter.events_normal_and_private_uri_count")}}
```

fixes #1088