### PR TITLE
fix: fix links to experimenter docs

### DIFF
--- a/jetstream/README.md
+++ b/jetstream/README.md
@@ -12,7 +12,7 @@ CI checks will validate the columns, data sources, and SQL syntax.
 Once CI completes and the PR has been automatically approved, you may merge the pull request, which will trigger Jetstream to re-run your analysis.
 Additional reviews by data scientists are necessary when making changes to [metric definitions considered as source of truth](https://github.com/mozilla/metric-hub/tree/main/definitions).
 
-Are your analyses not rendering as expected? See https://experimenter.info/jetstream/troubleshooting.
+Are your analyses not rendering as expected? See https://experimenter.info/deep-dives/jetstream/troubleshooting.
 
 Learn how to write a Jetstream configuration at <https://experimenter.info/deep-dives/jetstream/configuration>.
 

--- a/lib/metric-config-parser/metric_config_parser/parameter.py
+++ b/lib/metric-config-parser/metric_config_parser/parameter.py
@@ -40,7 +40,7 @@ class ParameterDefinition:
                 "to be distinct by branch, a mapping expected in the following format: "
                 'for values: value.branch_1 = "1"'
                 'and defaults: default.branch_1 = "1"'
-                "See https://experimenter.info/jetstream/outcomes#parameterizing-outcomes for more information"  # noqa: E501
+                "See https://experimenter.info/deep-dives/jetstream/outcomes#parameterizing-outcomes for more information"  # noqa: E501
             )
             raise InvalidConfigurationException(error_msg)
 
@@ -53,7 +53,7 @@ class ParameterDefinition:
                 "Expected format: "
                 f'value = "param_value", provided: {self.value}'
                 f'default = "", provided: {self.default}'
-                "See https://experimenter.info/jetstream/outcomes#parameterizing-outcomes for more information"  # noqa: E501
+                "See https://experimenter.info/deep-dives/jetstream/outcomes#parameterizing-outcomes for more information"  # noqa: E501
             )
             raise InvalidConfigurationException(error_msg)
 


### PR DESCRIPTION
@ilanasegall noticed that the jetstream troubleshooting link was broken, so this fixes that one and a couple others I found in the repo.