### PR TITLE
[ci rerun-skip]Update android-trending-and-recent-searches-v1.toml

### DIFF
--- a/jetstream/android-trending-and-recent-searches-v1.toml
+++ b/jetstream/android-trending-and-recent-searches-v1.toml
@@ -1,28 +1,34 @@
 [metrics]
 overall = ["spoc_tiles_impressions", "spoc_tiles_clicks"]
 
-
 [metrics.spoc_tiles_impressions]
 friendly_name = "Sponsored Tiles Impressions"
 description = "Number of times Contile Sponsored Tiles are shown."
 select_expression = """
-      COALESCE(COUNTIF(
-          event.category = 'top_sites'
-          AND event.name = 'contile_impression'
-      ),0)
+    COALESCE(COUNTIF(event_name = 'contile_impression'), 0)
 """
-data_source = "events"   
+data_source = "events_filtered"
 statistics = { bootstrap_mean = {}, deciles = {} }
-
 
 [metrics.spoc_tiles_clicks]
 friendly_name = "Sponsored Tiles Clicks"
 description = "Number of times user clicked a Contile Sponsored Tile."
 select_expression = """
-      COALESCE(COUNTIF(
-          event.category = 'top_sites'
-          AND event.name = 'contile_click'
-      ),0)
+    COALESCE(COUNTIF(event_name = 'contile_click'), 0)
 """
-data_source = "events" 
+data_source = "events_filtered"
 statistics = { bootstrap_mean = {}, deciles = {} }
+
+[data_sources]
+[data_sources.events_filtered]
+from_expression = """(
+    SELECT
+      *,
+      DATE(submission_timestamp) AS submission_date
+    FROM `moz-fx-data-shared-prod.fenix.events_stream`
+    WHERE event_category = 'top_sites'
+)"""
+description = "Glean events_stream (one row per event) filtered to top_sites"
+friendly_name = "Glean Events Stream Filtered (top_sites)"
+experiments_column_type = "none"
+client_id_column = "client_id"


### PR DESCRIPTION
redoing using optimized event stream table that is filtered



fixes #
