### PR TITLE
[ci rerun-skip] Personalization Experiment Exposure Update

### DIFF
--- a/jetstream/new-tab-inferred-content-personalization.toml
+++ b/jetstream/new-tab-inferred-content-personalization.toml
@@ -1,2 +1,10 @@
 [experiment]
 sample_size = 50
+
+[experiment.exposure_signal]
+name = "first_content_click"
+friendly_name = "First Click on any content"
+description = "Clients Click on any content at least once"
+data_source = "newtab_visits_pocket_interactions"
+select_expression = "COALESCE(pocket_interactions.pocket_clicks, 0) > 0"
+window_end = "analysis_window_end"


### PR DESCRIPTION
Update The newtab Personalization experiment with the exposure logic: At least one content click