### PR TITLE
add custom config for false end date

### DIFF
--- a/jetstream/sections-in-germany.toml
+++ b/jetstream/sections-in-germany.toml
@@ -1,2 +1,2 @@
 [experiment]
-end_date = "2026-05-08"
+end_date = "2026-05-07"

--- a/jetstream/sections-in-germany.toml
+++ b/jetstream/sections-in-germany.toml
@@ -1,0 +1,2 @@
+[experiment]
+end_date = "2026-05-08"


### PR DESCRIPTION
I want to add a false end date to see the results with out actually ending this experiment:
https://experimenter.services.mozilla.com/nimbus/sections-in-germany/summary/