### PR TITLE
use env to pass input and output parameters

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -34,7 +34,9 @@ jobs:
           })
     - name: Skip
       if: needs.changed.outputs.any_changed == 'true'
+      env:
+        ALL_CHANGED_FILES: ${{ needs.changed.outputs.all_changed_files }}
       run: |
         echo "Metric definitions changed, needs manual review"
-        echo "Changed files: ${{ needs.changed.outputs.all_changed_files }}"
+        echo "Changed files: $ALL_CHANGED_FILES"
 

--- a/.github/workflows/changed-files.yml
+++ b/.github/workflows/changed-files.yml
@@ -33,7 +33,11 @@ jobs:
       with:
         files: ${{ inputs.path_filter }}
     - name: Print results
+      env:
+        PATH_FILTER: ${{ inputs.path_filter }}
+        ANY_CHANGED: ${{ steps.changed-files-specific.outputs.any_changed }}
+        ALL_CHANGED_FILES: ${{ steps.changed-files-specific.outputs.all_changed_files }}
       run: |
-        echo "Using path filter: ${{ inputs.path_filter }}"
-        echo "Did files change?: ${{ steps.changed-files-specific.outputs.any_changed }}"
-        echo "All changed files: ${{ steps.changed-files-specific.outputs.all_changed_files }}"
+        echo "Using path filter: $PATH_FILTER"
+        echo "Did files change?: $ANY_CHANGED"
+        echo "All changed files: $ALL_CHANGED_FILES"

--- a/.github/workflows/rerun-jetstream.yml
+++ b/.github/workflows/rerun-jetstream.yml
@@ -42,8 +42,10 @@ jobs:
         location: ${{ env.CLUSTER_ZONE }}
     - name: Rerun jetstream
       shell: bash
+      env:
+        changed_files: ${{ needs.changed.outputs.all_changed_files }}
+        commit_message: ${{ github.event.head_commit.message }}
       run: |
-        changed_files="${{ needs.changed.outputs.all_changed_files }}"
 
         ERROR_DASHBOARD_URL="https://mozilla.cloud.looker.com/dashboards/246"
 
@@ -70,7 +72,6 @@ jobs:
         cur_date=`date -u +%FT%TZ`
         LOGS_URL="https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22${{ env.CLUSTER_NAME }}%22%0Aresource.labels.location%3D%22${{ env.CLUSTER_ZONE }}%22%0Aresource.labels.namespace_name%3D%22argo%22;cursorTimestamp=$curDate?project=${{ vars.GCLOUD_PROJECT }}"
 
-        commit_message="${{ github.event.head_commit.message }}"
         echo "Checking commit message: $commit_message"
         if [[ "$commit_message" == *"[ci rerun-skip]"* ]] || [[ "$commit_message" == *"[ci rerun_skip]"* ]] || [[ "$commit_message" == *"[ci skip-rerun]"* ]] || [[ "$commit_message" == *"[ci skip_rerun]"* ]]; then
           echo "Skip rerun for files:"

--- a/.github/workflows/trigger-looker-dag.yml
+++ b/.github/workflows/trigger-looker-dag.yml
@@ -33,8 +33,10 @@ jobs:
           echo "DAGRUN_NOTE=DAG triggered by **[${{ github.actor }}](https://github.com/${{ github.actor }})** from ${{ github.repository }} CI build [${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_ENV
 
       - name: Trigger looker DAG in Airflow to deploy lookml
+        env:
+          ID_TOKEN: ${{ steps.auth.outputs.id_token }}
         run: |
           curl --location --request POST "https://us-west1-moz-fx-telemetry-airflow-prod.cloudfunctions.net/ci-external-trigger" \
-            -H "Authorization: bearer ${{ steps.auth.outputs.id_token }}" \
+            -H "Authorization: bearer $ID_TOKEN" \
             -H "Content-Type: application/json" \
             -d "{\"dagrun_note\": \"${DAGRUN_NOTE}\", \"dag_id\":\"looker\"}"

--- a/.github/workflows/validate-jetstream.yml
+++ b/.github/workflows/validate-jetstream.yml
@@ -49,13 +49,17 @@ jobs:
         id_token_audience: https://us-central1-moz-fx-data-shared-prod.cloudfunctions.net/bigquery-etl-dryrun
         id_token_include_email: true
     - name: Export ID Token for Python
-      run: echo "GOOGLE_GHA_ID_TOKEN=${{ steps.auth.outputs.id_token }}" >> $GITHUB_ENV
+      env:
+        GOOGLE_GHA_ID_TOKEN: ${{ steps.auth.outputs.id_token }}
+      run: echo "GOOGLE_GHA_ID_TOKEN=$GOOGLE_GHA_ID_TOKEN" >> $GITHUB_ENV
     - name: Validate jetstream config files
