### PR TITLE
Add Jetstream config for 48hr-os-notification-for-churned-resurrected-users

### DIFF
--- a/jetstream/48hr-os-notification-for-churned-resurrected-users.toml
+++ b/jetstream/48hr-os-notification-for-churned-resurrected-users.toml
@@ -1,0 +1,214 @@
+[experiment]
+analysis_unit = "client_id"
+
+segments = [
+  "firefox_default_at_enrollment",
+  "firefox_not_default_at_enrollment",
+  "profile_age_0_to_180_days",
+  "profile_age_181_to_365_days",
+  "profile_age_more_than_365_days",
+]
+
+enrollment_query = """
+SELECT * FROM
+(
+
+-- Early data shows that the 'experiments' annotation is more robust than either
+-- the 'enrollment' or the 'exposure' event in background update telemetry, see
+-- [Bug 1809275](https://bugzilla.mozilla.org/show_bug.cgi?id=1809275).  That
+-- is, some legacy client IDs do not report 'enrollment' or 'exposure' events,
+-- but do appear in `experiments` annotations.  Therefore, we use 'enrollment'
+-- events as our primary enrollment indicator but also look for an 'experiments'
+-- annotation.
+--
+-- But, some legacy client IDs that click the notification do not correspond to
+-- default profile IDs reported by background update pings: these may be due to
+-- multiple profiles, multiple OS-level users, or telemetry errors.  Some amount
+-- of such client IDs are anticipated.  We use a browsing telemetry query for
+-- these legacy client IDs.
+--
+-- Finally, we take the earliest of these two enrollment signals to determine
+-- enrollment date. This will always be before we witness a notification click,
+-- so we should not have a legacy client ID that does not have at least one
+-- analysis window containing a notification click.
+
+(
+SELECT
+    JSON_VALUE(metrics, '$.uuid.background_update_client_id') AS analysis_id,
+    JSON_VALUE(event_extra, '$.branch') AS branch,
+    MIN(DATE(events.submission_timestamp)) AS enrollment_date,
+    COUNT(events.submission_timestamp) AS num_enrollment_events
+-- Query from events_stream because it's much more efficient than unnesting events.
+FROM `moz-fx-data-shared-prod.firefox_desktop_background_update.events_stream` events
+WHERE
+    DATE(submission_timestamp) BETWEEN
+        '{{experiment.start_date_str}}' AND
+        -- Here we can restrict to the last enrollment date range.
+        '{{experiment.last_enrollment_date_str}}'
+    AND event_category = 'nimbus_events'
+    AND event_name = 'enrollment'
+    -- The background update experiment slug is exact.
+    AND JSON_VALUE(event_extra, '$.experiment') = '{{experiment.normandy_slug}}'
+    -- This should never happen, but belt-and-braces.
+    AND JSON_VALUE(metrics, '$.uuid.background_update_client_id') IS NOT NULL
+    AND sample_id < 100
+GROUP BY analysis_id, branch
+)
+
+UNION ALL
+
+(
+SELECT
+    m.metrics.uuid.background_update_client_id AS analysis_id,
+    experiment.value.branch AS branch,
+    MIN(DATE(submission_timestamp)) AS enrollment_date,
+    -- These aren't discrete events, it makes no sense to count them.
+    1 AS num_enrollment_events
+-- We need to query from the Glean `background_update` table because pre-[Bug
+-- 1794053](https://bugzilla.mozilla.org/show_bug.cgi?id=1794053) (scheduled for
+-- Firefox 109) we don't have the legacy client ID in
+-- `mozdata.firefox_desktop_background_update.events`.
+FROM `mozdata.firefox_desktop_background_update.background_update` AS m
+CROSS JOIN
+    UNNEST(ping_info.experiments) AS experiment
+WHERE
+    -- Background update telemetry can be delayed, so we accept enrollment
+    -- _submission_ dates during the elongated enrollment period.  It's safer to
+    -- compare submission dates generated server-side than internal ping dates
+    -- generated client-side.
+    DATE(submission_timestamp) BETWEEN
+        '{{experiment.start_date_str}}' AND
+        '{{experiment.last_enrollment_date_str}}'
+    -- The background update experiment slug is exact.
+    AND experiment.key = '{{experiment.normandy_slug}}'
+    AND sample_id < 100
+GROUP BY analysis_id, branch
+)
+
+UNION ALL
+
+(
+SELECT
+    client_id AS analysis_id,
+    -- Post [Bug 1804988](https://bugzilla.mozilla.org/show_bug.cgi?id=1804988),
+    -- this name looks like 'slug:branch'.
+    SPLIT(mozfun.map.get_key(event_map_values, 'name'), ':')[SAFE_OFFSET(1)] AS branch,
+    MIN(submission_date) AS enrollment_date,
+    COUNT(submission_date) AS num_enrollment_events
+FROM
+    `mozdata.telemetry.events`
+WHERE
+    -- Browsing telemetry should not be delayed, but notification clicks need
+    -- not coincide with actual enrollment.
+    submission_date BETWEEN
+        '{{experiment.start_date_str}}' AND
+        '{{experiment.last_enrollment_date_str}}'
+    AND event_category = 'browser.launched_to_handle'
+    AND event_method = 'system_notification'
+    AND event_object = 'toast'
+    -- Post [Bug 1804988](https://bugzilla.mozilla.org/show_bug.cgi?id=1804988),
+    -- this name looks like 'slug:branch'.
+    AND STARTS_WITH(mozfun.map.get_key(event_map_values, 'name'), '{{experiment.normandy_slug}}:')
+    AND sample_id < 100
+GROUP BY
+    analysis_id, branch
+)
+
+)
+QUALIFY ROW_NUMBER() OVER (PARTITION BY analysis_id ORDER BY enrollment_date ASC) = 1
+"""
+
+
+[metrics]
+
+weekly = [
+  "is_pinned",
+]
+
+overall = [
+  "is_pinned",
+]
+
+# ============================================================================
+# SEGMENTS
+# ============================================================================
+# Two dimensions per the brief:
+#   1. Default browser status at enrollment (default / NOT default)
+#   2. Profile age at enrollment (<6mo / 6-12mo / 12+mo)
+#
+# All segments use a 365-day pre-enrollment lookback on clients_daily because
+# the target audience is lapsed-resurrected users (28+ days inactive at
+# enrollment), so a short lookback would miss most clients. Pattern mirrors
+# the locale fix on os-notification-split-view-release-lapsed-users (PR #1416).
+
+[segments.firefox_default_at_enrollment]
+friendly_name = "Firefox is default browser (pre-enrollment)"
+description = "Clients who reported Firefox as their default browser on at least one clients_daily ping in the 365 days before enrollment"
+select_expression = """COALESCE(LOGICAL_OR(is_default_browser), FALSE)"""
+data_source = "client_history"
+window_start = -365
+window_end = -1
+
+[segments.firefox_not_default_at_enrollment]
+friendly_name = "Firefox is NOT default browser (pre-enrollment)"
+description = "Clients who never reported Firefox as their default browser on any clients_daily ping in the 365 days before enrollment (and had at least one ping with is_default_browser = FALSE)"
+select_expression = """COALESCE(LOGICAL_AND(NOT is_default_browser), FALSE)"""
+data_source = "client_history"
+window_start = -365
+window_end = -1
+
+[segments.profile_age_0_to_180_days]
+friendly_name = "Profile age 0-180 days (<6 months)"
+description = "Clients whose profile age at enrollment is between 0 and 180 days"
+select_expression = """
+  COALESCE(
+    DATE_DIFF(MIN(e.enrollment_date), MIN(first_seen_date), DAY) BETWEEN 0 AND 180,
+    FALSE
+  )
+"""
+data_source = "client_history"
+window_start = -365
+window_end = -1
+
+[segments.profile_age_181_to_365_days]
+friendly_name = "Profile age 181-365 days (6-12 months)"
+description = "Clients whose profile age at enrollment is between 181 and 365 days"
+select_expression = """
+  COALESCE(
+    DATE_DIFF(MIN(e.enrollment_date), MIN(first_seen_date), DAY) BETWEEN 181 AND 365,
+    FALSE
+  )
+"""
+data_source = "client_history"
+window_start = -365
+window_end = -1
+
+[segments.profile_age_more_than_365_days]
+friendly_name = "Profile age 365+ days (12+ months)"
+description = "Clients whose profile age at enrollment is more than 365 days"
+select_expression = """
+  COALESCE(
+    DATE_DIFF(MIN(e.enrollment_date), MIN(first_seen_date), DAY) > 365,
+    FALSE
+  )
+"""
+data_source = "client_history"
+window_start = -365
+window_end = -1
+
+[segments.data_sources.client_history]
+from_expression = """(
+  SELECT
+    client_id,
+    profile_group_id,
+    submission_date,
+    is_default_browser,
+    first_seen_date
+  FROM `mozdata.telemetry.clients_daily`
+  WHERE submission_date >= DATE_SUB('2026-04-20', INTERVAL 365 DAY)
+    AND submission_date < '2026-04-20'
+)"""
+description = "Pre-enrollment client history (default browser status + first seen date) from clients_daily, looking back 365 days before the experiment start (2026-04-20)."
+friendly_name = "Client history (pre-enrollment)"
+window_start = -365
+window_end = -1


