### PR TITLE
Expand VPN holdback enrollment_period from 8 to 14 days

### DIFF
--- a/jetstream/vpn-mvp-beta-holdback.toml
+++ b/jetstream/vpn-mvp-beta-holdback.toml
@@ -1,5 +1,5 @@
 [experiment]
-enrollment_period = 8
+enrollment_period = 14
 segments = [
   "country_de",
   "country_fr",


### PR DESCRIPTION
Increases the Jetstream analysis cohort from 8 to 14 days post-publishedDate (2026-03-23), capturing ~3.5x more enrollees for the retained_dau and VPN adoption metrics. The experiment is still actively enrolling and has sufficient analysis time for 4-week retention (week 4 available 2026-05-03).