### PR TITLE
fix: commit message needs quotes

### DIFF
--- a/.github/workflows/rerun-jetstream.yml
+++ b/.github/workflows/rerun-jetstream.yml
@@ -69,7 +69,7 @@ jobs:
         cur_date=`date -u +%FT%TZ`
         LOGS_URL="https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22${{ env.CLUSTER_NAME }}%22%0Aresource.labels.location%3D%22${{ env.CLUSTER_ZONE }}%22%0Aresource.labels.namespace_name%3D%22argo%22;cursorTimestamp=$curDate?project=${{ vars.GCLOUD_PROJECT }}"
 
-        commit_message=${{ github.event.head_commit.message }}
+        commit_message="${{ github.event.head_commit.message }}"
         echo "Checking commit message: $commit_message"
         if [[ "$commit_message" == *"[ci rerun-skip]"* ]] || [[ "$commit_message" == *"[ci rerun_skip]"* ]] || [[ "$commit_message" == *"[ci skip-rerun]"* ]] || [[ "$commit_message" == *"[ci skip_rerun]"* ]]; then
           echo "Skip rerun for files:"


### PR DESCRIPTION
Latest rerun had an error that appears to be due to missing quotes in the commit message. Local testing reveals that the current syntax can be invalid.