### PR TITLE
Add Jetstream config for felt-privacy-faster-the-10-tracker-milestone

### DIFF
--- a/jetstream/felt-privacy-faster-the-10-tracker-milestone.toml
+++ b/jetstream/felt-privacy-faster-the-10-tracker-milestone.toml
@@ -1,0 +1,165 @@
+[experiment]
+
+segments = [
+    "os_windows",
+    "os_mac",
+    "os_linux",
+    "default_at_enrollment",
+    "not_default_at_enrollment",
+    "pinned_at_enrollment",
+    "not_pinned_at_enrollment",
+    "onboarding_intent_privacy_and_security",
+    "onboarding_intent_productivity",
+    "onboarding_intent_other",
+]
+
+[metrics]
+
+weekly = [
+    "is_pinned",
+    "imported_bookmarks",
+    "imported_history",
+    "imported_logins",
+    "fxa_signed_in",
+    "main_crashes",
+    "content_crashes",
+    "startup_crashes",
+]
+
+overall = [
+    "is_pinned",
+    "imported_bookmarks",
+    "imported_history",
+    "imported_logins",
+    "fxa_signed_in",
+    "main_crashes",
+    "content_crashes",
+    "startup_crashes",
+]
+
+## Segments — OS
+
+[segments.os_windows]
+select_expression = "MAX(CASE WHEN LOWER(os) LIKE '%windows%' THEN TRUE ELSE FALSE END)"
+data_source = "cls_segments"
+
+[segments.os_mac]
+select_expression = "MAX(CASE WHEN os = 'Darwin' THEN TRUE ELSE FALSE END)"
+data_source = "cls_segments"
+
+[segments.os_linux]
+select_expression = "MAX(CASE WHEN os = 'Linux' THEN TRUE ELSE FALSE END)"
+data_source = "cls_segments"
+
+## Segments — Default / Pin status at enrollment
+
+[segments.default_at_enrollment]
+select_expression = "COALESCE(LOGICAL_OR(is_default_browser), FALSE)"
+data_source = "cls_segments"
+window_start = 0
+window_end = 0
+
+[segments.not_default_at_enrollment]
+select_expression = "NOT COALESCE(LOGICAL_OR(is_default_browser), FALSE)"
+data_source = "cls_segments"
+window_start = 0
+window_end = 0
+
+[segments.pinned_at_enrollment]
+select_expression = "COALESCE(LOGICAL_OR(scalar_parent_os_environment_is_taskbar_pinned), FALSE)"
+data_source = "cls_segments"
+window_start = 0
+window_end = 0
+
+[segments.not_pinned_at_enrollment]
+select_expression = "COALESCE(LOGICAL_OR(scalar_parent_os_environment_is_taskbar_pinned), FALSE) = FALSE"
+data_source = "cls_segments"
+window_start = 0
+window_end = 0
+
+[segments.data_sources.cls_segments]
+from_expression = """
+    (SELECT
+        submission_date,
+        client_id,
+        os,
+        is_default_browser,
+        scalar_parent_os_environment_is_taskbar_pinned
+    FROM `moz-fx-data-shared-prod.telemetry.clients_daily`
+    )
+"""
+window_start = 0
+window_end = 0
+
+## Segments — Onboarding Intent
+
+[segments.onboarding_intent_privacy_and_security]
+friendly_name = "Onboarding Intent Privacy and Security"
+description = "Users who selected Privacy and Security as onboarding intent"
+select_expression = "LOGICAL_OR(COALESCE(selection LIKE '%Privacy and Security%', FALSE))"
+data_source = "onboarding_selection"
+window_start = -3
+window_end = "analysis_window_end"
+
+[segments.onboarding_intent_productivity]
+friendly_name = "Onboarding Intent Productivity"
+description = "Users who selected Productivity as onboarding intent"
+select_expression = "LOGICAL_OR(COALESCE(selection LIKE '%Productivity%', FALSE))"
+data_source = "onboarding_selection"
+window_start = -3
+window_end = "analysis_window_end"
+
+[segments.onboarding_intent_other]
+friendly_name = "Onboarding Intent Other"
+description = "Users who selected Other as onboarding intent"
+select_expression = "LOGICAL_OR(COALESCE(selection LIKE '%Other%', FALSE))"
+data_source = "onboarding_selection"
+window_start = -3
+window_end = "analysis_window_end"
+
+[segments.data_sources.onboarding_selection]
+from_expression = """(
+WITH
+ExperimentEvents AS (
+  SELECT
+    client_id,
+    DATE(submission_timestamp) AS submission_date,
+    JSON_EXTRACT_ARRAY(event_context, '$.source') AS checkbox_sources
+  FROM `moz-fx-data-shared-prod.firefox_desktop.onboarding`
+  WHERE
+    DATE(submission_timestamp) >= '2026-04-17'
+    AND event = 'SELECT_CHECKBOX'
+),
+CheckboxSelectionByClientID AS (
+  SELECT
+    client_id,
+    submission_date,
+    ARRAY_CONCAT_AGG(checkbox_sources) AS all_selected_checkboxes
+  FROM ExperimentEvents
+  GROUP BY
+    client_id,
+    submission_date
+)
+SELECT
+  client_id,
+  submission_date,
+  ARRAY_TO_STRING(
+      ARRAY_AGG(
+        CASE
+            WHEN s = '"checkbox-motivation-1"' THEN 'Privacy and Security'
+            WHEN s = '"checkbox-motivation-2"' THEN 'Productivity'
+            WHEN s = '"checkbox-motivation-3"' THEN 'Other'
+        END ),
+      ', '
+    ) AS selection
+FROM CheckboxSelectionByClientID, UNNEST(all_selected_checkboxes) AS s
+WHERE
+  ARRAY_LENGTH(all_selected_checkboxes) > 0
+  AND s IN ('"checkbox-motivation-1"',
+    '"checkbox-motivation-2"',
+    '"checkbox-motivation-3"')
+GROUP BY
+  client_id,
+  submission_date
+)"""
+window_start = -3

