### PR TITLE
create new version of organic topsite interactions and clicks 

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1427,12 +1427,20 @@ description = """
 Rate of Clicks per Impression Sponsored Tiles (aka Sponsored Topsites on New Tab) across all positions.
 """
 
+[metrics.newtab_organic_topsite_ctr_v2]
+depends_on=['newtab_organic_topsite_clicks_v2', 'newtab_organic_topsite_impressions_v2']
+friendly_name = "Organic Tile Click Through Rate"
+description = """
+Rate of Clicks per Impression Organic Tiles (aka Sponsored Topsites on New Tab) across all positions.
+"""
+
 [metrics.newtab_organic_topsite_ctr]
 depends_on=['newtab_organic_topsite_clicks', 'newtab_organic_topsite_impressions']
 friendly_name = "Organic Tile Click Through Rate"
 description = """
 Rate of Clicks per Impression Organic Tiles (aka Sponsored Topsites on New Tab) across all positions.
 """
+deprecated = true
 
 [metrics.newtab_newtab_enabled]
 data_source = "newtab_clients_daily"
@@ -1529,6 +1537,14 @@ friendly_name = "Newtab Non-Search Engaged Visit Count"
 description = """
 Count of New Tab visits with non-search engagement
 """
+[metrics.newtab_organic_topsite_clicks_v2]
+data_source = "newtab_clients_daily"
+select_expression = "COALESCE(SUM(organic_topsite_tile_clicks), 0)"
+friendly_name = "Newtab Organic Tile Clicks"
+type = "scalar"
+description = """
+Count of New Tab organic tile clicks across all positions.
+"""
 
 [metrics.newtab_organic_topsite_clicks]
 data_source = "newtab_visits_topsite_tile_interactions"
@@ -1537,6 +1553,16 @@ friendly_name = "Newtab Organic Tile Clicks"
 type = "scalar"
 description = """
 Count of New Tab organic tile clicks across all positions.
+"""
+deprecated = true
+
+[metrics.newtab_organic_topsite_impressions_v2]
+data_source = "newtab_clients_daily"
+select_expression = "COALESCE(SUM(organic_topsite_tile_impressions), 0)"
+friendly_name = "Newtab Organic Tile Impressions"
+type = "scalar"
+description = """
+Count of New Tab organic tile impressions across all positions.
 """
 
 [metrics.newtab_organic_topsite_impressions]
@@ -1547,6 +1573,7 @@ type = "scalar"
 description = """
 Count of New Tab organic tile impressions across all positions.
 """
+deprecated = true
 
 [metrics.wallpaper_clicks]
 data_source = "newtab_clients_daily"

--- a/jetstream/outcomes/firefox_desktop/newtab_do_no_harm.toml
+++ b/jetstream/outcomes/firefox_desktop/newtab_do_no_harm.toml
@@ -24,10 +24,10 @@ Guardrail metrics for the New Tab. Includes user experience and revenue-related 
 [metrics.sponsored_tile_impressions.statistics.linear_model_mean]
 
 
-[metrics.newtab_organic_topsite_clicks.statistics.sum]
-[metrics.newtab_organic_topsite_clicks.statistics.linear_model_mean]
-[metrics.newtab_organic_topsite_impressions.statistics.sum]
-[metrics.newtab_organic_topsite_impressions.statistics.linear_model_mean]
+[metrics.newtab_organic_topsite_clicks_v2.statistics.sum]
+[metrics.newtab_organic_topsite_clicks_v2.statistics.linear_model_mean]
+[metrics.newtab_organic_topsite_impressions_v2.statistics.sum]
+[metrics.newtab_organic_topsite_impressions_v2.statistics.linear_model_mean]
 
 [metrics.sponsored_pocket_clicks.statistics.sum]
 [metrics.sponsored_pocket_clicks.statistics.linear_model_mean]


### PR DESCRIPTION
New version of organic topsite interactions that avoids using the massive "newtab_visits_topsite_tile_interactions" datasource