### PR TITLE
Fix locale segments and remove splitview-usage segments for os-notification-split-view-release-lapsed-users

### DIFF
--- a/jetstream/os-notification-split-view-release-lapsed-users.toml
+++ b/jetstream/os-notification-split-view-release-lapsed-users.toml
@@ -11,9 +11,6 @@ segments = [
   "fr_locale",
   "de_locale",
   "en_locale",
-
-  "used_splitview_at_least_once",
-  "never_used_splitview",
 ]
 
 enrollment_query = """
@@ -149,16 +146,22 @@ select_expression = "SUM(COALESCE(mozfun.map.extract_keyed_scalar_sum(metrics.la
 [segments]
 
 [segments.fr_locale]
+friendly_name = "FR locale (pre-enrollment)"
+description = "Clients who reported an fr* locale on any clients_daily ping in the 365 days before enrollment"
 select_expression = """COALESCE(LOGICAL_OR(locale LIKE "fr%"), FALSE)"""
-data_source = 'clients_daily'
+data_source = "client_locale_history"
 
 [segments.de_locale]
+friendly_name = "DE locale (pre-enrollment)"
+description = "Clients who reported a de* locale on any clients_daily ping in the 365 days before enrollment"
 select_expression = """COALESCE(LOGICAL_OR(locale LIKE "de%"), FALSE)"""
-data_source = 'clients_daily'
+data_source = "client_locale_history"
 
 [segments.en_locale]
+friendly_name = "EN locale (pre-enrollment)"
+description = "Clients who reported an en-* locale on any clients_daily ping in the 365 days before enrollment"
 select_expression = """COALESCE(LOGICAL_OR(locale LIKE "en-%"), FALSE)"""
-data_source = 'clients_daily'
+data_source = "client_locale_history"
 
 [segments.last_dau_28_to_34_days_ago]
 friendly_name = "Last DAU 28 to 34 days ago"
@@ -208,18 +211,6 @@ window_start = -183
 window_end = -1
 
 
-[segments.used_splitview_at_least_once]
-friendly_name = "Used Splitview at least Once"
-description = "Clients who used splitview at least once during the experiment"
-select_expression = "LOGICAL_OR(COALESCE(used_splitview, FALSE))"
-data_source = "splitview_feature_usage"
-
-[segments.never_used_splitview]
-friendly_name = "Never Used Splitview"
-description = "Clients who never used splitview the experiment"
-select_expression = "NOT LOGICAL_OR(COALESCE(used_splitview, FALSE))"
-data_source = "splitview_feature_usage"
-
 [segments.data_sources.active_users_last_seen]
 from_expression = """(
   SELECT
@@ -233,26 +224,21 @@ from_expression = """(
 )"""
 window_start = -183
 
-[segments.data_sources.splitview_feature_usage]
+[segments.data_sources.client_locale_history]
 from_expression = """(
-    SELECT
-        DATE(submission_timestamp) AS submission_date,
-        client_id,
-        TRUE AS used_splitview,
-        ANY_VALUE(event_extra) AS event_extra,
-    FROM 
-        `moz-fx-data-shared-prod.firefox_desktop.events_stream`
-    WHERE 
-        event_category = 'splitview'
-        AND event_name = 'start'
-        AND DATE(submission_timestamp) BETWEEN '2026-03-26' AND '2026-04-30'
-    GROUP BY
-        ALL
+  SELECT
+    client_id,
+    profile_group_id,
+    locale,
+    submission_date
+  FROM `mozdata.telemetry.clients_daily`
+  WHERE submission_date >= DATE_SUB('2026-03-26', INTERVAL 365 DAY)
+    AND submission_date < '2026-03-26'
 )"""
-description = "Splitview Feature Usage and Retention using 'splitview.start'"
-friendly_name = "Splitview Feature Usage and Retention"
-client_id_column = "client_id"
-experiments_column_type = "events_stream"
+description = "Pre-enrollment locale history from clients_daily, looking back 365 days before the experiment start."
+friendly_name = "Client locale history (pre-enrollment)"
+window_start = -365
+window_end = -1
 
 
 [data_sources.splitview_feature_retention]


### PR DESCRIPTION
Fixes selection-bias artifacts in segment-level results for `os-notification-split-view-release-lapsed-users`.

## What this changes

**Locale segments (`fr_locale`, `de_locale`, `en_locale`):**
- Switched data source from the unspecified default `clients_daily` (which Jetstream computes over the experiment window) to a custom `client_locale_history` data source backed by `mozdata.telemetry.clients_daily` with a 365-day pre-enrollment lookback (`window_start = -365`, `window_end = -1`).

**Splitview-usage segments (`used_splitview_at_least_once`, `never_used_splitview`):**
- Removed entirely, along with the `[segments.data_sources.splitview_feature_usage]` block they depended on.

Lapse segments, metrics, `[data_sources.splitview_feature_retention]`, the enrollment_query, and `[segments.data_sources.active_users_last_seen]` are unchanged.

## Why

The experiment targets lapsed users (28+ days inactive at enrollment). With the previous setup:

- Locale segments used `clients_daily` over the experiment window. Most enrollees, by definition, are not active during the experiment, so they fell outside every locale segment. Only ~3.3% of enrollees were tagged across all three locales combined (en 2.5%, fr 0.4%, de 0.35%) — versus ~97% coverage for the lapse segments, which use a pre-enrollment data source.
- The small subset that did get tagged was branch-dependent: treatment users who saw a notification were ~2.7× more likely to become active and pick up a locale tag than control users. That conditioned segment membership on a post-treatment outcome, producing apparent "lifts" of −60% (en), −54% (fr), −49% (de) in `per_client_dau_impact` while the overall effect was null. This is selection bias, not a treatment effect.
- Splitview-usage segments had the same post-treatment-conditioning shape but were inert in this experiment because Split View just released in Fx 149 and ~all enrollees were `never_used`. Removing them rather than fixing them keeps the config minimal — a future iteration can reintroduce them with a pre-enrollment window if/when the feature has historical usage.

The new `client_locale_history` data source determines locale membership before any treatment is applied, eliminating the bias. Coverage will be lower than the lapse segments because users with no telemetry in the prior 365 days cannot be tagged, but it is unbiased.

## Validation

- TOML parses cleanly with `tomli`.
- Diff against upstream `main`: only the four sections described above change.

🤖 Generated via `/create-custom-config`