### PR TITLE
Create taskbar-tabs-discovery-expanded-impressions-pin-cta.toml

### DIFF
--- a/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
+++ b/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
@@ -44,22 +44,22 @@ overall = [
 ]
 
 [metrics.installed_web_apps.statistics.linear_model_mean]
-drop_highest = 0.05
-[metrics.pinned_apps.statistics.bootstrap_mean]
-drop_highest = 0.05
-[metrics.web_app_launches.statistics.bootstrap_mean]
-drop_highest = 0.05
+drop_highest = 0.005
+[metrics.pinned_apps.statistics.linear_model_mean]
+drop_highest = 0.005
+[metrics.web_app_launches.statistics.linear_model_mean]
+drop_highest = 0.005
 [metrics.web_app_active_users.statistics.binomial]
 [metrics.any_web_app_installed.statistics.binomial]
 [metrics.any_web_app_pinned.statistics.binomial]
-[metrics.number_of_desktop_launches.statistics.bootstrap_mean]
-drop_highest = 0.05
-[metrics.number_of_taskbar_launches.statistics.bootstrap_mean]
-drop_highest = 0.05
-[metrics.number_of_startmenu_launches.statistics.bootstrap_mean]
-drop_highest = 0.05
-[metrics.number_of_taskbartab_launches.statistics.bootstrap_mean]
-drop_highest = 0.05
+[metrics.number_of_desktop_launches.statistics.linear_model_mean]
+drop_highest = 0.005
+[metrics.number_of_taskbar_launches.statistics.linear_model_mean]
+drop_highest = 0.005
+[metrics.number_of_startmenu_launches.statistics.linear_model_mean]
+drop_highest = 0.005
+[metrics.number_of_taskbartab_launches.statistics.linear_model_mean]
+drop_highest = 0.005
 
 # ============================================================================
 # CUSTOM METRICS - Web App (Taskbar Tabs) activity

--- a/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
+++ b/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
@@ -43,7 +43,7 @@ overall = [
   "number_of_taskbartab_launches",
 ]
 
-[metrics.installed_web_apps.statistics.bootstrap_mean]
+[metrics.installed_web_apps.statistics.linear_model_mean]
 drop_highest = 0.05
 [metrics.pinned_apps.statistics.bootstrap_mean]
 drop_highest = 0.05

--- a/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
+++ b/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
@@ -199,3 +199,37 @@ select_expression = "COALESCE(NOT LOGICAL_OR(event_name IN ('install', 'pin', 'a
 data_source = "web_app_events"
 window_start = -365
 window_end = -1
+
+# ============================================================================
+# SEGMENT DATA SOURCE - Web App events
+# ============================================================================
+# Segments have their own data_sources namespace, distinct from metric
+# data sources. Duplicated from [data_sources.web_app_events] above so the
+# ever/never_used_taskbar_tabs_pre_enrollment segments can reference it.
+
+[segments.data_sources.web_app_events]
+from_expression = """(
+WITH events AS (
+SELECT
+    CAST(submission_timestamp as DATE) as submission_date,
+    legacy_telemetry_client_id as client_id,
+    profile_group_id,
+    event_name,
+    COUNT(1) as event_count
+FROM `moz-fx-data-shared-prod.firefox_desktop.events_stream`
+WHERE
+    event_category = 'web_app'
+    AND event_name IN ('install', 'uninstall', 'pin', 'unpin', 'activate')
+    AND DATE(submission_timestamp) >= '2025-07-31'
+GROUP BY ALL
+)
+  SELECT
+    submission_date,
+    client_id,
+    profile_group_id,
+    event_name,
+    SUM(event_count) OVER (PARTITION BY client_id, event_name ORDER BY submission_date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as cumulative_count
+  FROM events
+)"""
+friendly_name = "Web App Events (segments)"
+description = "Events for Web App (Taskbar Tabs) with per-client cumulative counts, for use in segments"

