### PR TITLE
[ci rerun-skip] Add Pinned to Windows Taskbar to windows-10-eos-reminder-messaging experiment

### DIFF
--- a/jetstream/windows-10-eos-reminder-messaging.toml
+++ b/jetstream/windows-10-eos-reminder-messaging.toml
@@ -1,0 +1,11 @@
+[metrics]
+weekly = ["pinned_windows_taskbar"]
+overall = ["pinned_windows_taskbar"]
+
+[metrics.pinned_windows_taskbar.statistics.binomial]
+
+[metrics.pinned_windows_taskbar]
+select_expression = "COALESCE(LOGICAL_OR(metrics.boolean.os_environment_is_taskbar_pinned), FALSE)"
+data_source = "metrics"
+friendly_name = "Pinned Windows Taskbar"
+description = "Percentage of clients who pinned Firefox on Windows Taskbar"


### PR DESCRIPTION
Add `Pinned to Windows Taskbar` metric to windows-10-eos-reminder-messaging experiment