### PR TITLE
actually remove datasources

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -2099,35 +2099,6 @@ from_expression = """(
 client_id_column = "metrics.uuid.legacy_telemetry_client_id"
 experiments_column_type = "glean"
 
-[data_sources.newtab_visits_topsite_tile_interactions]
-from_expression = """(
-    SELECT
-        e.* EXCEPT (topsite_tile_interactions),
-        topsite_tile_interactions
-    FROM
-        `moz-fx-data-shared-prod.telemetry.newtab_visits` e
-    CROSS JOIN
-        UNNEST(e.topsite_tile_interactions) AS topsite_tile_interactions
-)"""
-submission_date_column = "submission_date"
-description = "Topsite Tiles Visit Activity Daily"
-friendly_name = "Topsite Tiles Visit Activity Daily"
-[data_sources.newtab_visits_search_interactions]
-from_expression = """(
-    SELECT
-        e.* EXCEPT (search_interactions),
-        search_interactions
-    FROM
-        `moz-fx-data-shared-prod.telemetry.newtab_visits` e
-    CROSS JOIN
-        UNNEST(e.search_interactions) AS search_interactions
-)"""
-submission_date_column = "submission_date"
-description = "Search Tiles Visit Activity Daily"
-friendly_name = "Search Tiles Visit Activity Daily"
-client_id_column = "legacy_telemetry_client_id"
-experiments_column_type = "native"
-
 [data_sources.newtab_visits]
 from_expression = """(
     SELECT


### PR DESCRIPTION
Somehow #1241 just added back in the datasource I removed in #1240 , so this PR actually removes both tile_interactions and search_interactions