### PR TITLE
Add used_pbm segment to vpn-mvp-beta-holdback

### DIFF
--- a/jetstream/vpn-mvp-beta-holdback.toml
+++ b/jetstream/vpn-mvp-beta-holdback.toml
@@ -6,6 +6,7 @@ segments = [
   "country_gb",
   "country_us",
   "new_users",
+  "used_pbm",
 ]
 
 [metrics]
@@ -96,3 +97,11 @@ description = "Clients enrolled on their first day with Firefox (first_seen_date
 select_expression = "COALESCE(LOGICAL_OR(days_since_first_seen = 0), FALSE)"
 window_start = 0
 window_end = 0
+
+[segments.used_pbm]
+data_source = "clients_daily"
+friendly_name = "Used PBM (first 7 days)"
+description = "Opened at least one private window on any of the 7 days post-enrollment."
+select_expression = "COALESCE(LOGICAL_OR(dom_parentprocess_private_window_used), FALSE)"
+window_start = 0
+window_end = 6


### PR DESCRIPTION
## Summary
- Adds a `used_pbm` segment to the `vpn-mvp-beta-holdback` jetstream config
- Evaluates `clients_daily.dom_parentprocess_private_window_used` over days [0, 6] post-enrollment
- Mirrors the inline segment used in the holdback PBM-cohort retention notebook so jetstream can produce parallel results

## Test plan
- [ ] Jetstream picks up the new segment on next run
- [ ] Segment column appears alongside the existing `new_users` / country segments

🤖 Generated with [Claude Code](https://claude.com/claude-code)