### PR TITLE
Create churn-risk-os-notification.toml

### DIFF
--- a/jetstream/churn-risk-os-notification.toml
+++ b/jetstream/churn-risk-os-notification.toml
@@ -1,6 +1,5 @@
 [experiment]
 analysis_unit = "client_id"
-end_date = "2026-05-06"
 enrollment_period = 7
 
 enrollment_query = """
@@ -159,9 +158,9 @@ overall = [
 ]
 
 [metrics.ubo_newly_enabled.statistics.binomial]
-[metrics.searches_with_serp_ad_blocker.statistics.bootstrap_mean]
-[metrics.searches_with_non_serp_ad_blocker.statistics.bootstrap_mean]
-[metrics.searches_with_no_ad_blocker.statistics.bootstrap_mean]
+[metrics.searches_with_serp_ad_blocker.statistics.linear_model_mean]
+[metrics.searches_with_non_serp_ad_blocker.statistics.linear_model_mean]
+[metrics.searches_with_no_ad_blocker.statistics.linear_model_mean]
 
 [metrics.ubo_newly_enabled]
 friendly_name = "uBO newly enabled"

--- a/jetstream/churn-risk-os-notification.toml
+++ b/jetstream/churn-risk-os-notification.toml
@@ -1,0 +1,459 @@
+[experiment]
+analysis_unit = "client_id"
+end_date = "2026-05-06"
+enrollment_period = 7
+
+enrollment_query = """
+SELECT * FROM
+(
+
+-- Early data shows that the 'experiments' annotation is more robust than either
+-- the 'enrollment' or the 'exposure' event in background update telemetry, see
+-- [Bug 1809275](https://bugzilla.mozilla.org/show_bug.cgi?id=1809275).  That
+-- is, some legacy client IDs do not report 'enrollment' or 'exposure' events,
+-- but do appear in `experiments` annotations.  Therefore, we use 'enrollment'
+-- events as our primary enrollment indicator but also look for an 'experiments'
+-- annotation.
+--
+-- But, some legacy client IDs that click the notification do not correspond to
+-- default profile IDs reported by background update pings: these may be due to
+-- multiple profiles, multiple OS-level users, or telemetry errors.  Some amount
+-- of such client IDs are anticipated.  We use a browsing telemetry query for
+-- these legacy client IDs.
+--
+-- Finally, we take the earliest of these two enrollment signals to determine
+-- enrollment date. This will always be before we witness a notification click,
+-- so we should not have a legacy client ID that does not have at least one
+-- analysis window containing a notification click.
+
+(
+SELECT
+    JSON_VALUE(metrics, '$.uuid.background_update_client_id') AS analysis_id,
+    JSON_VALUE(event_extra, '$.branch') AS branch,
+    MIN(DATE(events.submission_timestamp)) AS enrollment_date,
+    COUNT(events.submission_timestamp) AS num_enrollment_events
+-- Query from events_stream because it's much more efficient than unnesting events.
+FROM `moz-fx-data-shared-prod.firefox_desktop_background_update.events_stream` events
+WHERE
+    DATE(submission_timestamp) BETWEEN
+        '{{experiment.start_date_str}}' AND
+        -- Here we can restrict to the last enrollment date range.
+        '{{experiment.last_enrollment_date_str}}'
+    AND event_category = 'nimbus_events'
+    AND event_name = 'enrollment'
+    -- The background update experiment slug is exact.
+    AND JSON_VALUE(event_extra, '$.experiment') = '{{experiment.normandy_slug}}'
+    -- This should never happen, but belt-and-braces.
+    AND JSON_VALUE(metrics, '$.uuid.background_update_client_id') IS NOT NULL
+    AND sample_id < 100
+GROUP BY analysis_id, branch
+)
+
+UNION ALL
+
+(
+SELECT
+    m.metrics.uuid.background_update_client_id AS analysis_id,
+    experiment.value.branch AS branch,
+    MIN(DATE(submission_timestamp)) AS enrollment_date,
+    -- These aren't discrete events, it makes no sense to count them.
+    1 AS num_enrollment_events
+-- We need to query from the Glean `background_update` table because pre-[Bug
+-- 1794053](https://bugzilla.mozilla.org/show_bug.cgi?id=1794053) (scheduled for
+-- Firefox 109) we don't have the legacy client ID in
+-- `mozdata.firefox_desktop_background_update.events`.
+FROM `mozdata.firefox_desktop_background_update.background_update` AS m
+CROSS JOIN
+    UNNEST(ping_info.experiments) AS experiment
+WHERE
+    -- Background update telemetry can be delayed, so we accept enrollment
+    -- _submission_ dates during the elongated enrollment period.  It's safer to
+    -- compare submission dates generated server-side than internal ping dates
+    -- generated client-side.
+    DATE(submission_timestamp) BETWEEN
+        '{{experiment.start_date_str}}' AND
+        '{{experiment.last_enrollment_date_str}}'
+    -- The background update experiment slug is exact.
+    AND experiment.key = '{{experiment.normandy_slug}}'
+    AND sample_id < 100
+GROUP BY analysis_id, branch
+)
+
+UNION ALL
+
+(
+SELECT
+    client_id AS analysis_id,
+    -- Post [Bug 1804988](https://bugzilla.mozilla.org/show_bug.cgi?id=1804988),
+    -- this name looks like 'slug:branch'.
+    SPLIT(mozfun.map.get_key(event_map_values, 'name'), ':')[SAFE_OFFSET(1)] AS branch,
+    MIN(submission_date) AS enrollment_date,
+    COUNT(submission_date) AS num_enrollment_events
+FROM
+    `mozdata.telemetry.events`
+WHERE
+    -- Browsing telemetry should not be delayed, but notification clicks need
+    -- not coincide with actual enrollment.
+    submission_date BETWEEN
+        '{{experiment.start_date_str}}' AND
+        '{{experiment.last_enrollment_date_str}}'
+    AND event_category = 'browser.launched_to_handle'
+    AND event_method = 'system_notification'
+    AND event_object = 'toast'
+    -- Post [Bug 1804988](https://bugzilla.mozilla.org/show_bug.cgi?id=1804988),
+    -- this name looks like 'slug:branch'.
+    AND STARTS_WITH(mozfun.map.get_key(event_map_values, 'name'), '{{experiment.normandy_slug}}:')
+    AND sample_id < 100
+GROUP BY
+    analysis_id, branch
+)
+
+)
+QUALIFY ROW_NUMBER() OVER (PARTITION BY analysis_id ORDER BY enrollment_date ASC) = 1
+"""
+
+
+# segment information: https://docs.telemetry.mozilla.org/concepts/segments.html
+segments = [
+  "inactive_7_to_9_days_at_enrollment",
+  "inactive_10_to_14_days_at_enrollment",
+
+  "default_at_enrollment",
+  "not_default_at_enrollment",
+
+  "profile_age_0_to_28_days",
+  "profile_age_29_to_180_days",
+  "profile_age_more_than_180_days",
+
+  "prior_cdou_low_1_to_3",
+  "prior_cdou_medium_4_to_10",
+  "prior_cdou_high_11_plus",
+]
+
+[metrics]
+
+weekly = [
+  "is_default_browser",
+  "ubo_newly_enabled",
+  "searches_with_serp_ad_blocker",
+  "searches_with_non_serp_ad_blocker",
+  "searches_with_no_ad_blocker",
+  "is_pinned",
+  "imported_bookmarks",
+  "imported_history",
+  "imported_logins",
+  "fxa_signed_in",
+]
+
+overall = [
+  "is_default_browser",
+  "ubo_newly_enabled",
+  "searches_with_serp_ad_blocker",
+  "searches_with_non_serp_ad_blocker",
+  "searches_with_no_ad_blocker",
+  "is_pinned",
+  "imported_bookmarks",
+  "imported_history",
+  "imported_logins",
+  "fxa_signed_in",
+]
+
+[metrics.ubo_newly_enabled.statistics.binomial]
+[metrics.searches_with_serp_ad_blocker.statistics.bootstrap_mean]
+[metrics.searches_with_non_serp_ad_blocker.statistics.bootstrap_mean]
+[metrics.searches_with_no_ad_blocker.statistics.bootstrap_mean]
+
+[metrics.ubo_newly_enabled]
+friendly_name = "uBO newly enabled"
+description = "uBO not enabled the day before enrollment, and enabled at least once after enrollment"
+select_expression = """
+  LOGICAL_OR(submission_date >= e.enrollment_date AND has_ubo)
+  AND NOT LOGICAL_OR(submission_date = DATE_SUB(e.enrollment_date, INTERVAL 1 DAY) AND has_ubo)
+"""
+data_source = "search_and_addons_daily"
+window_start = -1
+
+[metrics.searches_with_serp_ad_blocker]
+friendly_name = "Searches with SERP ad blocker"
+description = "Sum of searches (sap) on days where a SERP ad blocker is enabled"
+select_expression = "COALESCE(SUM(IF(has_serp_ad_blocker, COALESCE(sap, 0), 0)), 0)"
+data_source = "search_and_addons_daily"
+
+[metrics.searches_with_non_serp_ad_blocker]
+friendly_name = "Searches with non-SERP ad blocker"
+description = "Sum of searches (sap) on days where a non-SERP ad blocker is enabled and no SERP ad blocker is enabled"
+select_expression = "COALESCE(SUM(IF(NOT has_serp_ad_blocker AND has_non_serp_ad_blocker, COALESCE(sap, 0), 0)), 0)"
+data_source = "search_and_addons_daily"
+
+[metrics.searches_with_no_ad_blocker]
+friendly_name = "Searches with no ad blocker"
+description = "Sum of searches (sap) on days where no ad blockers are enabled"
+select_expression = "COALESCE(SUM(IF(NOT has_serp_ad_blocker AND NOT has_non_serp_ad_blocker, COALESCE(sap, 0), 0)), 0)"
+data_source = "search_and_addons_daily"
+
+[data_sources.search_and_addons_daily]
+from_expression = """(
+WITH
+  clients_daily_base AS (
+    SELECT
+      submission_date,
+      client_id,
+      profile_group_id,
+      experiments,
+      active_addons
+    FROM `mozdata.telemetry.clients_daily`
+    WHERE
+      submission_date
+      BETWEEN DATE_SUB('2026-04-01', INTERVAL 1 DAY)
+      AND '2026-05-06'
+  ),
+  addon_rows AS (
+    SELECT
+      submission_date,
+      client_id,
+      a.addon_id
+    FROM clients_daily_base,
+    UNNEST(active_addons) AS a
+    WHERE NOT a.user_disabled
+      AND NOT a.app_disabled
+      AND NOT COALESCE(a.is_system, FALSE)
+      AND COALESCE(a.is_web_extension, FALSE)
+      AND a.addon_id NOT LIKE '%mozilla.org'
+  ),
+  addon_daily AS (
+    SELECT
+      submission_date,
+      client_id,
+      COUNT(1) AS enabled_addons,
+      LOGICAL_OR(addon_id IN (
+        'uBlock0@raymondhill.net'                    /* uBlock Origin */
+      )) AS has_ubo,
+      LOGICAL_OR(addon_id IN (
+        'uBlock0@raymondhill.net',                   /* uBlock Origin */
+        'adblockultimate@adblockultimate.net',       /* AdBlocker Ultimate */
+        'firefox@ghostery.com'                       /* Ghostery */
+      )) AS has_serp_ad_blocker,
+      LOGICAL_OR(addon_id IN (
+        '{{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}}',  /* Adblock Plus */
+        'jid1-NIfFY2CA8fy1tg@jetpack'                /* Adblock */
+      )) AS has_non_serp_ad_blocker
+    FROM addon_rows
+    GROUP BY 1, 2
+  ),
+  search_daily AS (
+    SELECT
+      submission_date,
+      client_id,
+      SUM(COALESCE(sap, 0)) AS sap
+    FROM `mozdata.search.search_clients_engines_sources_daily`
+    WHERE submission_date BETWEEN '2026-04-01' AND '2026-05-06'
+    GROUP BY 1, 2
+  )
+SELECT
+  cd.submission_date,
+  cd.client_id,
+  cd.profile_group_id,
+  cd.experiments,
+  COALESCE(ad.enabled_addons, 0) AS enabled_addons,
+  COALESCE(ad.has_ubo, FALSE) AS has_ubo,
+  COALESCE(ad.has_serp_ad_blocker, FALSE) AS has_serp_ad_blocker,
+  COALESCE(ad.has_non_serp_ad_blocker, FALSE) AS has_non_serp_ad_blocker,
+  COALESCE(sd.sap, 0) AS sap
+FROM clients_daily_base AS cd
+LEFT JOIN addon_daily AS ad
+  USING (submission_date, client_id)
+LEFT JOIN search_daily AS sd
+  USING (submission_date, client_id)
+)"""
+friendly_name = "Daily search and add-on summary"
+description = """
+Daily client-level dataset combining enabled add-on state and search activity.
+Built on clients_daily and joined to daily search.
+"""
+
+# ============================================================================
+# USER SEGMENTS
+# ============================================================================
+# Using e.enrollment_date to reference enrollment date
+# (see https://github.com/mozilla/mozanalysis/blob/ccabadcc5233a1f48f528fa4a23e3495b3ac9ea2/src/mozanalysis/segments.py#L132-L156)
+
+# ----------------------------------------------------------------------------
+# 1. Inactivity duration at enrollment (brief: 7-9 vs 10-14 days inactive)
+#    Targeting restricts the population to clients inactive 7-14 days. These
+#    two buckets partition ~all enrollees. Small leakage expected for clients
+#    whose enrollment event lands after a server-side delay.
+# ----------------------------------------------------------------------------
+
+[segments.inactive_7_to_9_days_at_enrollment]
+friendly_name = "Inactive 7 to 9 days at enrollment"
+description = "Clients whose last DAU was 7-9 days before enrollment"
+select_expression = "COALESCE(DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) BETWEEN 7 AND 9, FALSE)"
+data_source = "active_users_last_seen"
+window_start = -21
+window_end = -1
+
+[segments.inactive_10_to_14_days_at_enrollment]
+friendly_name = "Inactive 10 to 14 days at enrollment"
+description = "Clients whose last DAU was 10-14 days before enrollment"
+select_expression = "COALESCE(DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) BETWEEN 10 AND 14, FALSE)"
+data_source = "active_users_last_seen"
+window_start = -21
+window_end = -1
+
+[segments.data_sources.active_users_last_seen]
+from_expression = """(
+  SELECT
+    client_id,
+    profile_group_id,
+    submission_date
+  FROM `mozdata.telemetry.desktop_active_users`
+  WHERE is_desktop
+    AND is_dau
+    AND submission_date >= DATE_SUB('2026-04-01', INTERVAL 21 DAY)
+)"""
+window_start = -21
+
+# ----------------------------------------------------------------------------
+# 2. Default browser at enrollment
+# ----------------------------------------------------------------------------
+
+[segments.default_at_enrollment]
+friendly_name = "Default browser at enrollment"
+description = "Clients who were the OS default browser at enrollment"
+select_expression = "COALESCE(LOGICAL_OR(is_default_browser), FALSE)"
+data_source = "clients_last_seen_default_status"
+window_start = -7
+window_end = -1
+
+[segments.not_default_at_enrollment]
+friendly_name = "Not default browser at enrollment"
+description = "Clients who were NOT the OS default browser at enrollment"
+select_expression = "COALESCE(LOGICAL_OR(NOT is_default_browser), FALSE)"
+data_source = "clients_last_seen_default_status"
+window_start = -7
+window_end = -1
+
+[segments.data_sources.clients_last_seen_default_status]
+from_expression = """(
+  SELECT
+    client_id,
+    profile_group_id,
+    submission_date,
+    is_default_browser
+  FROM `mozdata.telemetry.clients_last_seen`
+  WHERE submission_date >= DATE_SUB('2026-04-01', INTERVAL 7 DAY)
+)"""
+window_start = -7
+
+# ----------------------------------------------------------------------------
+# 3. Profile age (privacy-is-love buckets: 0-28 / 29-180 / 180+)
+# ----------------------------------------------------------------------------
+
+[segments.profile_age_0_to_28_days]
+friendly_name = "Profile age 0 to 28 days"
+description = "Profile first seen 0-28 days before enrollment"
+select_expression = "COALESCE(LOGICAL_OR(days_since_first_seen BETWEEN 0 AND 28), FALSE)"
+data_source = "clients_last_seen_profile_age"
+window_start = -7
+window_end = -1
+
+[segments.profile_age_29_to_180_days]
+friendly_name = "Profile age 29 to 180 days"
+description = "Profile first seen 29-180 days before enrollment"
+select_expression = "COALESCE(LOGICAL_OR(days_since_first_seen BETWEEN 29 AND 180), FALSE)"
+data_source = "clients_last_seen_profile_age"
+window_start = -7
+window_end = -1
+
+[segments.profile_age_more_than_180_days]
+friendly_name = "Profile age more than 180 days"
+description = "Profile first seen more than 180 days before enrollment"
+select_expression = "COALESCE(LOGICAL_OR(days_since_first_seen > 180), FALSE)"
+data_source = "clients_last_seen_profile_age"
+window_start = -7
+window_end = -1
+
+[segments.data_sources.clients_last_seen_profile_age]
+from_expression = """(
+  SELECT
+    client_id,
+    profile_group_id,
+    submission_date,
+    days_since_first_seen
+  FROM `mozdata.telemetry.clients_last_seen`
+  WHERE submission_date >= DATE_SUB('2026-04-01', INTERVAL 7 DAY)
+)"""
+window_start = -7
+
+# ----------------------------------------------------------------------------
+# 4. Prior engagement - CDOU in 28 days before lapse (1-3 / 4-10 / 11+)
+#    "Before lapse" = 28-day window ending on the client's last DAU date.
+#    Max lookback = 14 days inactivity + 28 days pre-lapse = 42 days.
+# ----------------------------------------------------------------------------
+
+[segments.prior_cdou_low_1_to_3]
+friendly_name = "Prior CDOU low (1-3 days)"
+description = "1-3 DAU days in the 28 days before client's last DAU (pre-lapse)"
+select_expression = "COALESCE(LOGICAL_OR(is_prior_cdou_low), FALSE)"
+data_source = "prior_engagement"
+window_start = -42
+window_end = -1
+
+[segments.prior_cdou_medium_4_to_10]
+friendly_name = "Prior CDOU medium (4-10 days)"
+description = "4-10 DAU days in the 28 days before client's last DAU (pre-lapse)"
+select_expression = "COALESCE(LOGICAL_OR(is_prior_cdou_medium), FALSE)"
+data_source = "prior_engagement"
+window_start = -42
+window_end = -1
+
+[segments.prior_cdou_high_11_plus]
+friendly_name = "Prior CDOU high (11+ days)"
+description = "11+ DAU days in the 28 days before client's last DAU (pre-lapse)"
+select_expression = "COALESCE(LOGICAL_OR(is_prior_cdou_high), FALSE)"
+data_source = "prior_engagement"
+window_start = -42
+window_end = -1
+
+[segments.data_sources.prior_engagement]
+from_expression = """(
+  WITH dau_rows AS (
+    SELECT
+      client_id,
+      profile_group_id,
+      submission_date
+    FROM `mozdata.telemetry.desktop_active_users`
+    WHERE is_desktop
+      AND is_dau
+      AND submission_date BETWEEN DATE_SUB('2026-04-01', INTERVAL 42 DAY) AND '2026-04-08'
+  ),
+  last_dau AS (
+    SELECT
+      client_id,
+      MAX(submission_date) AS last_dau_date
+    FROM dau_rows
+    GROUP BY 1
+  ),
+  prior_cdou AS (
+    SELECT
+      d.client_id,
+      ANY_VALUE(d.profile_group_id) AS profile_group_id,
+      l.last_dau_date,
+      COUNT(DISTINCT IF(
+        d.submission_date BETWEEN DATE_SUB(l.last_dau_date, INTERVAL 27 DAY) AND l.last_dau_date,
+        d.submission_date, NULL
+      )) AS cdou_28d_pre_lapse
+    FROM dau_rows d
+    JOIN last_dau l USING (client_id)
+    GROUP BY d.client_id, l.last_dau_date
+  )
+  SELECT
+    client_id,
+    profile_group_id,
+    last_dau_date AS submission_date,
+    cdou_28d_pre_lapse BETWEEN 1 AND 3  AS is_prior_cdou_low,
+    cdou_28d_pre_lapse BETWEEN 4 AND 10 AS is_prior_cdou_medium,
+    cdou_28d_pre_lapse >= 11            AS is_prior_cdou_high
+  FROM prior_cdou
+)"""
+window_start = -42


### PR DESCRIPTION
## Summary

Adds a Jetstream config for `churn-risk-os-notification` — an OS-level notification experiment targeting Windows users inactive 7–14 days who do not have uBlock Origin installed. Experiment runs 2026-04-01 through 2026-05-06 (7-day enrollment, 28-day observation).

## What this config adds

**Enrollment query:** standard background-updater 3-way UNION (Nimbus events from `events_stream` + background_update ping `experiments` annotation + notification-click events from `mozdata.telemetry.events`). Copied verbatim from `recommended-add-ons-os-notification-experiment.toml`.

**Metrics (weekly + overall):**
- Built-in: `is_default_browser`, `is_pinned`, `imported_bookmarks`, `imported_history`, `imported_logins`, `fxa_signed_in`
- Custom (same definitions as the recommended-add-ons experiment): `ubo_newly_enabled` (binomial), `searches_with_serp_ad_blocker` / `searches_with_non_serp_ad_blocker` / `searches_with_no_ad_blocker` (bootstrap_mean)

**Custom data source:** `search_and_addons_daily` — reused from the recommended-add-ons config, with date bounds adjusted to the churn-risk timeline (2026-04-01 → 2026-05-06).

**Segments:**
1. **Inactivity duration at enrollment** — `inactive_7_to_9_days_at_enrollment`, `inactive_10_to_14_days_at_enrollment` (lapse-bucket pattern on `desktop_active_users` / `is_dau`, −21d window)
2. **Default browser at enrollment** — `default_at_enrollment`, `not_default_at_enrollment` (LOGICAL_OR on `is_default_browser` from `clients_last_seen`)
3. **Profile age** — `profile_age_0_to_28_days`, `profile_age_29_to_180_days`, `profile_age_more_than_180_days` (`days_since_first_seen` from `clients_last_seen`)
4. **Prior engagement (CDOU 28 days before lapse)** — `prior_cdou_low_1_to_3`, `prior_cdou_medium_4_to_10`, `prior_cdou_high_11_plus` (custom CTE, −42d lookback = 14d max inactivity + 28d pre-lapse window)

## Validation

- TOML parses (`tomllib`)
- `enrollment_query` is byte-for-byte identical to `recommended-add-ons-os-notification-experiment.toml`