--- a/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
+++ b/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
@@ -1,0 +1,201 @@
+[experiment]
+enrollment_period = 15
+end_date = "2026-05-06"
+
+segments = [
+  "activity_infrequent",
+  "activity_casual",
+  "activity_core",
+  "regular_users_v3",
+
+  "profile_age_0_to_28_days",
+  "profile_age_29_to_180_days",
+  "profile_age_more_than_180_days",
+
+  "ever_used_taskbar_tabs_pre_enrollment",
+  "never_used_taskbar_tabs_pre_enrollment",
+]
+
+[metrics]
+
+weekly = [
+  "installed_web_apps",
+  "pinned_apps",
+  "web_app_launches",
+  "web_app_active_users",
+  "any_web_app_installed",
+  "any_web_app_pinned",
+  "number_of_desktop_launches",
+  "number_of_taskbar_launches",
+  "number_of_startmenu_launches",
+  "number_of_taskbartab_launches",
+]
+
+overall = [
+  "installed_web_apps",
+  "pinned_apps",
+  "web_app_launches",
+  "web_app_active_users",
+  "any_web_app_installed",
+  "any_web_app_pinned",
+  "number_of_desktop_launches",
+  "number_of_taskbar_launches",
+  "number_of_startmenu_launches",
+  "number_of_taskbartab_launches",
+]
+
+[metrics.installed_web_apps.statistics.bootstrap_mean]
+drop_highest = 0.0005
+[metrics.pinned_apps.statistics.bootstrap_mean]
+drop_highest = 0.0005
+[metrics.web_app_launches.statistics.bootstrap_mean]
+drop_highest = 0.0005
+[metrics.web_app_active_users.statistics.binomial]
+[metrics.any_web_app_installed.statistics.binomial]
+[metrics.any_web_app_pinned.statistics.binomial]
+[metrics.number_of_desktop_launches.statistics.bootstrap_mean]
+drop_highest = 0.0005
+[metrics.number_of_taskbar_launches.statistics.bootstrap_mean]
+drop_highest = 0.0005
+[metrics.number_of_startmenu_launches.statistics.bootstrap_mean]
+drop_highest = 0.0005
+[metrics.number_of_taskbartab_launches.statistics.bootstrap_mean]
+drop_highest = 0.0005
+
+# ============================================================================
+# CUSTOM METRICS - Web App (Taskbar Tabs) activity
+# ============================================================================
+# installed_web_apps / pinned_apps / web_app_launches / web_app_active_users
+# are copied verbatim from taskbar-tabs-discovery.toml.
+# any_web_app_installed / any_web_app_pinned are new binary versions: did the
+# client install/pin at least one web app during the analysis window?
+
+[metrics.installed_web_apps]
+friendly_name = "Installed Web Apps"
+description = "Average Installed Web Apps per user (approx from install and uninstall events)"
+select_expression = """
+  COALESCE(SUM(CASE WHEN event_name = 'install' THEN cumulative_count END),0) -
+  COALESCE(SUM(CASE WHEN event_name = 'uninstall' THEN cumulative_count END),0)
+"""
+data_source = "web_app_events"
+
+[metrics.pinned_apps]
+friendly_name = "Pinned Web Apps"
+description = "Average Pinned Web Apps per user (approx from pin and unpin events)"
+select_expression = """
+  COALESCE(SUM(CASE WHEN event_name = 'pin' THEN cumulative_count END),0) -
+  COALESCE(SUM(CASE WHEN event_name = 'unpin' THEN cumulative_count END),0)
+"""
+data_source = "web_app_events"
+
+[metrics.web_app_launches]
+friendly_name = "Web App Launches"
+description = "Average Web App Launches per user (approx from activate and install events)"
+select_expression = """
+  COALESCE(SUM(CASE WHEN event_name = 'activate' THEN cumulative_count END),0) -
+  COALESCE(SUM(CASE WHEN event_name = 'install' THEN cumulative_count END),0)
+"""
+data_source = "web_app_events"
+
+[metrics.web_app_active_users]
+friendly_name = "Web App Active Users"
+description = "Percentage of clients who had non-zero web app usage time"
+select_expression = """
+  COALESCE(SUM(metrics.timing_distribution.web_app_usage_time.sum),0) > 0
+"""
+data_source = "metrics"
+
+[metrics.any_web_app_installed]
+friendly_name = "Any Web App Installed"
+description = "Client had at least one web app install event during the analysis window"
+select_expression = "COALESCE(LOGICAL_OR(event_name = 'install'), FALSE)"
+data_source = "web_app_events"
+
+[metrics.any_web_app_pinned]
+friendly_name = "Any Web App Pinned"
+description = "Client had at least one web app pin event during the analysis window"
+select_expression = "COALESCE(LOGICAL_OR(event_name = 'pin'), FALSE)"
+data_source = "web_app_events"
+
+# ============================================================================
+# DATA SOURCE - Web App events with cumulative counts
+# ============================================================================
+# Copied verbatim from taskbar-tabs-discovery.toml. Floor 2025-07-31 covers
+# the full history of the `web_app` event category.
+
+[data_sources.web_app_events]
+from_expression = """(
+WITH events AS (
+SELECT
+    CAST(submission_timestamp as DATE) as submission_date,
+    legacy_telemetry_client_id as client_id,
+    profile_group_id,
+    event_name,
+    COUNT(1) as event_count
+FROM `moz-fx-data-shared-prod.firefox_desktop.events_stream`
+WHERE
+    event_category = 'web_app'
+    AND event_name IN ('install', 'uninstall', 'pin', 'unpin', 'activate')
+    AND DATE(submission_timestamp) >= '2025-07-31'
+GROUP BY ALL
+)
+  SELECT
+    submission_date,
+    client_id,
+    profile_group_id,
+    event_name,
+    SUM(event_count) OVER (PARTITION BY client_id, event_name ORDER BY submission_date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as cumulative_count
+  FROM events
+)"""
+experiments_column_type = "none"
+friendly_name = "Web App Events"
+description = "Events for Web App (Taskbar Tabs) with per-client cumulative counts"
+
+# ============================================================================
+# SEGMENTS - Profile age (copied verbatim from privacy-is-love-valentines-day-campaign)
+# ============================================================================
+
+[segments.profile_age_0_to_28_days]
+friendly_name = "Profile Age 0 to 28 days"
+description = "Time since first-seen 0-28 days"
+select_expression = "COALESCE(LOGICAL_OR(days_since_first_seen <= 28), FALSE)"
+data_source = "clients_last_seen"
+
+[segments.profile_age_29_to_180_days]
+friendly_name = "Profile Age 29 to 180 days"
+description = "Time since first-seen 29-180 days"
+select_expression = "COALESCE(LOGICAL_OR(days_since_first_seen BETWEEN 29 AND 180), FALSE)"
+data_source = "clients_last_seen"
+
+[segments.profile_age_more_than_180_days]
+friendly_name = "Profile Age more than 180 days"
+description = "Time since first-seen more than 180 days"
+select_expression = "COALESCE(LOGICAL_OR(days_since_first_seen > 180), FALSE)"
+data_source = "clients_last_seen"
+
+# ============================================================================
+# SEGMENTS - Pre-enrollment Taskbar Tabs usage
+# ============================================================================
+# Splits clients on whether they had ANY web_app engagement (install, pin, or
+# activate) in the 365 days before enrollment. This is a pre-treatment trait,
+# so it is a legitimate segmentation.
+#
+# Since the experiment targets users already in the Taskbar Tabs Discovery
+# rollout, everyone has seen the callout. These segments distinguish
+# "callout engaged" vs. "callout ignored" at baseline.
+
+[segments.ever_used_taskbar_tabs_pre_enrollment]
+friendly_name = "Ever used Taskbar Tabs pre-enrollment"
+description = "Client had at least one web_app install/pin/activate event before enrollment"
+select_expression = "COALESCE(LOGICAL_OR(event_name IN ('install', 'pin', 'activate')), FALSE)"
+data_source = "web_app_events"
+window_start = -365
+window_end = -1
+
+[segments.never_used_taskbar_tabs_pre_enrollment]
+friendly_name = "Never used Taskbar Tabs pre-enrollment"
+description = "Client had NO web_app install/pin/activate events before enrollment"
+select_expression = "COALESCE(NOT LOGICAL_OR(event_name IN ('install', 'pin', 'activate')), TRUE)"
+data_source = "web_app_events"
+window_start = -365
+window_end = -1

