### PR TITLE
Update mozilla-vpn-suggestions-holdback.toml

### DIFF
--- a/jetstream/mozilla-vpn-suggestions-holdback.toml
+++ b/jetstream/mozilla-vpn-suggestions-holdback.toml
@@ -4,54 +4,82 @@ enrollment_period = 7
 [experiment.exposure_signal]
 name = "exposed_session"
 friendly_name = "Exposed"
-description = "The set of clients that would have seen VPN"
-select_expression = "product_result_type = 'rust_vpn'"
+description = "The set of clients that typed characters to trigger a VPN result"
+select_expression = "product_result_type = 'vpn'"
 data_source =  "urlbar_events_daily_engagement_by_product_result_type_v1"
 window_end = "analysis_window_end"
 
 [metrics]
-weekly = ["rust_vpn_impressions", "search_suggestion_impressions", 
-"rust_vpn_clicks", "search_suggestion_clicks", "rust_vpn_ctr",  
-"search_suggestion_ctr"]
-overall = ["rust_vpn_impressions", "search_suggestion_impressions",
-"rust_vpn_clicks", "search_suggestion_clicks", "rust_vpn_ctr", 
-"search_suggestion_ctr"]
+weekly = ["history_impressions", "bookmark_impressions", "search_suggestion_impressions",
+"vpn_impressions", "history_clicks", "bookmark_clicks", "search_suggestion_clicks",
+"vpn_clicks", "history_ctr", "bookmark_ctr", "search_suggestion_ctr", "vpn_ctr"]
+
+overall = ["history_impressions", "bookmark_impressions", "search_suggestion_impressions",
+"vpn_impressions", "history_clicks", "bookmark_clicks", "search_suggestion_clicks",
+"vpn_clicks", "history_ctr", "bookmark_ctr", "search_suggestion_ctr", "vpn_ctr"]
 
 ## Impressions
-[metrics.rust_vpn_impressions]
-select_expression = "SUM(IF(product_result_type = 'rust_vpn', urlbar_impressions, 0))"
+[metrics.history_impressions]
+select_expression = "SUM(IF(product_result_type = 'history', urlbar_impressions, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.rust_vpn_impressions.statistics.bootstrap_mean]
+[metrics.history_impressions.statistics.bootstrap_mean]
 
+[metrics.bookmark_impressions]
+select_expression = "SUM(IF(product_result_type = 'bookmark', urlbar_impressions, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+[metrics.bookmark_impressions.statistics.bootstrap_mean]
 
 [metrics.search_suggestion_impressions]
 select_expression = "SUM(IF(product_result_type = 'default_partner_search_suggestion', urlbar_impressions, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 [metrics.search_suggestion_impressions.statistics.bootstrap_mean]
 
+[metrics.vpn_impressions]
+select_expression = "SUM(IF(product_result_type = 'vpn', urlbar_impressions, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+[metrics.vpn_impressions.statistics.bootstrap_mean]
+
 [metrics.urlbar_impressions_suggest.statistics.bootstrap_mean]
 
 ## Clicks
-[metrics.rust_vpn_clicks]
-select_expression = "SUM(IF(product_result_type = 'rust_vpn', urlbar_clicks, 0))"
+[metrics.history_clicks]
+select_expression = "SUM(IF(product_result_type = 'history', urlbar_clicks, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
-[metrics.rust_vpn_clicks.statistics.bootstrap_mean]
+[metrics.history_clicks.statistics.bootstrap_mean]
+
+[metrics.bookmark_clicks]
+select_expression = "SUM(IF(product_result_type = 'bookmark', urlbar_clicks, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+[metrics.bookmark_clicks.statistics.bootstrap_mean]
 
 [metrics.search_suggestion_clicks]
 select_expression = "SUM(IF(product_result_type = 'default_partner_search_suggestion', urlbar_clicks, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 [metrics.search_suggestion_clicks.statistics.bootstrap_mean]
 
+[metrics.vpn_clicks]
+select_expression = "SUM(IF(product_result_type = 'vpn', urlbar_clicks, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+[metrics.vpn_clicks.statistics.bootstrap_mean]
+
 ## CTR
-[metrics.rust_vpn_ctr]
-depends_on = ["rust_vpn_clicks", "rust_vpn_impressions"]
-friendly_name = "VPN CTR"
-description = "Proportion of urlbar sessions where suggestion from rust_VPN, out of all urlbar sessions where one was shown (not available on control)"
+[metrics.history_ctr]
+depends_on = ["history_clicks", "history_impressions"]
+friendly_name = "History CTR"
+description = "Proportion of urlbar sessions where suggestion from the user's browsing history was clicked, out of all urlbar sessions where one was shown (not available on control)"
 
-[metrics.rust_vpn_ctr.statistics.population_ratio]
-numerator = "rust_vpn_clicks"
-denominator = "rust_vpn_impressions"
+[metrics.history_ctr.statistics.population_ratio]
+numerator = "history_clicks"
+denominator = "history_impressions"
 
+[metrics.bookmark_ctr]
+depends_on = ["bookmark_clicks", "bookmark_impressions"]
+friendly_name = "Bookmark CTR"
+description = "Proportion of urlbar sessions where suggestion from the user's bookmarks was clicked, out of all urlbar sessions where one was shown (not available on control)"
+
+[metrics.bookmark_ctr.statistics.population_ratio]
+numerator = "bookmark_clicks"
+denominator = "bookmark_impressions"
 
 [metrics.search_suggestion_ctr]
 depends_on = ["search_suggestion_clicks", "search_suggestion_impressions"]
@@ -61,3 +89,13 @@ description = "Proportion of urlbar sessions where suggestion from the default s
 [metrics.search_suggestion_ctr.statistics.population_ratio]
 numerator = "search_suggestion_clicks"
 denominator = "search_suggestion_impressions"
+
+[metrics.vpn_ctr]
+depends_on = ["vpn_clicks", "vpn_impressions"]
+friendly_name = "VPN CTR"
+description = "Proportion of urlbar sessions where a VPN suggestion was clicked, out of all urlbar sessions where one was shown (not available on control)"
+
+[metrics.vpn_ctr.statistics.population_ratio]
+numerator = "vpn_clicks"
+denominator = "vpn_impressions"
+


### PR DESCRIPTION
the derived table was updated - and VPN is the product_result_type that is reported.

updated to use that.



fixes #
