### PR TITLE
fix: downsample to fix worker resource issues

### DIFF
--- a/jetstream/suggesting-past-the-dot.toml
+++ b/jetstream/suggesting-past-the-dot.toml
@@ -1,2 +1,2 @@
 [experiment]
-sample_size = 50
+sample_size = 10


### PR DESCRIPTION
This experiment has been failing to produce results due to KilledWorker issues calculating statistics on the cluster. To help reduce likelihood of memory issues, we'll try sampling at a 10% rate.