### PR TITLE
feat: add pr warnings for high data processing

### DIFF
--- a/.github/workflows/validate-jetstream.yml
+++ b/.github/workflows/validate-jetstream.yml
@@ -101,6 +101,6 @@ jobs:
               issue_number: context.issue.number,
               body: "❗ Experiment metrics query data processing estimate exceeded high threshold and may fail. Updating the configuration is recommended."
             });
-          } else {
+          } else if (process.env.JETSTREAM_EXIT_CODE != "0") {
             core.setFailed("Jetstream validation failed, see logs above for 'Validate jetstream config files'.")
           }


### PR DESCRIPTION
Adds some comments to a PR if data processing estimates are above certain thresholds. There are defaults set for moderate and high, but we can also configure these by passing the CLI options specified in jetstream.

This builds on https://github.com/mozilla/jetstream/pull/2904, using the new exit codes to provide helpful warning messages about data processing requirements in addition to ensuring configurations are valid.