### PR TITLE
Read from local repo

### DIFF
--- a/.script/validate.py
+++ b/.script/validate.py
@@ -32,6 +32,7 @@ from metric_config_parser.config import (
     ConfigCollection,
     entity_from_path,
 )
+from metric_config_parser.featmon import FEATMON_DIR
 from metric_config_parser.function import FunctionsSpec
 
 logger = logging.getLogger(__name__)
@@ -195,6 +196,15 @@ def validate(path, config_repos):
             continue
         if ".example" in config_file.suffixes:
             print(f"Skipping example config {config_file}")
+            continue
+
+        if config_file.parent.name == FEATMON_DIR:
+            entity = entity_from_path(config_file)
+            try:
+                entity.validate(config_collection)
+            except Exception as e:
+                dirty = True
+                print(e)
             continue
 
         if config_file.parent.name == DEFINITIONS_DIR:

--- a/lib/mcp-server/metric_hub_mcp/featmon.py
+++ b/lib/mcp-server/metric_hub_mcp/featmon.py
@@ -1,0 +1,106 @@
+"""Handlers for Nimbus feature monitoring (featmon) configs."""
+
+import logging
+from typing import Any
+
+from mcp.types import TextContent
+
+from .config import get_config_collection
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_list_monitored_features(arguments: dict[str, Any]) -> list[TextContent]:
+    """List all Nimbus features that have feature monitoring configs."""
+    platform_filter = arguments.get("platform")
+    config = get_config_collection()
+
+    result = "# Monitored Nimbus Features\n\n"
+    found = False
+
+    for app_config in config.featmon_configs:
+        if platform_filter and app_config.slug != platform_filter:
+            continue
+
+        found = True
+        result += f"## {app_config.slug}\n\n"
+        for feat_key, feat in app_config.spec.features.items():
+            nimbus_slug = feat.nimbus_slug()
+            sources = list(feat.metrics_by_source.keys())
+            result += f"### {nimbus_slug}\n"
+            if nimbus_slug != feat_key:
+                result += f"- TOML key: `{feat_key}`\n"
+            result += f"- Sources: {', '.join(sources) if sources else 'none'}\n"
+            total_metrics = sum(
+                sum(len(metrics) for metrics in source_metrics.values())
+                for source_metrics in feat.metrics_by_source.values()
+            )
+            result += f"- Metrics tracked: {total_metrics}\n\n"
+
+    if not found:
+        if platform_filter:
+            result += f"No monitored features found for platform '{platform_filter}'.\n"
+            result += (
+                "Use list_monitored_features without a platform filter to see all platforms.\n"
+            )
+        else:
+            result += "No featmon configs found.\n"
+
+    return [TextContent(type="text", text=result)]
+
+
+async def handle_get_monitored_feature(arguments: dict[str, Any]) -> list[TextContent]:
+    """Get detailed featmon config for a specific Nimbus feature."""
+    feature_slug = arguments["feature_slug"]
+    platform_filter = arguments.get("platform")
+    config = get_config_collection()
+
+    for app_config in config.featmon_configs:
+        if platform_filter and app_config.slug != platform_filter:
+            continue
+
+        for feat_key, feat in app_config.spec.features.items():
+            if feat.nimbus_slug() != feature_slug and feat_key != feature_slug:
+                continue
+
+            result = f"# Feature: {feat.nimbus_slug()}\n"
+            result += f"**Platform:** {app_config.slug}\n"
+            if feat.slug is not None:
+                result += f"**TOML key:** `{feat_key}` (slug overridden to `{feat.slug}`)\n"
+            result += "\n"
+
+            result += "## Data Sources\n\n"
+            for source_name, source in app_config.spec.data_sources.items():
+                result += f"### {source_name}\n"
+                result += f"- Table: `{source.table_name}`\n"
+                result += f"- Type: `{source.type}`\n"
+                result += f"- Analysis unit: `{source.analysis_unit_id}`\n"
+                if source.dimensions:
+                    result += f"- Dimensions: {', '.join(source.dimensions.keys())}\n"
+                result += "\n"
+
+            result += "## Metrics by Source\n\n"
+            if not feat.metrics_by_source:
+                result += "No metrics configured.\n"
+            else:
+                for source_name, source_metrics in feat.metrics_by_source.items():
+                    result += f"### {source_name}\n"
+                    for data_type, metrics in source_metrics.items():
+                        if data_type == "event":
+                            for category, category_metrics in metrics.items():
+                                for metric_name in category_metrics:
+                                    result += (
+                                        f"- `{category}_{metric_name}`"
+                                        f" (event: {category}.{metric_name})\n"
+                                    )
+                        else:
+                            for metric_name in metrics:
+                                result += f"- `{metric_name}` ({data_type})\n"
+                    result += "\n"
+
+            return [TextContent(type="text", text=result)]
+
+    msg = f"Feature '{feature_slug}' not found."
+    if not platform_filter:
+        msg += " Use list_monitored_features to see all available features."
+    return [TextContent(type="text", text=msg)]

--- a/lib/mcp-server/metric_hub_mcp/server.py
+++ b/lib/mcp-server/metric_hub_mcp/server.py
@@ -63,16 +63,8 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "platform": {
-                        "type": "string",
-                        "description": "Platform name (e.g., 'firefox_desktop', 'fenix', 'ads')",
-                    },
-                    "category": {
-                        "type": "string",
-                        "description": (
-                            "Optional: filter by category (e.g., 'search', 'performance')"
-                        ),
-                    },
+                    "platform": {"type": "string", "description": "Platform name (e.g., 'firefox_desktop', 'fenix', 'ads')"},
+                    "category": {"type": "string", "description": "Optional: filter by category (e.g., 'search', 'performance')"},
                 },
                 "required": ["platform"],
             },
@@ -107,10 +99,7 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "platform": {"type": "string", "description": "Platform name"},
-                    "data_source_name": {
-                        "type": "string",
-                        "description": "Name of the data source",
-                    },
+                    "data_source_name": {"type": "string", "description": "Name of the data source"},
                 },
                 "required": ["platform", "data_source_name"],
             },
@@ -122,10 +111,7 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "Search query"},
-                    "platform": {
-                        "type": "string",
-                        "description": "Optional: limit search to a specific platform",
-                    },
+                    "platform": {"type": "string", "description": "Optional: limit search to a specific platform"},
                 },
                 "required": ["query"],
             },
@@ -136,10 +122,7 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "metric_name": {
-                        "type": "string",
-                        "description": "Name for the new metric (snake_case)",
-                    },
+                    "metric_name": {"type": "string", "description": "Name for the new metric (snake_case)"},
                     "data_source": {"type": "string", "description": "Data source to use"},
                     "metric_type": {
                         "type": "string",
@@ -164,10 +147,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="list_experiment_configs",
-            description=(
-                "List configuration files. Use 'jetstream' for experiment configs,"
-                " 'opmon' for operational monitoring, 'looker' for Looker configs"
-            ),
+            description="List configuration files. Use 'jetstream' for experiment configs, 'opmon' for operational monitoring, 'looker' for Looker configs",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -182,10 +162,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="get_experiment_config",
-            description=(
-                "Get the contents of an existing configuration file"
-                " from jetstream/, opmon/, or looker/ folders"
-            ),
+            description="Get the contents of an existing configuration file from jetstream/, opmon/, or looker/ folders",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -193,10 +170,7 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "enum": ["jetstream", "opmon", "looker"],
                     },
