### PR TITLE
Revert "[AD-1133] Add unique ID metric to ads.toml"

### DIFF
--- a/looker/definitions/ads.toml
+++ b/looker/definitions/ads.toml
@@ -68,12 +68,6 @@ numerator = "native_saves_pos.sum"
 denominator = "native_impressions_pos.sum"
 
 ### data_sources.native_desktop_ad_metrics
-[metrics.id]
-select_expression = "ANY_VALUE(GENERATE_UUID())"
-data_source = "native_desktop_ad_metrics"
-friendly_name = "ID"
-description = "Randomly generated unique identifier for a row"
-
 [metrics.native_spend]
 select_expression = "SUM(spend)"
 data_source = "native_desktop_ad_metrics"


### PR DESCRIPTION
We've added the ID column to `ads.native_desktop_ad_metrics_hourly`

Reverts mozilla/metric-hub#1179