### PR TITLE
Add profile-age-at-enrollment segments to firefox_desktop definitions

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -2489,6 +2489,33 @@ friendly_name = "Mexico"
 description = "Clients in Mexico"
 select_expression = "COALESCE(LOGICAL_OR(country = 'MX'), FALSE)"
 
+[segments.profile_age_0_to_7_days]
+data_source = "clients_last_seen"
+friendly_name = "Profile age 0-6 days at enrollment"
+description = "Clients whose first_seen_date is 0-6 days before enrollment"
+select_expression = """COALESCE(
+    DATE_DIFF(MIN(e.enrollment_date), ANY_VALUE(first_seen_date), DAY) BETWEEN 0 AND 6,
+    FALSE
+)"""
+
+[segments.profile_age_7_to_28_days]
+data_source = "clients_last_seen"
+friendly_name = "Profile age 7-27 days at enrollment"
+description = "Clients whose first_seen_date is 7-27 days before enrollment"
+select_expression = """COALESCE(
+    DATE_DIFF(MIN(e.enrollment_date), ANY_VALUE(first_seen_date), DAY) BETWEEN 7 AND 27,
+    FALSE
+)"""
+
+[segments.profile_age_more_than_28_days]
+data_source = "clients_last_seen"
+friendly_name = "Profile age 28+ days at enrollment"
+description = "Clients whose first_seen_date is 28 or more days before enrollment"
+select_expression = """COALESCE(
+    DATE_DIFF(MIN(e.enrollment_date), ANY_VALUE(first_seen_date), DAY) >= 28,
+    FALSE
+)"""
+
 
 [segments.data_sources]
 


### PR DESCRIPTION
Adds three profile-age-at-enrollment segments to `definitions/firefox_desktop.toml` so they become reusable across all Firefox desktop experiments and selectable in the Experimenter UI before launch:

- `profile_age_0_to_7_days` — clients whose `first_seen_date` is 0-6 days before enrollment
- `profile_age_7_to_28_days` — 7-27 days
- `profile_age_more_than_28_days` — 28+ days

## Background

These segments were originally defined per-experiment in [`optimized-set-to-default-infobar.toml`](https://github.com/mozilla/metric-hub/blob/main/jetstream/optimized-set-to-default-infobar.toml) and copied again in [`set-to-default-prompt-style-spotlight-v2.toml`](https://github.com/mozilla/metric-hub/blob/main/jetstream/set-to-default-prompt-style-spotlight-v2.toml). In review of [PR #1424](https://github.com/mozilla/metric-hub/pull/1424), @mikewilli suggested promoting them to definitions since they're a common cut for Firefox Growth experiments. This PR does that.

## Implementation notes

- Uses the existing built-in `clients_last_seen` data source rather than the per-experiment `clients_last_seen_with_profile_age` projection — same underlying table, and `first_seen_date` is already available without a custom data source.
- `e.enrollment_date` is the alias Jetstream injects for the enrollments table when evaluating segment select expressions. The pattern is in production use via the two configs linked above; calling out here in case there's any subtlety with built-in data sources vs. custom ones.
- Live experiments that already launched will still need their per-experiment configs — this only helps experiments scoped after merge.

🤖 Generated via `/create-custom-config`