--- a/jetstream/felt-privacy-faster-the-10-tracker-milestone.toml
+++ b/jetstream/felt-privacy-faster-the-10-tracker-milestone.toml
@@ -1,95 +1,10 @@
 [experiment]
 
 segments = [
-    "os_windows",
-    "os_mac",
-    "os_linux",
-    "default_at_enrollment",
-    "not_default_at_enrollment",
-    "pinned_at_enrollment",
-    "not_pinned_at_enrollment",
     "onboarding_intent_privacy_and_security",
     "onboarding_intent_productivity",
     "onboarding_intent_other",
 ]
-
-[metrics]
-
-weekly = [
-    "is_pinned",
-    "imported_bookmarks",
-    "imported_history",
-    "imported_logins",
-    "fxa_signed_in",
-    "main_crashes",
-    "content_crashes",
-    "startup_crashes",
-]
-
-overall = [
-    "is_pinned",
-    "imported_bookmarks",
-    "imported_history",
-    "imported_logins",
-    "fxa_signed_in",
-    "main_crashes",
-    "content_crashes",
-    "startup_crashes",
-]
-
-## Segments — OS
-
-[segments.os_windows]
-select_expression = "MAX(CASE WHEN LOWER(os) LIKE '%windows%' THEN TRUE ELSE FALSE END)"
-data_source = "cls_segments"
-
-[segments.os_mac]
-select_expression = "MAX(CASE WHEN os = 'Darwin' THEN TRUE ELSE FALSE END)"
-data_source = "cls_segments"
-
-[segments.os_linux]
-select_expression = "MAX(CASE WHEN os = 'Linux' THEN TRUE ELSE FALSE END)"
-data_source = "cls_segments"
-
-## Segments — Default / Pin status at enrollment
-
-[segments.default_at_enrollment]
-select_expression = "COALESCE(LOGICAL_OR(is_default_browser), FALSE)"
-data_source = "cls_segments"
-window_start = 0
-window_end = 0
-
-[segments.not_default_at_enrollment]
-select_expression = "NOT COALESCE(LOGICAL_OR(is_default_browser), FALSE)"
-data_source = "cls_segments"
-window_start = 0
-window_end = 0
-
-[segments.pinned_at_enrollment]
-select_expression = "COALESCE(LOGICAL_OR(scalar_parent_os_environment_is_taskbar_pinned), FALSE)"
-data_source = "cls_segments"
-window_start = 0
-window_end = 0
-
-[segments.not_pinned_at_enrollment]
-select_expression = "COALESCE(LOGICAL_OR(scalar_parent_os_environment_is_taskbar_pinned), FALSE) = FALSE"
-data_source = "cls_segments"
-window_start = 0
-window_end = 0
-
-[segments.data_sources.cls_segments]
-from_expression = """
-    (SELECT
-        submission_date,
-        client_id,
-        os,
-        is_default_browser,
-        scalar_parent_os_environment_is_taskbar_pinned
-    FROM `moz-fx-data-shared-prod.telemetry.clients_daily`
-    )
-"""
-window_start = 0
-window_end = 0
 
 ## Segments — Onboarding Intent
 

