### PR TITLE
[ci rerun-skip] feat(nimbus): add 3dr metric for fenix and ios

### DIFF
--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -114,6 +114,12 @@ description = """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
+[metrics.active_in_last_3_days]
+select_expression = "COALESCE(MIN(days_since_active), 30) < 3"
+data_source = "fenix_active_users_view"
+friendly_name = "3 Days Retention"
+description = "Records whether a client submitted any pings (i.e. used Firefox) on any of the last 3 days."
+
 [metrics.user_reports_site_issue_count]
 data_source = "events"
 select_expression = """
@@ -817,6 +823,7 @@ from_expression = """(
 )"""
 submission_date_column = "submission_date"
 client_id_column = "client_id"
+experiments_column_type = "native"
 deprecated = false
 
 [data_sources.clients_daily]

--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -127,6 +127,12 @@ description = """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
+[metrics.active_in_last_3_days]
+select_expression = "COALESCE(MIN(days_since_active), 30) < 3"
+data_source = "firefox_ios_active_users_view"
+friendly_name = "3 Days Retention"
+description = "Records whether a client submitted any pings (i.e. used Firefox) on any of the last 3 days."
+
 ## search metrics
 
 [metrics.organic_search_count]
@@ -645,6 +651,7 @@ from_expression = """(
 )"""
 submission_date_column = "submission_date"
 client_id_column = "client_id"
+experiments_column_type = "native"
 deprecated = false
 
 [data_sources.clients_daily]

--- a/jetstream/defaults/fenix.toml
+++ b/jetstream/defaults/fenix.toml
@@ -5,6 +5,7 @@ daily = [
     "active_hours",
     "total_uri_count",
     "search_count",
+    "active_in_last_3_days",
 ]
 weekly = [
     "retained",
@@ -60,6 +61,9 @@ select_expression = "COALESCE(COUNT(document_id), 0) > 0"
 data_source = "baseline"
 
 [metrics.retained.statistics]
+binomial = {}
+
+[metrics.active_in_last_3_days.statistics]
 binomial = {}
 
 ##

--- a/jetstream/defaults/firefox_ios.toml
+++ b/jetstream/defaults/firefox_ios.toml
@@ -5,6 +5,7 @@ daily = [
     "active_hours",
     "search_count",
     "total_uri_count",
+    "active_in_last_3_days",
 ]
 weekly = [
     "retained",
@@ -47,6 +48,9 @@ select_expression = "COALESCE(COUNT(document_id), 0) > 0"
 data_source = "baseline"
 
 [metrics.retained.statistics]
+binomial = {}
+
+[metrics.active_in_last_3_days.statistics]
 binomial = {}
 
 ##


### PR DESCRIPTION
Adds 3-day retention ingestion for mobile experiments