### PR TITLE
Create optimize-multi-actiontail-fox-modals-for-existing-users-v2.toml

### DIFF
--- a/jetstream/optimize-multi-actiontail-fox-modals-for-existing-users-v2.toml
+++ b/jetstream/optimize-multi-actiontail-fox-modals-for-existing-users-v2.toml
@@ -1,0 +1,128 @@
+[experiment]
+end_date = "2026-04-20"
+
+segments = [
+  "last_dau_28_plus_days_ago",
+  "last_dau_28_to_34_days_ago",
+  "last_dau_35_to_59_days_ago",
+  "last_dau_60_to_119_days_ago",
+  "last_dau_120_to_179_days_ago",
+  "last_dau_180_plus_days_ago",
+]
+
+[metrics]
+
+# Retention (retained), DAU (client_level_daily_active_users_v2),
+# is_default_browser, and all search metrics auto-apply on desktop
+# experiments via jetstream/defaults/firefox_desktop.toml. Don't re-list.
+
+weekly = [
+  "is_pinned",
+  "imported_bookmarks",
+  "imported_history",
+  "imported_logins",
+  "any_browser_import",
+]
+
+overall = [
+  "is_pinned",
+  "imported_bookmarks",
+  "imported_history",
+  "imported_logins",
+  "any_browser_import",
+]
+
+[metrics.any_browser_import.statistics.binomial]
+
+[metrics.any_browser_import]
+friendly_name = "Any Browser Import"
+description = "Client imported bookmarks, history, OR logins during the analysis window"
+select_expression = """
+  LOGICAL_OR(
+    (bookmark_migrations_quantity_all IS NOT NULL AND bookmark_migrations_quantity_all != 0)
+    OR (history_migrations_quantity_all IS NOT NULL AND history_migrations_quantity_all != 0)
+    OR (logins_migrations_quantity_all IS NOT NULL AND logins_migrations_quantity_all != 0)
+  )
+"""
+data_source = "clients_daily"
+
+# ============================================================================
+# SEGMENTS - Lapse cohorts by last DAU before enrollment
+# ============================================================================
+# Pattern from recommended-add-ons-os-notification-experiment.toml.
+# 365-day lookback so the 180+ bucket picks up long-lapsed users cleanly.
+# Non-overlapping boundaries (inclusive lower, exclusive upper via BETWEEN
+# with adjusted ends).
+
+[segments.last_dau_28_plus_days_ago]
+friendly_name = "Last DAU 28+ days ago (superset)"
+description = "Clients whose last DAU was 28 or more days before enrollment (includes all lapse buckets below)"
+select_expression = """
+  COALESCE(
+    MAX(submission_date) IS NULL
+    OR DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) >= 28,
+    FALSE
+  )
+"""
+data_source = "active_users_last_seen"
+window_start = -365
+window_end = -1
+
+[segments.last_dau_28_to_34_days_ago]
+friendly_name = "Last DAU 28 to 34 days ago"
+description = "Clients whose last DAU was 28-34 days before enrollment"
+select_expression = "COALESCE(DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) BETWEEN 28 AND 34, FALSE)"
+data_source = "active_users_last_seen"
+window_start = -365
+window_end = -1
+
+[segments.last_dau_35_to_59_days_ago]
+friendly_name = "Last DAU 35 to 59 days ago"
+description = "Clients whose last DAU was 35-59 days before enrollment"
+select_expression = "COALESCE(DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) BETWEEN 35 AND 59, FALSE)"
+data_source = "active_users_last_seen"
+window_start = -365
+window_end = -1
+
+[segments.last_dau_60_to_119_days_ago]
+friendly_name = "Last DAU 60 to 119 days ago"
+description = "Clients whose last DAU was 60-119 days before enrollment"
+select_expression = "COALESCE(DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) BETWEEN 60 AND 119, FALSE)"
+data_source = "active_users_last_seen"
+window_start = -365
+window_end = -1
+
+[segments.last_dau_120_to_179_days_ago]
+friendly_name = "Last DAU 120 to 179 days ago"
+description = "Clients whose last DAU was 120-179 days before enrollment"
+select_expression = "COALESCE(DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) BETWEEN 120 AND 179, FALSE)"
+data_source = "active_users_last_seen"
+window_start = -365
+window_end = -1
+
+[segments.last_dau_180_plus_days_ago]
+friendly_name = "Last DAU 180+ days ago"
+description = "Clients whose last DAU was 180+ days before enrollment (or no DAU observed in 365d lookback)"
+select_expression = """
+  COALESCE(
+    MAX(submission_date) IS NULL
+    OR DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) >= 180,
+    FALSE
+  )
+"""
+data_source = "active_users_last_seen"
+window_start = -365
+window_end = -1
+
+[segments.data_sources.active_users_last_seen]
+from_expression = """(
+  SELECT
+    client_id,
+    profile_group_id,
+    submission_date
+  FROM `mozdata.telemetry.desktop_active_users`
+  WHERE is_desktop
+    AND is_dau
+    AND submission_date >= DATE_SUB('2026-03-23', INTERVAL 365 DAY)
+)"""
+window_start = -365


### PR DESCRIPTION
## Summary

Adds a Jetstream config for `optimize-multi-actiontail-fox-modals-for-existing-users-v2`, a 3-treatment Spotlight modal experiment (privacy-framed, multi-action CTAs) targeting existing users (profile age 7+, not default, not pinned). Relaunched 2026-03-23, analysis window ends 2026-04-20.

## Metrics (5 listed)

Brief-specified metrics that auto-apply on every desktop experiment (`retained`, `client_level_daily_active_users_v2`, `is_default_browser`, and all search metrics) are NOT listed — they run via `jetstream/defaults/firefox_desktop.toml`.

Listed metrics are the ones that exist as defined built-ins but don't auto-apply, plus one custom:

| Metric | Statistic | Type |
|---|---|---|
| `is_pinned` | binomial (pre-declared in defaults) | built-in |
| `imported_bookmarks` | binomial | built-in |
| `imported_history` | binomial | built-in |
| `imported_logins` | binomial | built-in |
| `any_browser_import` | binomial | **custom** — "did client import any of bookmarks/history/logins during the analysis window?" Gives a single headline import rate complementing the three individual ones. Reuses built-in `clients_daily` data source. |

## Segments (6 custom, non-overlapping)

Lapse cohorts by last DAU before enrollment (pattern from `recommended-add-ons-os-notification-experiment.toml`, 365-day lookback so the 180+ bucket picks up long-lapsed users cleanly):

| Segment | Window |
|---|---|
| `last_dau_28_plus_days_ago` | 28+ days (superset of all below, includes `MAX IS NULL`) |
| `last_dau_28_to_34_days_ago` | 28-34 |
| `last_dau_35_to_59_days_ago` | 35-59 |
| `last_dau_60_to_119_days_ago` | 60-119 |
| `last_dau_120_to_179_days_ago` | 120-179 |
| `last_dau_180_plus_days_ago` | 180+ (includes `MAX IS NULL`) |

One custom data source (`active_users_last_seen`) built on `desktop_active_users` with `is_desktop AND is_dau`, 365-day lookback from experiment start.

## Validation

- TOML parses (`tomllib`)
- Built-in metric column names (`bookmark_migrations_quantity_all`, `history_migrations_quantity_all`, `logins_migrations_quantity_all`) verified against `definitions/firefox_desktop.toml`