-                    "config_slug": {
-                        "type": "string",
-                        "description": "Config slug (filename without .toml extension)",
-                    },
+                    "config_slug": {"type": "string", "description": "Config slug (filename without .toml extension)"},
                 },
                 "required": ["config_type", "config_slug"],
             },
@@ -212,24 +186,15 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "enum": ["jetstream", "opmon", "looker"],
                     },
-                    "base_config_slug": {
-                        "type": "string",
-                        "description": "Optional: existing config slug to copy from",
-                    },
-                    "config_content": {
-                        "type": "string",
-                        "description": "Optional: TOML content for the new config",
-                    },
+                    "base_config_slug": {"type": "string", "description": "Optional: existing config slug to copy from"},
+                    "config_content": {"type": "string", "description": "Optional: TOML content for the new config"},
                 },
                 "required": ["new_config_slug", "config_type"],
             },
         ),
         Tool(
             name="generate_config_template",
-            description=(
-                "Generate a template for a new configuration"
-                " (jetstream experiment, opmon monitoring, or looker dashboard)"
-            ),
+            description="Generate a template for a new configuration (jetstream experiment, opmon monitoring, or looker dashboard)",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -239,11 +204,7 @@ async def list_tools() -> list[Tool]:
                     },
                     "template_type": {
                         "type": "string",
-                        "description": (
-                            "Template type. jetstream: 'basic', 'with_segments',"
-                            " 'with_custom_metrics', 'with_custom_data_source'."
-                            " opmon: 'basic', 'with_dimensions'. looker: 'basic'"
-                        ),
+                        "description": "Template type. jetstream: 'basic', 'with_segments', 'with_custom_metrics', 'with_custom_data_source'. opmon: 'basic', 'with_dimensions'. looker: 'basic'",
                     },
                     "platform": {"type": "string", "description": "Platform name"},
                 },
@@ -275,19 +236,13 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="list_glean_event_categories",
-            description=(
-                "List all Glean event categories for a product."
-                " Use this to orient when you don't know where to start."
-            ),
+            description="List all Glean event categories for a product. Use this to orient when you don't know where to start.",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "product": {
                         "type": "string",
-                        "description": (
-                            "Platform name (e.g. 'firefox_desktop', 'fenix')."
-                            " Defaults to 'firefox_desktop'."
-                        ),
+                        "description": "Platform name (e.g. 'firefox_desktop', 'fenix'). Defaults to 'firefox_desktop'.",
                     },
                 },
                 "required": [],
@@ -295,24 +250,14 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="search_glean_events",
-            description=(
-                "Search Glean events for a product by name, category, description, or tag."
-                " Returns event_category, event_name, and BigQuery details"
-                " needed to build a funnel."
-            ),
+            description="Search Glean events for a product by name, category, description, or tag. Returns event_category, event_name, and BigQuery details needed to build a funnel.",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Search term (e.g. 'tab group', 'create', 'save')",
-                    },
+                    "query": {"type": "string", "description": "Search term (e.g. 'tab group', 'create', 'save')"},
                     "product": {
                         "type": "string",
-                        "description": (
-                            "Platform name (e.g. 'firefox_desktop', 'fenix')."
-                            " Defaults to 'firefox_desktop'."
-                        ),
+                        "description": "Platform name (e.g. 'firefox_desktop', 'fenix'). Defaults to 'firefox_desktop'.",
                     },
                 },
                 "required": ["query"],
@@ -320,10 +265,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="get_glean_event",
-            description=(
-                "Get full details for a specific Glean event"
-                " including BigQuery table, filter, and extra keys."
-            ),
+            description="Get full details for a specific Glean event including BigQuery table, filter, and extra keys.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -341,46 +283,26 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="build_funnel_url",
-            description=(
-                "Generate a Looker event_funnel explore URL pre-populated with funnel steps."
-                " Validates events against the Glean dictionary. Supports up to 4 steps."
-            ),
+            description="Generate a Looker event_funnel explore URL pre-populated with funnel steps. Validates events against the Glean dictionary. Supports up to 4 steps.",
             inputSchema={
                 "type": "object",
                 "properties": {
                     "steps": {
                         "type": "array",
-                        "description": (
-                            "Ordered funnel steps. Each step needs event_category,"
-                            " event_name, and optionally label and description."
-                        ),
+                        "description": "Ordered funnel steps. Each step needs event_category, event_name, and optionally label and description.",
                         "items": {
                             "type": "object",
                             "properties": {
                                 "event_category": {"type": "string"},
                                 "event_name": {"type": "string"},
-                                "label": {
-                                    "type": "string",
-                                    "description": (
-                                        "Snake_case label for this step (e.g. 'created', 'saved')"
-                                    ),
-                                },
+                                "label": {"type": "string", "description": "Snake_case label for this step (e.g. 'created', 'saved')"},
                                 "description": {"type": "string"},
                                 "extra": {
                                     "type": "object",
                                     "description": "Optional extra key filter for this step.",
                                     "properties": {
-                                        "key": {
-                                            "type": "string",
-                                            "description": (
-                                                "Extra field path, e.g. 'strings.action',"
-                                                " 'booleans.checked', 'quantities.duration_ms'"
-                                            ),
-                                        },
-                                        "value": {
-                                            "type": "string",
-                                            "description": "Value to filter on",
-                                        },
+                                        "key": {"type": "string", "description": "Extra field path, e.g. 'strings.action', 'booleans.checked', 'quantities.duration_ms'"},
+                                        "value": {"type": "string", "description": "Value to filter on"},
                                     },
                                     "required": ["key", "value"],
                                 },
@@ -403,16 +325,8 @@ async def list_tools() -> list[Tool]:
                                 ],
                                 "description": "Country code(s) (e.g. 'US' or ['US', 'CA'])",
                             },
-                            "channel": {
-                                "type": "string",
-                                "description": (
-                                    "Release channel (e.g. 'release', 'beta', 'nightly')"
-                                ),
-                            },
-                            "os": {
-                                "type": "string",
-                                "description": "Operating system (e.g. 'Windows', 'Mac', 'Linux')",
-                            },
+                            "channel": {"type": "string", "description": "Release channel (e.g. 'release', 'beta', 'nightly')"},
+                            "os": {"type": "string", "description": "Operating system (e.g. 'Windows', 'Mac', 'Linux')"},
                         },
                     },
                 },