+      env:
+        ALL_CHANGED_FILES: ${{ needs.changed.outputs.all_changed_files }}
       run: |
         echo "Run validation on changed files: "
-        echo ${{ needs.changed.outputs.all_changed_files }}
-        echo "jetstream validate_config --config_repos='.' --config_repos=jetstream/ ${{ needs.changed.outputs.all_changed_files }}"
-        jetstream validate_config --config_repos='.' --config_repos=jetstream/ ${{ needs.changed.outputs.all_changed_files }}
+        echo $ALL_CHANGED_FILES
+        echo "jetstream validate_config --config_repos='.' --config_repos=jetstream/ $ALL_CHANGED_FILES"
+        jetstream validate_config --config_repos='.' --config_repos=jetstream/ $ALL_CHANGED_FILES
     - uses: actions/github-script@v6
       if: ${{ github.event_name == 'pull_request' && success() }}
       with:

--- a/.github/workflows/validate-looker.yml
+++ b/.github/workflows/validate-looker.yml
@@ -51,12 +51,16 @@ jobs:
         id_token_audience: https://us-central1-moz-fx-data-shared-prod.cloudfunctions.net/bigquery-etl-dryrun
         id_token_include_email: true
     - name: Export ID Token for Python
-      run: echo "GOOGLE_GHA_ID_TOKEN=${{ steps.auth.outputs.id_token }}" >> $GITHUB_ENV
+      env:
+        GOOGLE_GHA_ID_TOKEN: ${{ steps.auth.outputs.id_token }}
+      run: echo "GOOGLE_GHA_ID_TOKEN=$GOOGLE_GHA_ID_TOKEN" >> $GITHUB_ENV
     - name: Validate Looker config files
+      env:
+        ALL_CHANGED_FILES: ${{ needs.changed.outputs.all_changed_files }}
       run: |
         echo "Run validation on changed files: "
-        echo ${{ needs.changed.outputs.all_changed_files }}
-        python3 .script/validate.py --config_repos='.' --config_repos=looker/ ${{ needs.changed.outputs.all_changed_files }}
+        echo $ALL_CHANGED_FILES
+        python3 .script/validate.py --config_repos='.' --config_repos=looker/ $ALL_CHANGED_FILES
 
 
 

--- a/.github/workflows/validate-metrics.yml
+++ b/.github/workflows/validate-metrics.yml
@@ -51,12 +51,16 @@ jobs:
         id_token_audience: https://us-central1-moz-fx-data-shared-prod.cloudfunctions.net/bigquery-etl-dryrun
         id_token_include_email: true
     - name: Export ID Token for Python
-      run: echo "GOOGLE_GHA_ID_TOKEN=${{ steps.auth.outputs.id_token }}" >> $GITHUB_ENV
+      env:
+        GOOGLE_GHA_ID_TOKEN: ${{ steps.auth.outputs.id_token }}
+      run: echo "GOOGLE_GHA_ID_TOKEN=$GOOGLE_GHA_ID_TOKEN" >> $GITHUB_ENV
     - name: Validate metric config files
+      env:
+        ALL_CHANGED_FILES: ${{ needs.changed.outputs.all_changed_files }}
       run: |
         echo "Run validation on changed files: "
-        echo ${{ needs.changed.outputs.all_changed_files }}
-        python3 .script/validate.py --config_repos='.' ${{ needs.changed.outputs.all_changed_files }}
+        echo $ALL_CHANGED_FILES
+        python3 .script/validate.py --config_repos='.' $ALL_CHANGED_FILES
 
 
 

--- a/.github/workflows/validate-opmon.yml
+++ b/.github/workflows/validate-opmon.yml
@@ -30,10 +30,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Validate OpMon config files
+      env:
+        ALL_CHANGED_FILES: ${{ needs.changed.outputs.all_changed_files }}
       run: |
         echo "Run validation on changed files: "
-        echo ${{ needs.changed.outputs.all_changed_files }}
-        opmon validate_config --config_repos='.' --config_repos=opmon/ ${{ needs.changed.outputs.all_changed_files }}
+        echo $ALL_CHANGED_FILES
+        opmon validate_config --config_repos='.' --config_repos=opmon/ $ALL_CHANGED_FILES
 
 
 


### PR DESCRIPTION
use env to pass input and output parameters to prevent attacks from malicious input and dangerous writes, as described in [our guidelines](https://wiki.mozilla.org/GitHub/Repository_Security/GitHub_Workflows_%26_Actions#Perform_input_validation_and_encoding_on_Github_parameters).

When merging the PR, we need to make sure that the `GOOGLE_GHA_ID_TOKEN` is properly masked in the actions log after the changes.

