### PR TITLE
chore(docs): use outcome friendly_name as title

### DIFF
--- a/.script/templates/outcome.md
+++ b/.script/templates/outcome.md
@@ -1,3 +1,7 @@
+{% if outcome_name -%}
+#{{ outcome_name | trim }}
+{% endif %}
+
 {% if outcome_description -%}
 {{ outcome_description | trim }}
 {% endif %}


### PR DESCRIPTION
I noticed that the outcome `friendly_name` wasn't getting reflected in the header for the docs (example files below), so this does that explicitly.

friendly_name: https://github.com/mozilla/metric-hub/blob/main/jetstream/outcomes/firefox_desktop/spotlight_engagement.toml#L6
docs: https://mozilla.github.io/metric-hub/outcomes/firefox_desktop/spotlight_engagement/