### PR TITLE
fix(nimbus): remove deprecated event_stream alias and bump version to 2026.4.4

### DIFF
--- a/lib/metric-config-parser/metric_config_parser/featmon.py
+++ b/lib/metric-config-parser/metric_config_parser/featmon.py
@@ -31,7 +31,6 @@ class DataSourceType(StrEnum):
 
     METRICS = "metrics"
     EVENTS_STREAM = "events_stream"
-    DEPRECATED_EVENT_STREAM = "event_stream"  # deprecated alias, use events_stream
     CLIENTS_DAILY = "clients_daily"
 
 

--- a/lib/metric-config-parser/pyproject.toml
+++ b/lib/metric-config-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-metric-config-parser"
-version = "2026.4.3"
+version = "2026.4.4"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Parses metric configuration files."
 readme = "README.md"


### PR DESCRIPTION
Because

- `DEPRECATED_EVENT_STREAM = "event_stream"` was added as a temporary alias in #1415 to keep CI passing while `firefox_desktop.toml` still had `type = "event_stream"` on main
- Now that #1415 has merged, `firefox_desktop.toml` uses `events_stream` throughout and the alias is no longer needed

This commit

- Removes `DEPRECATED_EVENT_STREAM` from `DataSourceType`
- Bumps version to `2026.4.4`

Related: EXP-6732