--- a/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
+++ b/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
@@ -1,6 +1,5 @@
 [experiment]
-enrollment_period = 15
-end_date = "2026-05-06"
+enrollment_period = 14
 
 segments = [
   "activity_infrequent",
@@ -54,13 +53,13 @@ drop_highest = 0.0005
 [metrics.any_web_app_installed.statistics.binomial]
 [metrics.any_web_app_pinned.statistics.binomial]
 [metrics.number_of_desktop_launches.statistics.bootstrap_mean]
-drop_highest = 0.0005
+drop_highest = 0.005
 [metrics.number_of_taskbar_launches.statistics.bootstrap_mean]
-drop_highest = 0.0005
+drop_highest = 0.005
 [metrics.number_of_startmenu_launches.statistics.bootstrap_mean]
-drop_highest = 0.0005
+drop_highest = 0.005
 [metrics.number_of_taskbartab_launches.statistics.bootstrap_mean]
-drop_highest = 0.0005
+drop_highest = 0.005
 
 # ============================================================================
 # CUSTOM METRICS - Web App (Taskbar Tabs) activity

--- a/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
+++ b/jetstream/taskbar-tabs-discovery-expanded-impressions-pin-cta.toml
@@ -44,22 +44,22 @@ overall = [
 ]
 
 [metrics.installed_web_apps.statistics.bootstrap_mean]
-drop_highest = 0.0005
+drop_highest = 0.05
 [metrics.pinned_apps.statistics.bootstrap_mean]
-drop_highest = 0.0005
+drop_highest = 0.05
 [metrics.web_app_launches.statistics.bootstrap_mean]
-drop_highest = 0.0005
+drop_highest = 0.05
 [metrics.web_app_active_users.statistics.binomial]
 [metrics.any_web_app_installed.statistics.binomial]
 [metrics.any_web_app_pinned.statistics.binomial]
 [metrics.number_of_desktop_launches.statistics.bootstrap_mean]
-drop_highest = 0.005
+drop_highest = 0.05
 [metrics.number_of_taskbar_launches.statistics.bootstrap_mean]
-drop_highest = 0.005
+drop_highest = 0.05
 [metrics.number_of_startmenu_launches.statistics.bootstrap_mean]
-drop_highest = 0.005
+drop_highest = 0.05
 [metrics.number_of_taskbartab_launches.statistics.bootstrap_mean]
-drop_highest = 0.005
+drop_highest = 0.05
 
 # ============================================================================
 # CUSTOM METRICS - Web App (Taskbar Tabs) activity


### PR DESCRIPTION
## Summary

Adds a Jetstream config for `taskbar-tabs-discovery-expanded-impressions-pin-cta`, a 3-branch Taskbar Tabs Discovery experiment (control / expanded impressions / expanded impressions + Pin CTA). Enrollments ran 2026-03-25 through 2026-04-08; analysis window ends 2026-05-06 after 4 weeks of observation.

This is a foreground Nimbus experiment (no custom `enrollment_query` needed).

## Metrics (10)

**4 custom web app metrics** (copied verbatim from `taskbar-tabs-discovery.toml`):
- `installed_web_apps`, `pinned_apps`, `web_app_launches` (bootstrap_mean, drop_highest=0.0005)
- `web_app_active_users` (binomial)

**2 new binary metrics** on the same `web_app_events` data source:
- `any_web_app_installed` (binomial) — did the client install at least one web app during the analysis window?
- `any_web_app_pinned` (binomial) — did the client pin at least one web app during the analysis window?

**4 built-in launch source metrics** with `bootstrap_mean` stats overrides (pattern from `whats-new-toast-notification-taskbar-tabs-release-v2.toml`):
- `number_of_desktop_launches`, `number_of_taskbar_launches`, `number_of_startmenu_launches`, `number_of_taskbartab_launches`

## Segments (9)

**4 built-in engagement segments** (referenced by name only):
- `activity_infrequent`, `activity_casual`, `activity_core`, `regular_users_v3`

**3 profile-age segments** (copied verbatim from `privacy-is-love-valentines-day-campaign.toml`):
- `profile_age_0_to_28_days`, `profile_age_29_to_180_days`, `profile_age_more_than_180_days`

**2 pre-enrollment Taskbar Tabs usage segments** (new, using the `web_app_events` data source with `window_start=-365, window_end=-1`):
- `ever_used_taskbar_tabs_pre_enrollment` — client had any `install`/`pin`/`activate` event before enrollment
- `never_used_taskbar_tabs_pre_enrollment` — client had no such events

Since the experiment targets users already in the Taskbar Tabs Discovery rollout (everyone has seen the callout), these segments distinguish "callout engaged" from "callout ignored" as a pre-treatment trait.

## Data sources (1 custom)

- `web_app_events` — copied verbatim from `taskbar-tabs-discovery.toml`. Shared by all 6 web app metrics and both pre-enrollment usage segments.

## Validation

- TOML parses (`tomllib`)
- All custom metric/segment definitions cross-referenced against `taskbar-tabs-discovery.toml` and `privacy-is-love-valentines-day-campaign.toml`
- Built-in metrics (`number_of_*_launches`) and built-in segments (`activity_*`, `regular_users_v3`) verified in `definitions/firefox_desktop.toml`
