### PR TITLE
fix: quotes around changed files var

### DIFF
--- a/.github/workflows/rerun-jetstream.yml
+++ b/.github/workflows/rerun-jetstream.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Rerun jetstream
       shell: bash
       run: |
-        changed_files=${{ needs.changed.outputs.all_changed_files }}
+        changed_files="${{ needs.changed.outputs.all_changed_files }}"
 
         ERROR_DASHBOARD_URL="https://mozilla.cloud.looker.com/dashboards/246"
 


### PR DESCRIPTION
Multiple config file changes means that there is a space in the `changed_files` var. This fix just wraps the var in quotes so that bash knows it's one variable and not a new command.

fixes #1120 

cc @bani 