@@ -421,40 +335,23 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="list_monitored_features",
-            description=(
-                "List all Nimbus features that have feature monitoring (featmon) configs,"
-                " showing which metrics are tracked per feature"
-            ),
+            description="List all Nimbus features that have feature monitoring (featmon) configs, showing which metrics are tracked per feature",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "platform": {
-                        "type": "string",
-                        "description": "Optional: filter by platform (e.g. 'firefox_desktop')",
-                    },
+                    "platform": {"type": "string", "description": "Optional: filter by platform (e.g. 'firefox_desktop')"},
                 },
                 "required": [],
             },
         ),
         Tool(
             name="get_monitored_feature",
-            description=(
-                "Get detailed feature monitoring config for a specific Nimbus feature,"
-                " including all tracked metrics and data sources"
-            ),
+            description="Get detailed feature monitoring config for a specific Nimbus feature, including all tracked metrics and data sources",
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "feature_slug": {
-                        "type": "string",
-                        "description": (
-                            "Nimbus feature slug (e.g. 'address-autofill-feature') or TOML key"
-                        ),
-                    },
-                    "platform": {
-                        "type": "string",
-                        "description": "Optional: platform name (e.g. 'firefox_desktop')",
-                    },
+                    "feature_slug": {"type": "string", "description": "Nimbus feature slug (e.g. 'address-autofill-feature') or TOML key"},
+                    "platform": {"type": "string", "description": "Optional: platform name (e.g. 'firefox_desktop')"},
                 },
                 "required": ["feature_slug"],
             },
@@ -465,24 +362,16 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "status": {
-                        "type": "string",
-                        "description": "Filter by status: 'Live' or 'Complete'",
-                    },
+                    "status": {"type": "string", "description": "Filter by status: 'Live' or 'Complete'"},
                     "app_name": {"type": "string", "description": "Filter by application name"},
-                    "is_rollout": {
-                        "type": "boolean",
-                        "description": "Filter to rollouts (true) or experiments (false)",
-                    },
+                    "is_rollout": {"type": "boolean", "description": "Filter to rollouts (true) or experiments (false)"},
                 },
                 "required": [],
             },
         ),
         Tool(
             name="get_experiment",
-            description=(
-                "Get detailed information about a specific experiment or rollout from Experimenter"
-            ),
+            description="Get detailed information about a specific experiment or rollout from Experimenter",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -495,9 +384,7 @@ async def list_tools() -> list[Tool]:
 
 
 @app.call_tool()
-async def call_tool(
-    name: str, arguments: Any
-) -> list[TextContent | ImageContent | EmbeddedResource]:
+async def call_tool(name: str, arguments: Any) -> list[TextContent | ImageContent | EmbeddedResource]:
     try:
         match name:
             case "list_platforms":
@@ -559,10 +446,10 @@ async def main() -> None:
 
 async def run_sse_server(host: str = "0.0.0.0", port: int = 8080) -> None:
     """Run the MCP server via HTTP SSE (Cloud Run mode)."""
-    import uvicorn
     from mcp.server.sse import SseServerTransport
     from starlette.applications import Starlette
     from starlette.routing import Mount, Route
+    import uvicorn
 
     sse = SseServerTransport("/messages/")
 
@@ -584,7 +471,6 @@ async def run_sse_server(host: str = "0.0.0.0", port: int = 8080) -> None:
 def cli() -> None:
     """CLI entry point for local stdio mode."""
     import asyncio
-
     asyncio.run(main())
 
 

--- a/lib/mcp-server/metric_hub_mcp/server.py
+++ b/lib/mcp-server/metric_hub_mcp/server.py
@@ -20,6 +20,10 @@ from .experiments import (
     handle_list_experiment_configs,
     handle_list_experiments,
 )
+from .featmon import (
+    handle_get_monitored_feature,
+    handle_list_monitored_features,
+)
 from .funnels import (
     handle_build_funnel_url,
     handle_get_glean_event,
@@ -59,8 +63,16 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "platform": {"type": "string", "description": "Platform name (e.g., 'firefox_desktop', 'fenix', 'ads')"},
-                    "category": {"type": "string", "description": "Optional: filter by category (e.g., 'search', 'performance')"},
+                    "platform": {
+                        "type": "string",
+                        "description": "Platform name (e.g., 'firefox_desktop', 'fenix', 'ads')",
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": (
+                            "Optional: filter by category (e.g., 'search', 'performance')"
+                        ),
+                    },
                 },
                 "required": ["platform"],
             },
@@ -95,7 +107,10 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "platform": {"type": "string", "description": "Platform name"},
-                    "data_source_name": {"type": "string", "description": "Name of the data source"},
+                    "data_source_name": {
+                        "type": "string",
+                        "description": "Name of the data source",
+                    },
                 },
                 "required": ["platform", "data_source_name"],
             },
@@ -107,7 +122,10 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "query": {"type": "string", "description": "Search query"},
-                    "platform": {"type": "string", "description": "Optional: limit search to a specific platform"},
+                    "platform": {
+                        "type": "string",
+                        "description": "Optional: limit search to a specific platform",
+                    },
                 },
                 "required": ["query"],
             },
@@ -118,7 +136,10 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "metric_name": {"type": "string", "description": "Name for the new metric (snake_case)"},
+                    "metric_name": {
+                        "type": "string",
+                        "description": "Name for the new metric (snake_case)",
+                    },
                     "data_source": {"type": "string", "description": "Data source to use"},
                     "metric_type": {
                         "type": "string",
@@ -143,7 +164,10 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="list_experiment_configs",
-            description="List configuration files. Use 'jetstream' for experiment configs, 'opmon' for operational monitoring, 'looker' for Looker configs",
+            description=(
+                "List configuration files. Use 'jetstream' for experiment configs,"
+                " 'opmon' for operational monitoring, 'looker' for Looker configs"
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -158,7 +182,10 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="get_experiment_config",
-            description="Get the contents of an existing configuration file from jetstream/, opmon/, or looker/ folders",
+            description=(
+                "Get the contents of an existing configuration file"
+                " from jetstream/, opmon/, or looker/ folders"
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -166,7 +193,10 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "enum": ["jetstream", "opmon", "looker"],
                     },
-                    "config_slug": {"type": "string", "description": "Config slug (filename without .toml extension)"},
+                    "config_slug": {
+                        "type": "string",
+                        "description": "Config slug (filename without .toml extension)",
+                    },
                 },
                 "required": ["config_type", "config_slug"],
             },
@@ -182,15 +212,24 @@ async def list_tools() -> list[Tool]:
                         "type": "string",
                         "enum": ["jetstream", "opmon", "looker"],
                     },
-                    "base_config_slug": {"type": "string", "description": "Optional: existing config slug to copy from"},
-                    "config_content": {"type": "string", "description": "Optional: TOML content for the new config"},
+                    "base_config_slug": {
+                        "type": "string",
+                        "description": "Optional: existing config slug to copy from",
+                    },
+                    "config_content": {
+                        "type": "string",
+                        "description": "Optional: TOML content for the new config",
+                    },
                 },
                 "required": ["new_config_slug", "config_type"],
             },
         ),
         Tool(
             name="generate_config_template",
-            description="Generate a template for a new configuration (jetstream experiment, opmon monitoring, or looker dashboard)",
+            description=(
+                "Generate a template for a new configuration"
+                " (jetstream experiment, opmon monitoring, or looker dashboard)"
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -200,7 +239,11 @@ async def list_tools() -> list[Tool]:
                     },
                     "template_type": {
                         "type": "string",
-                        "description": "Template type. jetstream: 'basic', 'with_segments', 'with_custom_metrics', 'with_custom_data_source'. opmon: 'basic', 'with_dimensions'. looker: 'basic'",
+                        "description": (
+                            "Template type. jetstream: 'basic', 'with_segments',"
+                            " 'with_custom_metrics', 'with_custom_data_source'."
+                            " opmon: 'basic', 'with_dimensions'. looker: 'basic'"
+                        ),
                     },
                     "platform": {"type": "string", "description": "Platform name"},
                 },
