### PR TITLE
remove newtab_interactions

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -2183,14 +2183,6 @@ experiments_column_type = "native"
 friendly_name = "Events"
 description = "Events Ping"
 
-[data_sources.newtab_interactions]
-from_expression = "mozdata.telemetry.newtab_interactions"
-client_id_column = "legacy_telemetry_client_id"
-experiments_column_type = "native"
-submission_date_column = "submission_date"
-description = "New Tab Interactions"
-friendly_name = "New Tab Interactions"
-
 [data_sources.normandy_events]
 from_expression = """(
     SELECT
@@ -2579,30 +2571,6 @@ description = """
     in telemetry (i.e. new, unique profiles).
 """
 
-[segments.pocket_countries]
-data_source = "newtab_interactions"
-select_expression = "LOGICAL_OR(COALESCE(country_code in ('AT', 'BE', 'CA', 'CH', 'DE', 'GB', 'IE', 'IN', 'US'), FALSE))"
-friendly_name = "Pocket Countries"
-description = """
-    Clients in countries with Pocket.
-"""
-
-[segments.sponsored_tile_countries]
-data_source = "newtab_interactions"
-select_expression = "LOGICAL_OR(COALESCE(country_code in ('AU', 'BR', 'CA', 'DE', 'ES', 'FR', 'GB', 'IN', 'IT', 'JA', 'MX', 'US'), FALSE))"
-friendly_name = "Sponsored Tile Countries"
-description = """
-    Clients in countries with AdMarketplace Sponsored Tiles.
-"""
-
-[segments.marketing_tier1_countries]
-data_source = "newtab_interactions"
-select_expression = "LOGICAL_OR(COALESCE(country_code in ('CA', 'DE', 'FR', 'GB', 'US'), FALSE))"
-friendly_name = "Marketing Tier1 Countries"
-description = """
-    Clients in countries considered Tier 1 by Marketing. Other business units may have different definitions of 'Tier 1'.
-"""
-
 [segments.clients_with_blocked_sponsors]
 data_source = "newtab"
 select_expression = '{{agg_any("ARRAY_LENGTH(metrics.string_list.newtab_blocked_sponsors) > 0")}}'
@@ -2662,12 +2630,6 @@ window_end = 0
 
 [segments.data_sources.clients_daily]
 from_expression = "mozdata.telemetry.clients_daily"
-window_start = 0
-window_end = 0
-
-[segments.data_sources.newtab_interactions]
-from_expression = "mozdata.telemetry.newtab_interactions"
-client_id = "legacy_telemetry_client_id"
 window_start = 0
 window_end = 0
 


### PR DESCRIPTION
newtab_interactions is defined in firefox_desktop but is not used anywhere else in the codebase