### PR TITLE
feat(m-c-p): add enrollments query type experiment config override

### DIFF
--- a/lib/metric-config-parser/metric_config_parser/experiment.py
+++ b/lib/metric-config-parser/metric_config_parser/experiment.py
@@ -52,7 +52,7 @@ class EnrollmentsQueryType(StrEnum):
     FENIX_FALLBACK = "fenix-fallback"
     NORMANDY = "normandy"
     GLEAN_EVENT = "glean-event"
-    BACKGROUND_UDPATE = "background-update"
+    BACKGROUND_UPDATE = "background-update"
 
 
 @attr.s(auto_attribs=True, kw_only=True, slots=True, frozen=True)
@@ -246,6 +246,12 @@ class ExperimentConfiguration:
     @property
     def dataset_id(self) -> str | None:
         return self.experiment_spec.dataset_id
+
+    @property
+    def enrollments_query_type(self) -> EnrollmentsQueryType | None:
+        if self.experiment_spec.enrollments_query_type:
+            return EnrollmentsQueryType(self.experiment_spec.enrollments_query_type)
+        return None
 
     def has_external_config_overrides(self) -> bool:
         """Check whether the external config overrides experiment configuration."""

--- a/lib/metric-config-parser/metric_config_parser/experiment.py
+++ b/lib/metric-config-parser/metric_config_parser/experiment.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 import attr
@@ -44,6 +45,14 @@ class BucketConfig:
     start: int
     count: int
     total: int = 10000
+
+
+class EnrollmentsQueryType(StrEnum):
+    CIRRUS = "cirrus"
+    FENIX_FALLBACK = "fenix-fallback"
+    NORMANDY = "normandy"
+    GLEAN_EVENT = "glean-event"
+    BACKGROUND_UDPATE = "background-update"
 
 
 @attr.s(auto_attribs=True, kw_only=True, slots=True, frozen=True)
@@ -276,6 +285,11 @@ def _validate_analysis_unit(instance: Any, attribute, value):
         AnalysisUnit(value)
 
 
+def _validate_enrollments_query_type(instance: Any, attribute, value):
+    if value is not None:
+        EnrollmentsQueryType(value)
+
+
 @attr.s(auto_attribs=True, kw_only=True)
 class ExperimentSpec:
     """Describes the interface for overriding experiment details."""
@@ -292,6 +306,9 @@ class ExperimentSpec:
     dataset_id: str | None = attr.ib(default=None, validator=_validate_dataset_id)
     sample_size: int | None = None
     analysis_unit: str | None = attr.ib(default=None, validator=_validate_analysis_unit)
+    enrollments_query_type: str | None = attr.ib(
+        default=None, validator=_validate_enrollments_query_type
+    )
 
     def resolve(
         self,

--- a/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
@@ -100,7 +100,7 @@ class TestExperimentSpec:
 
     def test_enrollments_query_type(self, experiments, config_collection):
         trivial = AnalysisSpec().resolve(experiments[0], config_collection)
-        assert trivial.experiment.enrollments_query_type == EnrollmentsQueryType.NORMANDY
+        assert trivial.experiment.enrollments_query_type is None
 
         conf = dedent(
             """
@@ -118,7 +118,7 @@ class TestExperimentSpec:
         conf = dedent(
             """
             [experiment]
-            enrollments_query_type = "not_valid_type"
+            enrollments_query_type = "not-valid-type"
             """
         )
 

--- a/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
@@ -12,7 +12,7 @@ from mozilla_nimbus_schemas import RandomizationUnit
 from metric_config_parser import AnalysisUnit
 from metric_config_parser.analysis import AnalysisSpec
 from metric_config_parser.errors import NoEndDateException
-from metric_config_parser.experiment import Branch, BucketConfig, Experiment
+from metric_config_parser.experiment import Branch, BucketConfig, EnrollmentsQueryType, Experiment
 from metric_config_parser.metric import AnalysisPeriod
 from metric_config_parser.segment import Segment
 
@@ -92,6 +92,33 @@ class TestExperimentSpec:
             """
             [experiment]
             analysis_unit = "not_valid_id"
+            """
+        )
+
+        with pytest.raises(ClassValidationError):
+            AnalysisSpec.from_dict(toml.loads(conf))
+
+    def test_enrollments_query_type(self, experiments, config_collection):
+        trivial = AnalysisSpec().resolve(experiments[0], config_collection)
+        assert trivial.experiment.enrollments_query_type == EnrollmentsQueryType.NORMANDY
+
+        conf = dedent(
+            """
+            [experiment]
+            enrollments_query_type = "background-update"
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(conf))
+        configured = spec.resolve(experiments[0], config_collection)
+        assert (
+            configured.experiment.enrollments_query_type == EnrollmentsQueryType.BACKGROUND_UPDATE
+        )
+
+    def test_enrollments_query_type_invalid(self):
+        conf = dedent(
+            """
+            [experiment]
+            enrollments_query_type = "not_valid_type"
             """
         )
 

--- a/lib/metric-config-parser/pyproject.toml
+++ b/lib/metric-config-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-metric-config-parser"
-version = "2026.1.1"
+version = "2026.4.1"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Parses metric configuration files."
 readme = "README.md"


### PR DESCRIPTION
- Moves `EnrollmentsQueryType` to metric-config-parser
- adds `enrollments_query_type` config option to experiment model
  - this will allow experiment owners to manually override the experiment's enrollments query to a different supported type (I expect this will only be useful for background-update experiments)

Will update mozanalysis in a subsequent PR to:
- add an enrollments query for background-update
- use the `EnrollmentsQueryType` from here instead of defining it itself