### PR TITLE
[ci rerun-skip]  remove references to deprecated metric

### DIFF
--- a/jetstream/outcomes/firefox_desktop/sponsored_tiles.toml
+++ b/jetstream/outcomes/firefox_desktop/sponsored_tiles.toml
@@ -1,7 +1,6 @@
 friendly_name = "Sponsored Tiles"
 description = "Interaction metrics for sponsored tiles."
 
-[metrics.sponsored_tiles_disabled.statistics.binomial]
 [metrics.any_sponsored_tiles_dismissals.statistics.binomial]
 
 [metrics.sponsored_tiles_dismissals.statistics.bootstrap_mean]

--- a/jetstream/shortcuts-visual-refresh.toml
+++ b/jetstream/shortcuts-visual-refresh.toml
@@ -3,7 +3,6 @@
 [metrics]
 
 overall = [
-  "sponsored_tiles_disabled",
   "any_sponsored_tiles_dismissals",
   "sponsored_tiles_dismissals",
   "sponsored_tiles_dismissals_pos1_2",
@@ -12,7 +11,6 @@ overall = [
 ]
 
 # Copied from jetstream/outcomes/firefox_desktop/sponsored_tiles.toml
-[metrics.sponsored_tiles_disabled.statistics.binomial]
 [metrics.any_sponsored_tiles_dismissals.statistics.binomial]
 
 [metrics.sponsored_tiles_dismissals.statistics.bootstrap_mean]


### PR DESCRIPTION
`sponsored_tiles_disabled` was removed and needs to be removed from some configs so the doc creation in the CI doesn't crash