### PR TITLE
correct friendly name of gt4 metric

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1191,7 +1191,7 @@ data_source = "newtab_clients_daily"
 select_expression = 'COALESCE(CASE WHEN SUM(search_interaction_count) > 4 THEN 1 ELSE 0 END, 0)'
 friendly_name = "Greater Than 4 Newtab Searches"
 description = """
-Client performed any Newtab Handoff searches during the experiment
+Client performed at least 5 Newtab Handoff searches during the experiment
 """
 
 [metrics.newtab_searches_with_ads]

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1189,7 +1189,7 @@ Client performed any Newtab Handoff searches during the experiment
 [metrics.newtab_gt4_searches]
 data_source = "newtab_clients_daily"
 select_expression = 'COALESCE(CASE WHEN SUM(search_interaction_count) > 4 THEN 1 ELSE 0 END, 0)'
-friendly_name = "Any Newtab Searches"
+friendly_name = "Greater Than 4 Newtab Searches"
 description = """
 Client performed any Newtab Handoff searches during the experiment
 """


### PR DESCRIPTION
Correct friendly name of gt4 metric so "Any Newtab Searches" is no longer redundant