--- a/jetstream/felt-privacy-faster-the-10-tracker-milestone.toml
+++ b/jetstream/felt-privacy-faster-the-10-tracker-milestone.toml
@@ -51,30 +51,35 @@ CheckboxSelectionByClientID AS (
     submission_date,
     ARRAY_CONCAT_AGG(checkbox_sources) AS all_selected_checkboxes
   FROM ExperimentEvents
-  GROUP BY
+  GROUP BY client_id, submission_date
+),
+SelectionPerClient AS (
+  SELECT
     client_id,
-    submission_date
+    submission_date,
+    ARRAY_TO_STRING(
+        ARRAY_AGG(
+          CASE
+              WHEN s = '"checkbox-motivation-1"' THEN 'Privacy and Security'
+              WHEN s = '"checkbox-motivation-2"' THEN 'Productivity'
+              WHEN s = '"checkbox-motivation-3"' THEN 'Other'
+          END ),
+        ', '
+      ) AS selection
+  FROM CheckboxSelectionByClientID, UNNEST(all_selected_checkboxes) AS s
+  WHERE
+    ARRAY_LENGTH(all_selected_checkboxes) > 0
+    AND s IN ('"checkbox-motivation-1"',
+      '"checkbox-motivation-2"',
+      '"checkbox-motivation-3"')
+  GROUP BY client_id, submission_date
 )
 SELECT
-  client_id,
-  submission_date,
-  ARRAY_TO_STRING(
-      ARRAY_AGG(
-        CASE
-            WHEN s = '"checkbox-motivation-1"' THEN 'Privacy and Security'
-            WHEN s = '"checkbox-motivation-2"' THEN 'Productivity'
-            WHEN s = '"checkbox-motivation-3"' THEN 'Other'
-        END ),
-      ', '
-    ) AS selection
-FROM CheckboxSelectionByClientID, UNNEST(all_selected_checkboxes) AS s
-WHERE
-  ARRAY_LENGTH(all_selected_checkboxes) > 0
-  AND s IN ('"checkbox-motivation-1"',
-    '"checkbox-motivation-2"',
-    '"checkbox-motivation-3"')
-GROUP BY
-  client_id,
-  submission_date
+  cfs.profile_group_id,
+  s.submission_date,
+  s.selection
+FROM SelectionPerClient s
+JOIN `moz-fx-data-shared-prod.telemetry.clients_first_seen` cfs
+  ON cfs.client_id = s.client_id
 )"""
 window_start = -3


### PR DESCRIPTION
Adds a custom Jetstream config for the `felt-privacy-faster-the-10-tracker-milestone` experiment (FXE-1478).

## What this adds
- **Metrics**: `is_pinned`, `imported_bookmarks`, `imported_history`, `imported_logins`, `fxa_signed_in`, `main_crashes`, `content_crashes`, `startup_crashes` (weekly + overall)
- **Segments**: OS (Windows/macOS/Linux), default status at enrollment, pinned status at enrollment, onboarding intent (Privacy & Security / Productivity / Other)
- Auto-applied metrics (retained, DAU, active_hours, search_count, etc.) are omitted — they run by default

## Experiment context
- Nimbus: https://experimenter.services.mozilla.com/nimbus/felt-privacy-faster-the-10-tracker-milestone
- Ticket: FXE-1478

🤖 Generated via `/create-custom-config`