@@ -232,13 +275,19 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="list_glean_event_categories",
-            description="List all Glean event categories for a product. Use this to orient when you don't know where to start.",
+            description=(
+                "List all Glean event categories for a product."
+                " Use this to orient when you don't know where to start."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
                     "product": {
                         "type": "string",
-                        "description": "Platform name (e.g. 'firefox_desktop', 'fenix'). Defaults to 'firefox_desktop'.",
+                        "description": (
+                            "Platform name (e.g. 'firefox_desktop', 'fenix')."
+                            " Defaults to 'firefox_desktop'."
+                        ),
                     },
                 },
                 "required": [],
@@ -246,14 +295,24 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="search_glean_events",
-            description="Search Glean events for a product by name, category, description, or tag. Returns event_category, event_name, and BigQuery details needed to build a funnel.",
+            description=(
+                "Search Glean events for a product by name, category, description, or tag."
+                " Returns event_category, event_name, and BigQuery details"
+                " needed to build a funnel."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "query": {"type": "string", "description": "Search term (e.g. 'tab group', 'create', 'save')"},
+                    "query": {
+                        "type": "string",
+                        "description": "Search term (e.g. 'tab group', 'create', 'save')",
+                    },
                     "product": {
                         "type": "string",
-                        "description": "Platform name (e.g. 'firefox_desktop', 'fenix'). Defaults to 'firefox_desktop'.",
+                        "description": (
+                            "Platform name (e.g. 'firefox_desktop', 'fenix')."
+                            " Defaults to 'firefox_desktop'."
+                        ),
                     },
                 },
                 "required": ["query"],
@@ -261,7 +320,10 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="get_glean_event",
-            description="Get full details for a specific Glean event including BigQuery table, filter, and extra keys.",
+            description=(
+                "Get full details for a specific Glean event"
+                " including BigQuery table, filter, and extra keys."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -279,26 +341,46 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="build_funnel_url",
-            description="Generate a Looker event_funnel explore URL pre-populated with funnel steps. Validates events against the Glean dictionary. Supports up to 4 steps.",
+            description=(
+                "Generate a Looker event_funnel explore URL pre-populated with funnel steps."
+                " Validates events against the Glean dictionary. Supports up to 4 steps."
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
                     "steps": {
                         "type": "array",
-                        "description": "Ordered funnel steps. Each step needs event_category, event_name, and optionally label and description.",
+                        "description": (
+                            "Ordered funnel steps. Each step needs event_category,"
+                            " event_name, and optionally label and description."
+                        ),
                         "items": {
                             "type": "object",
                             "properties": {
                                 "event_category": {"type": "string"},
                                 "event_name": {"type": "string"},
-                                "label": {"type": "string", "description": "Snake_case label for this step (e.g. 'created', 'saved')"},
+                                "label": {
+                                    "type": "string",
+                                    "description": (
+                                        "Snake_case label for this step (e.g. 'created', 'saved')"
+                                    ),
+                                },
                                 "description": {"type": "string"},
                                 "extra": {
                                     "type": "object",
                                     "description": "Optional extra key filter for this step.",
                                     "properties": {
-                                        "key": {"type": "string", "description": "Extra field path, e.g. 'strings.action', 'booleans.checked', 'quantities.duration_ms'"},
-                                        "value": {"type": "string", "description": "Value to filter on"},
+                                        "key": {
+                                            "type": "string",
+                                            "description": (
+                                                "Extra field path, e.g. 'strings.action',"
+                                                " 'booleans.checked', 'quantities.duration_ms'"
+                                            ),
+                                        },
+                                        "value": {
+                                            "type": "string",
+                                            "description": "Value to filter on",
+                                        },
                                     },
                                     "required": ["key", "value"],
                                 },
@@ -321,12 +403,60 @@ async def list_tools() -> list[Tool]:
                                 ],
                                 "description": "Country code(s) (e.g. 'US' or ['US', 'CA'])",
                             },
-                            "channel": {"type": "string", "description": "Release channel (e.g. 'release', 'beta', 'nightly')"},
-                            "os": {"type": "string", "description": "Operating system (e.g. 'Windows', 'Mac', 'Linux')"},
+                            "channel": {
+                                "type": "string",
+                                "description": (
+                                    "Release channel (e.g. 'release', 'beta', 'nightly')"
+                                ),
+                            },
+                            "os": {
+                                "type": "string",
+                                "description": "Operating system (e.g. 'Windows', 'Mac', 'Linux')",
+                            },
                         },
                     },
                 },
                 "required": ["steps"],
