### PR TITLE
Update metrics from pocket to content

### DIFF
--- a/opmon/fr-billboard-rollout.toml
+++ b/opmon/fr-billboard-rollout.toml
@@ -17,7 +17,7 @@ skip_default_metrics=true
 
 data_source = "newtab_clients_daily"
 boolean_pref = "mozfun.map.get_key(experiments, 'fr-billboard-rollout').branch IS NOT NULL"
-dimensions=['country']
+dimensions=['country_code']
 
 [metrics.organic_content_impressions.statistics]
 mean = {}
@@ -40,6 +40,6 @@ mean = {}
 mean = {}
 
 [dimensions]
-[dimensions.country]
+[dimensions.country_code]
 data_source = "newtab_clients_daily"
 select_expression = "country"


### PR DESCRIPTION
The metric names have changed in https://github.com/mozilla/metric-hub/commit/d03b23a11a7592057cc556c41468b71dee1cc8b1

Not sure if this rollout is still relevant? If we need historical data, then a backfill needs to be triggered via https://workflow.telemetry.mozilla.org/dags/operational_monitoring_backfill/grid?search=operational_monitoring_backfill