### PR TITLE
remove newtab_clients_daily from looker definitions

### DIFF
--- a/looker/definitions/firefox_desktop.toml
+++ b/looker/definitions/firefox_desktop.toml
@@ -325,15 +325,6 @@ select_expression = "SUM(sponsored_topsite_click_count)"
 friendly_name = "Sum of Sponsored Topsite Clicks "
 description = "Sum of sponsored topsite clicks"
 
-[metrics.sponsored_impressions]
-data_source = "newtab_clients_daily"
-select_expression = "SUM(sponsored_pocket_impressions) + SUM(sponsored_topsite_tile_impressions)"
-friendly_name = "Sponsored Impressions"
-type = "scalar"
-description = """
-Total number of sponsored impressions across content and tiles on New Tab
-"""
-
 [metrics.any_topsite_impression_count.statistics.sum]
 [metrics.organic_topsite_impression_count.statistics.sum]
 [metrics.sponsored_topsite_impression_count.statistics.sum]
@@ -409,31 +400,6 @@ denominator = "sponsored_tile_impressions.sum"
 numerator = "sponsored_pocket_clicks.sum"
 denominator = "sponsored_pocket_impressions.sum"
 
-
-[metrics.sponsored_pocket_impressions_per_client]
-data_source = "newtab_clients_daily"
-select_expression = "SUM(1)"
-friendly_name = "Sponsored Pocket Impressions Per Client"
-description = """
-Number of sponsored content impressions divided by number of clients
-"""
-
-[metrics.sponsored_tile_impressions_per_client]
-data_source = "newtab_clients_daily"
-select_expression = "SUM(1)"
-friendly_name = "Sponsored Topsite Tile Impressions Per Client"
-description = """
-Number of sponsored topsite tile impressions divided by number of clients
-"""
-
-[metrics.sponsored_impressions_per_client]
-data_source = "newtab_clients_daily"
-select_expression = "SUM(1)"
-friendly_name = "Sponsored Impressions Per Client"
-description = """
-Number of sponsored impressions (content and tiles on New Tab) divided by number of clients
-"""
-
 [metrics.sponsored_pocket_impressions_per_client.statistics.ratio]
 numerator = "sponsored_pocket_impressions.sum"
 denominator = "sponsored_impressions.client_count"
@@ -504,13 +470,6 @@ columns_as_dimensions = true
 [data_sources.desktop_engagement_v1.joins.countries]
 relationship = "one_to_many"
 on_expression = "desktop_engagement_v1.country = countries.code"
-
-[data_sources.newtab_clients_daily]
-columns_as_dimensions = true
-
-[data_sources.newtab_clients_daily.joins.countries]
-relationship = "one_to_many"
-on_expression = "newtab_clients_daily.country_code = countries.code"
 
 #HNT data model revamp data sources
 [data_sources.newtab_clients_daily_aggregates]


### PR DESCRIPTION
newtab_clients_daily and related metrics are not currently being used, and can be removed.