### PR TITLE
Firefox vpn alpha ds

### DIFF
--- a/jetstream/jetstream/firefox-vpn-for-windows-10-users.toml
+++ b/jetstream/jetstream/firefox-vpn-for-windows-10-users.toml
@@ -1,0 +1,2 @@
+[experiment]
+end_date = "2025-11-19"


### PR DESCRIPTION
The end date for the alpha experiment is intentionally set to end on April 4, 2026 so that the users have access to the service while following experiments are being conducted. I set `end_date` parameters to be 28 days from the end of the enrollment date so that the jetstream analysis generates the confidence intervals for the metrics automatically based on the 28 days as the observation period. 