### PR TITLE
fix(nimbus): rename event_stream to events_stream, add SourceType enum, add ratios to FeatureSpec

### DIFF
--- a/featmon/firefox_desktop.toml
+++ b/featmon/firefox_desktop.toml
@@ -2,7 +2,7 @@
 # Each data source specifies:
 #   - analysis_unit_id: field used to identify analysis units (client/profile IDs)
 #   - table_name: the BigQuery table name within the application dataset
-#   - type: one of "metrics", "event_stream", or "clients_daily"
+#   - type: one of "metrics", "events_stream", or "clients_daily"
 #   - dimensions: optional fields to group metrics by
 
 [data_sources.metrics]
@@ -24,7 +24,7 @@ normalized_country_code = { value_in = ["CA", "DE", "FR", "GB", "US"], default_v
 [data_sources.events_stream]
 analysis_unit_id = "profile_group_id"
 table_name = "events_stream"
-type = "event_stream"
+type = "events_stream"
 
 [data_sources.newtab]
 analysis_unit_id = "metrics.uuid.legacy_telemetry_profile_group_id"

--- a/lib/metric-config-parser/metric_config_parser/featmon.py
+++ b/lib/metric-config-parser/metric_config_parser/featmon.py
@@ -5,7 +5,7 @@ checkout, with one TOML file per application (e.g. ``firefox_desktop.toml``).
 
 Each file defines:
 - ``data_sources``: BigQuery tables to query, each with a ``type`` of
-  ``"metrics"``, ``"event_stream"``, or ``"clients_daily"``
+  ``"metrics"``, ``"events_stream"``, or ``"clients_daily"``
 - ``features``: Nimbus features and the metrics to collect per source table
 
 The ``dataset`` is derived from the filename stem (e.g. ``firefox_desktop.toml``
@@ -16,15 +16,23 @@ and are accessible via ``ConfigCollection.featmon_configs``.
 """
 
 from collections.abc import Mapping
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 import attr
 import toml
 
-VALID_SOURCE_TYPES = frozenset({"metrics", "event_stream", "clients_daily"})
-
 FEATMON_DIR = "featmon"
+
+
+class DataSourceType(StrEnum):
+    """Valid BigQuery source table types for featmon configs."""
+
+    METRICS = "metrics"
+    EVENTS_STREAM = "events_stream"
+    DEPRECATED_EVENT_STREAM = "event_stream"  # deprecated alias, use events_stream
+    CLIENTS_DAILY = "clients_daily"
 
 
 @attr.s(auto_attribs=True)
@@ -33,7 +41,7 @@ class SourceTableSpec:
 
     name: str
     table_name: str
-    type: str = "metrics"
+    type: str = DataSourceType.METRICS.value
     analysis_unit_id: str = "client_info.client_id"
     dimensions: dict[str, Any] = attr.Factory(dict)
 
@@ -45,6 +53,7 @@ class FeatureSpec:
     name: str
     slug: str | None = None
     metrics_by_source: dict[str, Any] = attr.Factory(dict)
+    ratios: list[list[str]] = attr.Factory(list)
 
     def nimbus_slug(self) -> str:
         """Return the Nimbus slug for this feature.
@@ -79,11 +88,12 @@ class FeatmonSpec:
 
     def _validate(self) -> None:
         """Validate data source types."""
+        valid = {t.value for t in DataSourceType}
         for name, source in self.data_sources.items():
-            if source.type not in VALID_SOURCE_TYPES:
+            if source.type not in valid:
                 raise ValueError(
                     f"data_source '{name}' has invalid type '{source.type}'. "
-                    f"Must be one of: {sorted(VALID_SOURCE_TYPES)}"
+                    f"Must be one of: {sorted(valid)}"
                 )
 
     @classmethod
@@ -98,6 +108,7 @@ class FeatmonSpec:
                 name=name,
                 slug=cfg.get("slug"),
                 metrics_by_source=cfg.get("metrics_by_source", {}),
+                ratios=cfg.get("ratios", []),
             )
             for name, cfg in d.get("features", {}).items()
         }


### PR DESCRIPTION
Because

- `events_stream` matches the actual BigQuery table name; `event_stream` was inconsistent
- `ratios` was referenced in the bigquery-etl query template but had no way to be defined in TOML configs
- The source type was validated against a plain frozenset with no type safety

This commit

- Renames `event_stream` → `events_stream` in `VALID_SOURCE_TYPES`, `SourceTableSpec` default, and `firefox_desktop.toml`
- Adds `SourceType` enum (`metrics`, `events_stream`, `clients_daily`) for type-safe validation
- Adds `ratios: list[list[str]]` to `FeatureSpec` so TOML configs can define metric ratios
- Updates `FeatmonSpec.from_dict` to populate `ratios` from config
- Bumps version to `2026.4.4`

Related: EXP-6732