### PR TITLE
Add Jetstream config for optimize-multi-actiontail-fox-modals-for-existing-users-v2

### DIFF
--- a/jetstream/optimize-multi-actiontail-fox-modals-for-existing-users-v2.toml
+++ b/jetstream/optimize-multi-actiontail-fox-modals-for-existing-users-v2.toml
@@ -9,8 +9,14 @@ segments = [
 ]
 
 [metrics]
+# Note: is_default_browser and retained auto-apply, but we re-list them here to
+# force the Experimenter UI Results tab to surface them alongside is_pinned.
+# Both are binomial in definitions/firefox_desktop.toml — re-listing preserves
+# the default stat (no CUPED concern; binomial doesn't use covariate adjustment).
 weekly = [
+  "is_default_browser",
   "is_pinned",
+  "retained",
   "imported_bookmarks",
   "imported_history",
   "imported_logins",
@@ -20,7 +26,9 @@ weekly = [
   "shutdown_hangs",
 ]
 overall = [
+  "is_default_browser",
   "is_pinned",
+  "retained",
   "imported_bookmarks",
   "imported_history",
   "imported_logins",

--- a/jetstream/optimize-multi-actiontail-fox-modals-for-existing-users-v2.toml
+++ b/jetstream/optimize-multi-actiontail-fox-modals-for-existing-users-v2.toml
@@ -1,116 +1,91 @@
 [experiment]
-
 segments = [
   "last_dau_28_plus_days_ago",
   "last_dau_28_to_34_days_ago",
   "last_dau_35_to_59_days_ago",
   "last_dau_60_to_119_days_ago",
   "last_dau_120_to_179_days_ago",
-  "last_dau_180_plus_days_ago",
+  "new_or_last_dau_180plus_days_ago",
 ]
 
 [metrics]
-
-# Retention (retained), DAU (client_level_daily_active_users_v2),
-# is_default_browser, and all search metrics auto-apply on desktop
-# experiments via jetstream/defaults/firefox_desktop.toml. Don't re-list.
-
 weekly = [
   "is_pinned",
   "imported_bookmarks",
   "imported_history",
   "imported_logins",
-  "any_browser_import",
+  "main_crashes",
+  "content_crashes",
+  "startup_crashes",
+  "shutdown_hangs",
 ]
-
 overall = [
   "is_pinned",
   "imported_bookmarks",
   "imported_history",
   "imported_logins",
-  "any_browser_import",
+  "main_crashes",
+  "content_crashes",
+  "startup_crashes",
+  "shutdown_hangs",
 ]
 
-[metrics.any_browser_import.statistics.binomial]
-
-[metrics.any_browser_import]
-friendly_name = "Any Browser Import"
-description = "Client imported bookmarks, history, OR logins during the analysis window"
-select_expression = """
-  LOGICAL_OR(
-    (bookmark_migrations_quantity_all IS NOT NULL AND bookmark_migrations_quantity_all != 0)
-    OR (history_migrations_quantity_all IS NOT NULL AND history_migrations_quantity_all != 0)
-    OR (logins_migrations_quantity_all IS NOT NULL AND logins_migrations_quantity_all != 0)
-  )
-"""
-data_source = "clients_daily"
-
-# ============================================================================
-# SEGMENTS - Lapse cohorts by last DAU before enrollment
-# ============================================================================
-# Pattern from recommended-add-ons-os-notification-experiment.toml.
-# 365-day lookback so the 180+ bucket picks up long-lapsed users cleanly.
-# Non-overlapping boundaries (inclusive lower, exclusive upper via BETWEEN
-# with adjusted ends).
-
 [segments.last_dau_28_plus_days_ago]
-friendly_name = "Last DAU 28+ days ago (superset)"
-description = "Clients whose last DAU was 28 or more days before enrollment (includes all lapse buckets below)"
+friendly_name = "Last DAU 28+ days ago"
+description = "Clients whose last DAU was 28+ days before enrollment (or no DAU observed in 183-day lookback). Superset of all sub-buckets below."
 select_expression = """
-  COALESCE(
+  (
     MAX(submission_date) IS NULL
-    OR DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) >= 28,
-    FALSE
+    OR DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) >= 28
   )
 """
 data_source = "active_users_last_seen"
-window_start = -365
+window_start = -183
 window_end = -1
 
 [segments.last_dau_28_to_34_days_ago]
 friendly_name = "Last DAU 28 to 34 days ago"
-description = "Clients whose last DAU was 28-34 days before enrollment"
+description = "Clients whose last DAU was 28–34 days before enrollment."
 select_expression = "COALESCE(DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) BETWEEN 28 AND 34, FALSE)"
 data_source = "active_users_last_seen"
-window_start = -365
+window_start = -183
 window_end = -1
 
 [segments.last_dau_35_to_59_days_ago]
 friendly_name = "Last DAU 35 to 59 days ago"
-description = "Clients whose last DAU was 35-59 days before enrollment"
+description = "Clients whose last DAU was 35–59 days before enrollment."
 select_expression = "COALESCE(DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) BETWEEN 35 AND 59, FALSE)"
 data_source = "active_users_last_seen"
-window_start = -365
+window_start = -183
 window_end = -1
 
 [segments.last_dau_60_to_119_days_ago]
 friendly_name = "Last DAU 60 to 119 days ago"
-description = "Clients whose last DAU was 60-119 days before enrollment"
+description = "Clients whose last DAU was 60–119 days before enrollment."
 select_expression = "COALESCE(DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) BETWEEN 60 AND 119, FALSE)"
 data_source = "active_users_last_seen"
-window_start = -365
+window_start = -183
 window_end = -1
 
 [segments.last_dau_120_to_179_days_ago]
 friendly_name = "Last DAU 120 to 179 days ago"
-description = "Clients whose last DAU was 120-179 days before enrollment"
+description = "Clients whose last DAU was 120–179 days before enrollment."
 select_expression = "COALESCE(DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) BETWEEN 120 AND 179, FALSE)"
 data_source = "active_users_last_seen"
-window_start = -365
+window_start = -183
 window_end = -1
 
-[segments.last_dau_180_plus_days_ago]
-friendly_name = "Last DAU 180+ days ago"
-description = "Clients whose last DAU was 180+ days before enrollment (or no DAU observed in 365d lookback)"
+[segments.new_or_last_dau_180plus_days_ago]
+friendly_name = "New or last DAU 180+ days ago"
+description = "Clients whose last DAU was 180+ days before enrollment, or with no DAU observed in the 183-day lookback window."
 select_expression = """
-  COALESCE(
+  (
     MAX(submission_date) IS NULL
-    OR DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) >= 180,
-    FALSE
+    OR DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) >= 180
   )
 """
 data_source = "active_users_last_seen"
-window_start = -365
+window_start = -183
 window_end = -1
 
 [segments.data_sources.active_users_last_seen]
@@ -122,6 +97,6 @@ from_expression = """(
   FROM `mozdata.telemetry.desktop_active_users`
   WHERE is_desktop
     AND is_dau
-    AND submission_date >= DATE_SUB('2026-03-23', INTERVAL 365 DAY)
+    AND submission_date >= DATE_SUB('2026-03-23', INTERVAL 183 DAY)
 )"""
-window_start = -365
+window_start = -183


### PR DESCRIPTION
Adds a custom Jetstream config for the `optimize-multi-actiontail-fox-modals-for-existing-users-v2` experiment.

## What this adds

**Metrics** (weekly + overall):
- `is_pinned` — built-in but not auto-applied; listed so Jetstream surfaces pin rate per branch (primary fix; Experimenter UI currently shows no pin data)
- `imported_bookmarks`, `imported_history`, `imported_logins` — built-in binomials for browser-import rate
- `main_crashes`, `content_crashes`, `startup_crashes`, `shutdown_hangs` — built-in guardrails

Default-browser rate, retention, DAU, search, and ad metrics are omitted because they auto-apply.

**Segments** (6 custom lapse buckets based on last DAU before enrollment):
- `last_dau_28_plus_days_ago` (superset catchall)
- `last_dau_28_to_34_days_ago`
- `last_dau_35_to_59_days_ago`
- `last_dau_60_to_119_days_ago`
- `last_dau_120_to_179_days_ago`
- `new_or_last_dau_180plus_days_ago`

All six use `active_users_last_seen` (defined under `[segments.data_sources]`), modeled on `os-notification-split-view-release-lapsed-users.toml`.

## Experiment context

- Nimbus: https://experimenter.services.mozilla.com/nimbus/optimize-multi-actiontail-fox-modals-for-existing-users-v2/summary/
- Brief: Experiment: Optimize multi-action/tail fox modals for existing users
- Target: existing users (profile age 7+ days) who are not default and/or not pinned, shown a startup Window Spotlight message
- Feature: `fxms-message-7`
- Dates: 2026-03-23 to 2026-04-20 (7-day enrollment)

🤖 Generated via `/create-custom-config`