### PR TITLE
Enable segments and extend enrollment_period for vpn-mvp-beta-holdback

### DIFF
--- a/jetstream/vpn-mvp-beta-holdback.toml
+++ b/jetstream/vpn-mvp-beta-holdback.toml
@@ -1,5 +1,12 @@
 [experiment]
-enrollment_period = 5
+enrollment_period = 8
+segments = [
+  "country_de",
+  "country_fr",
+  "country_gb",
+  "country_us",
+  "new_users",
+]
 
 [metrics]
 daily = ["retained_dau", "vpn_started", "vpn_get_started"]


### PR DESCRIPTION
## Summary

Follow-up to #1405. Two changes:

- **Opt in to the segments that were defined in #1405.** The segment blocks (`country_de/fr/gb/us`, `new_users`) were defined but never referenced under \`[experiment].segments\`, so the rerun only computed the default \`all\` segment. Listing them explicitly triggers per-segment statistics.
- **Extend \`enrollment_period\` from 5 to 8 days.**

This will trigger a full rerun (custom config change).

## Test plan

- [ ] CI passes (validate-jetstream)
- [ ] After rerun, \`statistics_vpn_mvp_beta_holdback_daily\` contains rows with \`segment\` in \`{country_de, country_fr, country_gb, country_us, new_users, all}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)