### PR TITLE
feat(docs): render metric sql

### DIFF
--- a/.script/generate_docs.py
+++ b/.script/generate_docs.py
@@ -77,10 +77,17 @@ def generate_metrics_docs(out_dir: Path):
     platform_definitions_repos = {repo: config for repo, config in REPOS.items()}
 
     for repo, config in platform_definitions_repos.items():
+        metric_env = config.get_env()
         for platform in config.definitions:
             cfg = MinimalConfiguration(platform.platform)
             metrics_list = []
             for _, metric in platform.spec.metrics.definitions.items():
+                try:
+                    metric.rendered_expression = metric_env.from_string(
+                        metric.select_expression
+                    ).render()
+                except TypeError:
+                    continue
                 try:
                     ds_def = config.get_data_source_definition(
                         metric.data_source.name, platform.platform

--- a/.script/templates/metrics.md
+++ b/.script/templates/metrics.md
@@ -15,12 +15,17 @@ Pre-defined metrics for `{{ platform }}`. These metrics are defined in [metric-h
 
 Data Source: [`{{ metric.data_source.name }}`](https://mozilla.github.io/metric-hub/data_sources/{{ platform }}/#{{ metric.data_source.name }})
 
+**Definition:**
+```sql
+{{ metric.select_expression | trim }}
+```
+
 <details>
-<summary>Definition:</summary>
+<summary>SQL with DataSource</summary>
 
 ```sql
 SELECT
-  {{ metric.select_expression | trim }}
+  {{ metric.rendered_expression | trim }}
 FROM (
   {{ metric.data_source.from_expression | trim }}
 )


### PR DESCRIPTION
Relevant part of the new metric doc markdown:

> **Definition:**
> ```sql
>{{agg_sum("active_hours_sum")}}
>```
> 
> <details>
> <summary>SQL with DataSource</summary>
> 
> ```sql
> SELECT
>   COALESCE(SUM(active_hours_sum), 0)
> FROM (
>   mozdata.telemetry.clients_daily
> )
> ```
> </details>