### PR DESCRIPTION
Adds a custom Jetstream config for the `48hr-os-notification-for-churned-resurrected-users` experiment.

## What this adds

- **Background-updater enrollment_query** — copied verbatim from `recommended-add-ons-os-notification-experiment.toml` (3-way UNION: background-update events_stream + ping `experiments` annotation + browser notification-click events). `analysis_unit = "client_id"`, `sample_id < 100`.
- **1 listed metric** — `is_pinned` (built-in, NOT auto-applied; binomial pre-declared) for the pin-to-taskbar rate called out in the brief. All other brief metrics (4-week / 2-week retention, DAU, days of use, active hours, default rate, search count, tagged search count, ad clicks, searches with ads, URI count) auto-apply via `jetstream/defaults/firefox_desktop.toml` and are deliberately not listed.
- **5 custom segments across 2 dimensions:**
  - Default browser status pre-enrollment (`firefox_default_at_enrollment`, `firefox_not_default_at_enrollment`)
  - Profile age at enrollment (`profile_age_0_to_180_days`, `profile_age_181_to_365_days`, `profile_age_more_than_365_days` — i.e. <6mo / 6-12mo / 12+mo per the brief)
- **Custom segment data source** `client_history` — `clients_daily` with 365-day pre-enrollment lookback (the audience is lapsed-resurrected users, so a short lookback would miss most clients). Mirrors the locale-fix pattern from PR #1416.

## Experiment context

- Nimbus: https://experimenter.services.mozilla.com/nimbus/48hr-os-notification-for-churned-resurrected-users/summary/
- Background-updater (`backgroundTaskMessage`), Windows-only, 7-day enrollment + 28-day observation, branches: `control` + `treatment-a` (Finish Setup).

🤖 Generated via `/create-custom-config`