### PR TITLE
replace broken metric in firefox_desktop

### DIFF
--- a/jetstream/outcomes/firefox_desktop/sponsored_tiles.toml
+++ b/jetstream/outcomes/firefox_desktop/sponsored_tiles.toml
@@ -1,7 +1,7 @@
 friendly_name = "Sponsored Tiles"
 description = "Interaction metrics for sponsored tiles."
 
-[metrics.sponsored_tiles_disabled.statistics.binomial]
+[metrics.newtab_sponsored_tiles_enabled.statistics.binomial]
 [metrics.any_sponsored_tiles_dismissals.statistics.binomial]
 
 [metrics.sponsored_tiles_dismissals.statistics.bootstrap_mean]


### PR DESCRIPTION
sponsored_tiles_disabled has been broken for months, this metric gets at the same signal