+            },
+        ),
+        Tool(
+            name="list_monitored_features",
+            description=(
+                "List all Nimbus features that have feature monitoring (featmon) configs,"
+                " showing which metrics are tracked per feature"
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "platform": {
+                        "type": "string",
+                        "description": "Optional: filter by platform (e.g. 'firefox_desktop')",
+                    },
+                },
+                "required": [],
+            },
+        ),
+        Tool(
+            name="get_monitored_feature",
+            description=(
+                "Get detailed feature monitoring config for a specific Nimbus feature,"
+                " including all tracked metrics and data sources"
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "feature_slug": {
+                        "type": "string",
+                        "description": (
+                            "Nimbus feature slug (e.g. 'address-autofill-feature') or TOML key"
+                        ),
+                    },
+                    "platform": {
+                        "type": "string",
+                        "description": "Optional: platform name (e.g. 'firefox_desktop')",
+                    },
+                },
+                "required": ["feature_slug"],
             },
         ),
         Tool(
@@ -335,16 +465,24 @@ async def list_tools() -> list[Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "status": {"type": "string", "description": "Filter by status: 'Live' or 'Complete'"},
+                    "status": {
+                        "type": "string",
+                        "description": "Filter by status: 'Live' or 'Complete'",
+                    },
                     "app_name": {"type": "string", "description": "Filter by application name"},
-                    "is_rollout": {"type": "boolean", "description": "Filter to rollouts (true) or experiments (false)"},
+                    "is_rollout": {
+                        "type": "boolean",
+                        "description": "Filter to rollouts (true) or experiments (false)",
+                    },
                 },
                 "required": [],
             },
         ),
         Tool(
             name="get_experiment",
-            description="Get detailed information about a specific experiment or rollout from Experimenter",
+            description=(
+                "Get detailed information about a specific experiment or rollout from Experimenter"
+            ),
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -357,7 +495,9 @@ async def list_tools() -> list[Tool]:
 
 
 @app.call_tool()
-async def call_tool(name: str, arguments: Any) -> list[TextContent | ImageContent | EmbeddedResource]:
+async def call_tool(
+    name: str, arguments: Any
+) -> list[TextContent | ImageContent | EmbeddedResource]:
     try:
         match name:
             case "list_platforms":
@@ -396,6 +536,10 @@ async def call_tool(name: str, arguments: Any) -> list[TextContent | ImageConten
                 return await handle_get_glean_event(arguments)
             case "build_funnel_url":
                 return await handle_build_funnel_url(arguments)
+            case "list_monitored_features":
+                return await handle_list_monitored_features(arguments)
+            case "get_monitored_feature":
+                return await handle_get_monitored_feature(arguments)
             case "list_experiments":
                 return await handle_list_experiments(arguments)
             case "get_experiment":
@@ -415,10 +559,10 @@ async def main() -> None:
 
 async def run_sse_server(host: str = "0.0.0.0", port: int = 8080) -> None:
     """Run the MCP server via HTTP SSE (Cloud Run mode)."""
+    import uvicorn
     from mcp.server.sse import SseServerTransport
     from starlette.applications import Starlette
     from starlette.routing import Mount, Route
-    import uvicorn
 
     sse = SseServerTransport("/messages/")
 
@@ -440,6 +584,7 @@ async def run_sse_server(host: str = "0.0.0.0", port: int = 8080) -> None:
 def cli() -> None:
     """CLI entry point for local stdio mode."""
     import asyncio
+
     asyncio.run(main())
 
 

--- a/lib/mcp-server/tests/test_server.py
+++ b/lib/mcp-server/tests/test_server.py
@@ -1,11 +1,11 @@
 """Tests for the MCP server."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from metric_hub_mcp.server import (
-    handle_list_platforms,
-    handle_generate_metric_template,
-    handle_validate_metric_config,
-)
+
+from metric_hub_mcp.featmon import handle_get_monitored_feature, handle_list_monitored_features
+from metric_hub_mcp.metrics import handle_generate_metric_template, handle_list_platforms
 
 
 @pytest.mark.asyncio
@@ -19,11 +19,13 @@ async def test_list_platforms():
 @pytest.mark.asyncio
 async def test_generate_simple_metric_template():
     """Test generating a simple metric template."""
-    result = await handle_generate_metric_template({
-        "metric_name": "test_metric",
-        "data_source": "clients_daily",
-        "metric_type": "simple",
-    })
+    result = await handle_generate_metric_template(
+        {
+            "metric_name": "test_metric",
+            "data_source": "clients_daily",
+            "metric_type": "simple",
+        }
+    )
 
     assert len(result) == 1
     text = result[0].text
@@ -40,11 +42,13 @@ async def test_generate_simple_metric_template():
 @pytest.mark.asyncio
 async def test_generate_derived_metric_template():
     """Test generating a derived metric template."""
-    result = await handle_generate_metric_template({
-        "metric_name": "derived_metric",
-        "data_source": "clients_daily",
-        "metric_type": "derived",
-    })
+    result = await handle_generate_metric_template(
+        {
+            "metric_name": "derived_metric",
+            "data_source": "clients_daily",
+            "metric_type": "derived",
+        }
+    )
 
     assert len(result) == 1
     text = result[0].text
@@ -55,61 +59,90 @@ async def test_generate_derived_metric_template():
     assert "metric1" in text
 
 
-@pytest.mark.asyncio
-async def test_validate_valid_metric():
-    """Test validating a valid metric configuration."""
-    config = """
-[metrics.test_metric]
-friendly_name = "Test Metric"
-description = "A test metric"
-data_source = "clients_daily"
-select_expression = '{{agg_sum("field")}}'
-category = "test"
-"""
+def _make_mock_config(features):
+    """Build a minimal mock ConfigCollection with featmon_configs."""
+    app_config = MagicMock()
+    app_config.slug = "firefox_desktop"
+    app_config.spec.dataset = "firefox_desktop"
+    app_config.spec.features = features
+    app_config.spec.data_sources = {
+        "metrics": MagicMock(
+            table_name="metrics",
+            type="metrics",
+            analysis_unit_id="client_info.client_id",
+            dimensions={"normalized_channel": {}},
+        ),
+    }
 
-    result = await handle_validate_metric_config({
-        "config_toml": config,
-        "platform": "firefox_desktop",
-    })
-
-    assert len(result) == 1
-    text = result[0].text
-    assert "valid" in text.lower() or "✅" in text
+    collection = MagicMock()
+    collection.featmon_configs = [app_config]
+    return collection
 
 
-@pytest.mark.asyncio
-async def test_validate_invalid_metric():
-    """Test validating an invalid metric configuration."""
-    config = """
-[metrics.invalid_metric]
-# Missing required fields
-friendly_name = "Invalid Metric"
-"""
-
-    result = await handle_validate_metric_config({
-        "config_toml": config,
-        "platform": "firefox_desktop",
-    })
-
-    assert len(result) == 1
-    text = result[0].text
-    assert "error" in text.lower() or "❌" in text
+def _make_feature(key, slug, metrics_by_source):
+    feat = MagicMock()
+    feat.name = key
+    feat.slug = slug
+    feat.nimbus_slug.return_value = slug if slug else key
+    feat.metrics_by_source = metrics_by_source
+    return feat
 
 
 @pytest.mark.asyncio
-async def test_validate_malformed_toml():
-    """Test validating malformed TOML."""
-    config = """
-[metrics.bad
-this is not valid toml
-"""
+async def test_list_monitored_features_returns_all():
+    features = {
+        "address_autofill_feature": _make_feature(
+            "address_autofill_feature",
+            "address-autofill-feature",
+            {"metrics": {"boolean": {"formautofill_availability": {}}}},
+        ),
+    }
+    mock_config = _make_mock_config(features)
 
-    result = await handle_validate_metric_config({
-        "config_toml": config,
-        "platform": "firefox_desktop",
-    })
+    with patch("metric_hub_mcp.featmon.get_config_collection", return_value=mock_config):
+        result = await handle_list_monitored_features({})
 
-    assert len(result) == 1
     text = result[0].text
-    assert "error" in text.lower() or "❌" in text
-    assert "parse" in text.lower() or "toml" in text.lower()
+    assert "address-autofill-feature" in text
+    assert "firefox_desktop" in text
+
+
+@pytest.mark.asyncio
+async def test_list_monitored_features_platform_filter():
+    features = {"my_feature": _make_feature("my_feature", None, {})}
+    mock_config = _make_mock_config(features)
+
+    with patch("metric_hub_mcp.featmon.get_config_collection", return_value=mock_config):
+        result = await handle_list_monitored_features({"platform": "fenix"})
+
+    assert "No monitored features found" in result[0].text
+
+
+@pytest.mark.asyncio
+async def test_get_monitored_feature_found():
+    features = {
+        "address_autofill_feature": _make_feature(
+            "address_autofill_feature",
+            "address-autofill-feature",
+            {"metrics": {"boolean": {"formautofill_availability": {}}}},
+        ),
+    }
+    mock_config = _make_mock_config(features)
+
+    with patch("metric_hub_mcp.featmon.get_config_collection", return_value=mock_config):
+        result = await handle_get_monitored_feature({"feature_slug": "address-autofill-feature"})
+
+    text = result[0].text
+    assert "address-autofill-feature" in text
+    assert "firefox_desktop" in text
+    assert "metrics" in text
+
+
+@pytest.mark.asyncio
+async def test_get_monitored_feature_not_found():
+    mock_config = _make_mock_config({})
+
+    with patch("metric_hub_mcp.featmon.get_config_collection", return_value=mock_config):
+        result = await handle_get_monitored_feature({"feature_slug": "nonexistent-feature"})
+
+    assert "not found" in result[0].text.lower()

--- a/lib/metric-config-parser/metric_config_parser/config.py
+++ b/lib/metric-config-parser/metric_config_parser/config.py
@@ -214,17 +214,40 @@ class DefinitionConfig(Config):
         analysis_spec.resolve(dummy_experiment, configs)
 
 
+@attr.s(auto_attribs=True)
+class FeatmonConfig:
+    """Represents a feature monitoring config file for a single application."""
+
+    slug: str  # app name inferred from file stem (e.g. "firefox_desktop")
+    spec: FeatmonSpec
+
+    def validate(self, configs: "ConfigCollection", _experiment=None) -> None:
+        # Structural validation (e.g. valid source types) is already performed by
+        # FeatmonSpec.__attrs_post_init__ at parse time. No cross-config validation
+        # is needed here, so this stub intentionally does nothing.
+        pass
+
+
 def entity_from_path(
     path: Path, is_private: bool = False
-) -> Config | Outcome | DefaultConfig | DefinitionConfig | FunctionsSpec:
+) -> Config | Outcome | DefaultConfig | DefinitionConfig | FunctionsSpec | FeatmonConfig:
     is_outcome = path.parent.parent.name == OUTCOMES_DIR
     is_default_config = path.parent.name == DEFAULTS_DIR
     is_definition_config = path.parent.name == DEFINITIONS_DIR
+    is_featmon = path.parent.name == FEATMON_DIR
     slug = path.stem
 
-    validate_config_settings(path)
-
     config_dict = toml.loads(path.read_text())
+
+    # featmon TOMLs have their own schema (data_sources/features) that is not
+    # compatible with validate_config_settings, which checks jetstream/opmon keys
+    if is_featmon:
+        return FeatmonConfig(
+            slug=slug,
+            spec=FeatmonSpec.from_dict(config_dict, dataset=slug),
+        )
+
+    validate_config_settings(path)
 
     if is_outcome:
         platform = path.parent.name
@@ -315,7 +338,7 @@ class ConfigCollection:
     functions: FunctionsSpec | None = None
     repos: list[Repository] = attr.Factory(list)  # repos configs were loaded from
     is_private: bool = False
-    featmon_configs: dict[str, FeatmonSpec] = attr.Factory(dict)
+    featmon_configs: list[FeatmonConfig] = attr.Factory(list)
 
     repo_url = "https://github.com/mozilla/metric-hub"
 
@@ -481,12 +504,16 @@ class ConfigCollection:
         for functions_file in files_path.glob(f"{DEFINITIONS_DIR}/{FUNCTIONS_FILE}"):
             functions_spec = FunctionsSpec.from_dict(toml.load(functions_file))
 
+        featmons = []
         featmon_dir = files_path / FEATMON_DIR
-        featmon_configs = (
-            {p.stem: FeatmonSpec.from_file(p) for p in sorted(featmon_dir.glob("*.toml"))}
-            if featmon_dir.is_dir()
-            else {}
-        )
+        if featmon_dir.is_dir():
+            for featmon_file in sorted(featmon_dir.glob("*.toml")):
+                featmons.append(
+                    FeatmonConfig(
+                        slug=featmon_file.stem,
+                        spec=FeatmonSpec.from_file(featmon_file),
+                    )
+                )
 
         return cls(
             external_configs,
@@ -503,7 +530,7 @@ class ConfigCollection:
                 )
             ],
             is_private=is_private,
-            featmon_configs=featmon_configs,
+            featmon_configs=featmons,
         )
 
     def as_of(self, timestamp: datetime) -> "ConfigCollection":
@@ -813,7 +840,11 @@ class ConfigCollection:
             self.functions.functions = functions
 
         # merge featmon configs (other takes precedence)
-        self.featmon_configs = {**self.featmon_configs, **other.featmon_configs}
+        featmons = {fc.slug: fc for fc in deepcopy(other.featmon_configs)}
+        for fc in self.featmon_configs:
+            if fc.slug not in featmons:
+                featmons[fc.slug] = fc
+        self.featmon_configs = list(featmons.values())
 
         self.repos += other.repos
 
@@ -912,6 +943,17 @@ class LocalConfigCollection(ConfigCollection):
         for functions_file in files_path.glob(f"{DEFINITIONS_DIR}/{FUNCTIONS_FILE}"):
             functions_spec = FunctionsSpec.from_dict(toml.load(functions_file))
 
+        featmons = []
+        featmon_dir = files_path / FEATMON_DIR
+        if featmon_dir.is_dir():
+            for featmon_file in sorted(featmon_dir.glob("*.toml")):
+                featmons.append(
+                    FeatmonConfig(
+                        slug=featmon_file.stem,
+                        spec=FeatmonSpec.from_file(featmon_file),
+                    )
+                )
+
         return cls(
             external_configs,
             outcomes,
@@ -920,6 +962,7 @@ class LocalConfigCollection(ConfigCollection):
             functions_spec,
             repos=[],
             is_private=is_private,
+            featmon_configs=featmons,
         )
 
     @classmethod

--- a/lib/metric-config-parser/metric_config_parser/config.py
+++ b/lib/metric-config-parser/metric_config_parser/config.py
@@ -23,6 +23,7 @@ from metric_config_parser.segment import SegmentDataSourceDefinition, SegmentDef
 from .analysis import AnalysisSpec
 from .errors import UnexpectedKeyConfigurationException
 from .experiment import Channel, Experiment
+from .featmon import FEATMON_DIR, FeatmonSpec
 from .metric import MetricDefinition
 from .outcome import OutcomeSpec
 from .sql import generate_data_source_sql, generate_metrics_sql
@@ -314,6 +315,7 @@ class ConfigCollection:
     functions: FunctionsSpec | None = None
     repos: list[Repository] = attr.Factory(list)  # repos configs were loaded from
     is_private: bool = False
+    featmon_configs: dict[str, FeatmonSpec] = attr.Factory(dict)
 
     repo_url = "https://github.com/mozilla/metric-hub"
 
@@ -479,6 +481,13 @@ class ConfigCollection:
         for functions_file in files_path.glob(f"{DEFINITIONS_DIR}/{FUNCTIONS_FILE}"):
             functions_spec = FunctionsSpec.from_dict(toml.load(functions_file))
 
+        featmon_dir = files_path / FEATMON_DIR
+        featmon_configs = (
+            {p.stem: FeatmonSpec.from_file(p) for p in sorted(featmon_dir.glob("*.toml"))}
+            if featmon_dir.is_dir()
+            else {}
+        )
+
         return cls(
             external_configs,
             outcomes,
@@ -494,6 +503,7 @@ class ConfigCollection:
                 )
             ],
             is_private=is_private,
+            featmon_configs=featmon_configs,
         )
 
     def as_of(self, timestamp: datetime) -> "ConfigCollection":
@@ -801,6 +811,9 @@ class ConfigCollection:
             self.functions = FunctionsSpec(functions=functions)
         else:
             self.functions.functions = functions
+
+        # merge featmon configs (other takes precedence)
+        self.featmon_configs = {**self.featmon_configs, **other.featmon_configs}
 
         self.repos += other.repos
 

--- a/lib/metric-config-parser/metric_config_parser/featmon.py
+++ b/lib/metric-config-parser/metric_config_parser/featmon.py
@@ -10,21 +10,21 @@ Each file defines:
 
 The ``dataset`` is derived from the filename stem (e.g. ``firefox_desktop.toml``
 → ``firefox_desktop``).
+
+Featmon configs are loaded automatically by ``ConfigCollection.from_github_repo()``
+and are accessible via ``ConfigCollection.featmon_configs``.
 """
 
-import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 import attr
 import toml
-from git import Repo
 
 VALID_SOURCE_TYPES = frozenset({"metrics", "event_stream", "clients_daily"})
 
 FEATMON_DIR = "featmon"
-METRIC_HUB_URL = "https://github.com/mozilla/metric-hub"
 
 
 @attr.s(auto_attribs=True)
@@ -59,25 +59,15 @@ class FeatureSpec:
 class FeatmonSpec:
     """Represents a Nimbus feature monitoring config file for a single application.
 
-    The expected use is like::
+    The expected use is via ``ConfigCollection``::
 
-        FeatmonSpec.from_file(Path("featmon/firefox_desktop.toml"))
+        collection = ConfigCollection.from_github_repo()
+        for app_name, spec in collection.featmon_configs.items():
+            ...
 
     Config files are TOML and live in ``featmon/`` in metric-hub, one per
     application (e.g. ``firefox_desktop.toml``).  The ``dataset`` is inferred
     from the filename stem so it does not need to be repeated in the file.
-
-    To load all configs from a metric-hub repo checkout::
-
-        specs = FeatmonSpec.configs_from_repo(Path("/path/to/metric-hub"))
-        for app_name, spec in specs:
-            ...
-
-    To load configs directly from GitHub (or a local clone)::
-
-        specs = FeatmonSpec.from_github_repo()                        # clones metric-hub
-        specs = FeatmonSpec.from_github_repo("/path/to/metric-hub")   # local clone
-        specs = FeatmonSpec.from_github_repo("https://github.com/...") # custom URL
     """
 
     dataset: str
@@ -121,45 +111,3 @@ class FeatmonSpec:
         → dataset ``firefox_desktop``).
         """
         return cls.from_dict(toml.load(str(path)), dataset=path.stem)
-
-    @staticmethod
-    def configs_from_repo(repo_path: Path) -> "list[tuple[str, FeatmonSpec]]":
-        """Load all featmon configs from a metric-hub checkout.
-
-        Args:
-            repo_path: Path to the root of a metric-hub repository checkout.
-
-        Returns:
-            Sorted list of ``(app_name, spec)`` tuples, one per TOML file found
-            in the ``featmon/`` directory.
-        """
-        config_dir = repo_path / FEATMON_DIR
-        if not config_dir.is_dir():
-            return []
-        return [(p.stem, FeatmonSpec.from_file(p)) for p in sorted(config_dir.glob("*.toml"))]
-
-    @classmethod
-    def from_github_repo(cls, repo_url: str | None = None) -> "list[tuple[str, FeatmonSpec]]":
-        """Load all featmon configs from a metric-hub repo URL or local path.
-
-        If ``repo_url`` is a local directory, reads configs directly from it.
-        If ``repo_url`` is a GitHub URL (or ``None``, which defaults to the
-        canonical metric-hub URL), the repo is cloned to a temporary directory.
-
-        Args:
-            repo_url: Local path or GitHub URL of a metric-hub checkout.
-                      Defaults to ``https://github.com/mozilla/metric-hub``.
-
-        Returns:
-            Sorted list of ``(app_name, spec)`` tuples.
-        """
-        url = repo_url or METRIC_HUB_URL
-
-        if Path(url).exists() and Path(url).is_dir():
-            repo_path = Path(url)
-        else:
-            tmp_dir = Path(tempfile.mkdtemp())
-            Repo.clone_from(url, tmp_dir)
-            repo_path = tmp_dir
-
-        return cls.configs_from_repo(repo_path)

--- a/lib/metric-config-parser/metric_config_parser/featmon.py
+++ b/lib/metric-config-parser/metric_config_parser/featmon.py
@@ -12,16 +12,19 @@ The ``dataset`` is derived from the filename stem (e.g. ``firefox_desktop.toml``
 → ``firefox_desktop``).
 """
 
+import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 import attr
 import toml
+from git import Repo
 
 VALID_SOURCE_TYPES = frozenset({"metrics", "event_stream", "clients_daily"})
 
 FEATMON_DIR = "featmon"
+METRIC_HUB_URL = "https://github.com/mozilla/metric-hub"
 
 
 @attr.s(auto_attribs=True)
@@ -69,6 +72,12 @@ class FeatmonSpec:
         specs = FeatmonSpec.configs_from_repo(Path("/path/to/metric-hub"))
         for app_name, spec in specs:
             ...
+
+    To load configs directly from GitHub (or a local clone)::
+
+        specs = FeatmonSpec.from_github_repo()                        # clones metric-hub
+        specs = FeatmonSpec.from_github_repo("/path/to/metric-hub")   # local clone
+        specs = FeatmonSpec.from_github_repo("https://github.com/...") # custom URL
     """
 
     dataset: str
@@ -128,3 +137,29 @@ class FeatmonSpec:
         if not config_dir.is_dir():
             return []
         return [(p.stem, FeatmonSpec.from_file(p)) for p in sorted(config_dir.glob("*.toml"))]
+
+    @classmethod
+    def from_github_repo(cls, repo_url: str | None = None) -> "list[tuple[str, FeatmonSpec]]":
+        """Load all featmon configs from a metric-hub repo URL or local path.
+
+        If ``repo_url`` is a local directory, reads configs directly from it.
+        If ``repo_url`` is a GitHub URL (or ``None``, which defaults to the
+        canonical metric-hub URL), the repo is cloned to a temporary directory.
+
+        Args:
+            repo_url: Local path or GitHub URL of a metric-hub checkout.
+                      Defaults to ``https://github.com/mozilla/metric-hub``.
+
+        Returns:
+            Sorted list of ``(app_name, spec)`` tuples.
+        """
+        url = repo_url or METRIC_HUB_URL
+
+        if Path(url).exists() and Path(url).is_dir():
+            repo_path = Path(url)
+        else:
+            tmp_dir = Path(tempfile.mkdtemp())
+            Repo.clone_from(url, tmp_dir)
+            repo_path = tmp_dir
+
+        return cls.configs_from_repo(repo_path)

--- a/lib/metric-config-parser/metric_config_parser/featmon.py
+++ b/lib/metric-config-parser/metric_config_parser/featmon.py
@@ -62,7 +62,7 @@ class FeatmonSpec:
     The expected use is via ``ConfigCollection``::
 
         collection = ConfigCollection.from_github_repo()
-        for app_name, spec in collection.featmon_configs.items():
+        for app_config in collection.featmon_configs:
             ...
 
     Config files are TOML and live in ``featmon/`` in metric-hub, one per

--- a/lib/metric-config-parser/metric_config_parser/tests/test_config.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_config.py
@@ -979,8 +979,10 @@ class TestFeatmonConfig:
         from metric_config_parser.featmon import FeatmonSpec
 
         spec = FeatmonSpec.from_dict(
-            {"data_sources": {"metrics": {"table_name": "metrics", "type": "metrics"}},
-             "features": {}},
+            {
+                "data_sources": {"metrics": {"table_name": "metrics", "type": "metrics"}},
+                "features": {},
+            },
             dataset="firefox_desktop",
         )
         config = FeatmonConfig(slug="firefox_desktop", spec=spec)
@@ -992,8 +994,10 @@ class TestFeatmonConfig:
         from metric_config_parser.featmon import FeatmonSpec
 
         spec = FeatmonSpec.from_dict(
-            {"data_sources": {"metrics": {"table_name": "metrics", "type": "metrics"}},
-             "features": {}},
+            {
+                "data_sources": {"metrics": {"table_name": "metrics", "type": "metrics"}},
+                "features": {},
+            },
             dataset="firefox_desktop",
         )
         config = FeatmonConfig(slug="firefox_desktop", spec=spec)

--- a/lib/metric-config-parser/metric_config_parser/tests/test_config.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_config.py
@@ -18,8 +18,10 @@ from metric_config_parser.config import (
     ConfigCollection,
     DefaultConfig,
     DefinitionConfig,
+    FeatmonConfig,
     LocalConfigCollection,
     Outcome,
+    entity_from_path,
 )
 from metric_config_parser.data_source import DataSourceJoinRelationship
 from metric_config_parser.errors import DefinitionNotFound
@@ -952,3 +954,97 @@ class TestConfigIntegration:
 
         outcomes = [o.slug for o in config_collection.outcomes]
         assert len(outcomes) == 4
+
+
+class TestFeatmonConfig:
+    FIREFOX_DESKTOP_TOML = dedent(
+        """
+        [data_sources.metrics]
+        table_name = "metrics"
+        type = "metrics"
+        analysis_unit_id = "metrics.uuid.legacy_telemetry_profile_group_id"
+
+        [data_sources.metrics.dimensions]
+        normalized_channel = {}
+
+        [features.my_feature]
+        slug = "my-feature"
+
+        [features.my_feature.metrics_by_source.metrics.boolean]
+        some_flag = {}
+        """
+    )
+
+    def test_featmon_config_attributes(self):
+        from metric_config_parser.featmon import FeatmonSpec
+
+        spec = FeatmonSpec.from_dict(
+            {"data_sources": {"metrics": {"table_name": "metrics", "type": "metrics"}},
+             "features": {}},
+            dataset="firefox_desktop",
+        )
+        config = FeatmonConfig(slug="firefox_desktop", spec=spec)
+        assert config.slug == "firefox_desktop"
+        assert config.spec.dataset == "firefox_desktop"
+        assert "metrics" in config.spec.data_sources
+
+    def test_featmon_config_validate_is_noop(self):
+        from metric_config_parser.featmon import FeatmonSpec
+
+        spec = FeatmonSpec.from_dict(
+            {"data_sources": {"metrics": {"table_name": "metrics", "type": "metrics"}},
+             "features": {}},
+            dataset="firefox_desktop",
+        )
+        config = FeatmonConfig(slug="firefox_desktop", spec=spec)
+        # validate() is a stub; validation happens in FeatmonSpec.__attrs_post_init__
+        config.validate(ConfigCollection())  # must not raise
+
+    def test_entity_from_path_recognizes_featmon(self, tmp_path):
+        featmon_dir = tmp_path / "featmon"
+        featmon_dir.mkdir()
+        (featmon_dir / "firefox_desktop.toml").write_text(self.FIREFOX_DESKTOP_TOML)
+        entity = entity_from_path(featmon_dir / "firefox_desktop.toml")
+        assert isinstance(entity, FeatmonConfig)
+        assert entity.slug == "firefox_desktop"
+        assert entity.spec.dataset == "firefox_desktop"
+        assert "my_feature" in entity.spec.features
+        assert entity.spec.features["my_feature"].nimbus_slug() == "my-feature"
+
+    def test_config_collection_loads_featmon_from_local_repo(self, tmp_path):
+        r = Repo.init(tmp_path)
+        r.config_writer().set_value("user", "name", "test").release()
+        r.config_writer().set_value("user", "email", "test@example.com").release()
+        r.config_writer().set_value("commit", "gpgsign", "false").release()
+
+        featmon_dir = tmp_path / "featmon"
+        featmon_dir.mkdir()
+        (featmon_dir / "firefox_desktop.toml").write_text(self.FIREFOX_DESKTOP_TOML)
+        r.git.add(".")
+        r.git.commit("-m", "add featmon config")
+
+        collection = ConfigCollection.from_github_repo(tmp_path)
+        assert len(collection.featmon_configs) == 1
+        app = collection.featmon_configs[0]
+        assert app.slug == "firefox_desktop"
+        assert app.spec.dataset == "firefox_desktop"
+        assert "my_feature" in app.spec.features
+
+    def test_featmon_merge(self, tmp_path):
+        r = Repo.init(tmp_path)
+        r.config_writer().set_value("user", "name", "test").release()
+        r.config_writer().set_value("user", "email", "test@example.com").release()
+        r.config_writer().set_value("commit", "gpgsign", "false").release()
+
+        featmon_dir = tmp_path / "featmon"
+        featmon_dir.mkdir()
+        (featmon_dir / "firefox_desktop.toml").write_text(self.FIREFOX_DESKTOP_TOML)
+        r.git.add(".")
+        r.git.commit("-m", "add featmon config")
+
+        collection1 = ConfigCollection.from_github_repo(tmp_path)
+        collection2 = ConfigCollection.from_github_repo(tmp_path)
+
+        collection1.merge(collection2)
+        # after merge, de-duplication by slug should keep only one entry
+        assert len(collection1.featmon_configs) == 1

--- a/lib/metric-config-parser/pyproject.toml
+++ b/lib/metric-config-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-metric-config-parser"
-version = "2026.4.2"
+version = "2026.4.3"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Parses metric configuration files."
 readme = "README.md"


### PR DESCRIPTION
Part of [EXP-6732](https://mozilla-hub.atlassian.net/browse/EXP-6732) — moving Nimbus feature monitoring configs from hardcoded bigquery-etl YAML files into metric-hub TOML.

This PR makes featmon configs a first-class config type in `ConfigCollection`, so they load the same way as jetstream/opmon configs and can be accessed via `ConfigCollection.from_github_repo().featmon_configs.`

What's in here
-` FeatmonConfig `class — a slim wrapper around `FeatmonSpec (slug + spec), `following the same pattern as Outcome. Plugs into `entity_from_path() `and validate.py so featmon files get validated in CI like everything else.
- `ConfigCollection.featmon_configs` — `a list[FeatmonConfig] `populated automatically when you load from GitHub or a local repo. The old` FeatmonSpec.configs_from_repo() `method is removed since `ConfigCollection `handles this now.
- Two new MCP tools — `list_monitored_features` and` get_monitored_feature`, so AI assistants can discover and inspect featmon configs.
- Tests — TestFeatmonConfig covering the new class, plus 4 MCP handler tests.
Notes
- The featmon check in `entity_from_path()` runs before `validate_config_settings()` — featmon TOMLs use data_sources/features keys that would otherwise be rejected by the jetstream/opmon schema checker.
- The companion bigquery-etl PR updates the SQL generator to read from `ConfigCollection` instead of the local YAML templates.
- Bumps version to 2026.4.3.

Relates to EXP-6732
https://github.com/mozilla/experimenter/issues/15387
https://github.com/mozilla/experimenter/issues/15428 