### PR TITLE
remove unused urlbar_events_unnested_results

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1986,22 +1986,6 @@ description = "Urlbar Events Clients Daily"
 submission_date_column = "submission_date"
 experiments_column_type = "native"
 
-[data_sources.urlbar_events_unnested_results]
-from_expression = """(
-    SELECT
-        e.* EXCEPT (results),
-        result
-    FROM
-        `moz-fx-data-shared-prod.firefox_desktop.urlbar_events` e
-    CROSS JOIN
-        UNNEST(e.results) AS result
-)"""
-friendly_name = "Urlbar Events with Unnested Results"
-description = "Urlbar Events table with the list of displayed results unnested"
-submission_date_column = "submission_date"
-client_id_column = "legacy_telemetry_client_id"
-experiments_column_type = "native"
-
 [data_sources.serp_events]
 from_expression = "mozdata.firefox_desktop.serp_events"
 friendly_name = "SERP Events"


### PR DESCRIPTION
urlbar_events_unnested_results is used in the following jetstream configs, with the time since last update:

cross-platform-enhanced-suggest.toml: 24 months ago
fakespot-in-suggest.toml: 24 months ago
firefox-mdn-web-docs-suggestion-experiment.toml: 24 months ago
higher-placement-phase-3-relaunch.toml: 8 months ago
pages-ranking-experiment-revised.toml: 19 months ago
sponsored-suggestion-placement-phase-2.toml: 19 months ago
sponsored-suggestion-placement.toml: 23 months ago
weather-suggestions-simplified.toml: 17 months ago