### PR TITLE
fix(ci): validate script includes enrollments for segments

### DIFF
--- a/.github/workflows/validate-jetstream.yml
+++ b/.github/workflows/validate-jetstream.yml
@@ -4,13 +4,9 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'jetstream/**'
   push:
     branches:
       - main
-    paths:
-      - 'jetstream/**'
 
 jobs:
   changed:

--- a/.github/workflows/validate-metrics.yml
+++ b/.github/workflows/validate-metrics.yml
@@ -4,13 +4,9 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'definitions/**'
   push:
     branches:
       - main
-    paths:
-      - 'definitions/**'
 
 jobs:
   changed:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .vscode
+venv/

--- a/.script/templates/validation_query.sql
+++ b/.script/templates/validation_query.sql
@@ -12,12 +12,29 @@ GROUP BY
 {% endfor %}
 
 {% for segment in segments %}
+WITH enrollments AS (
+    SELECT '00000' AS analysis_id,
+        'test' AS branch,
+        DATE('2020-01-01') AS enrollment_date,
+        DATE('2020-01-01') AS exposure_date,
+        1 AS num_enrollment_events,
+        1 AS num_exposure_events
+    UNION ALL
+    SELECT '00000' AS analysis_id,
+        'test' AS branch,
+        DATE('2020-01-01') AS enrollment_date,
+        DATE('2020-01-01') AS exposure_date,
+        1 AS num_enrollment_events,
+        1 AS num_exposure_events
+)
 SELECT
     {{ segment_data_sources[segment.data_source.name].submission_date_column }} AS submission_date,
     {{ segment_data_sources[segment.data_source.name].client_id_column }} AS client_id,
     {{ segment.select_expression }} AS {{ segment.name }}
 FROM
-    {{ segment_data_sources[segment.data_source.name].from_expression }}
+    enrollments e
+    LEFT JOIN {{ segment_data_sources[segment.data_source.name].from_expression }} s
+        ON e.analysis_id = s.client_id
 WHERE {{ segment_data_sources[segment.data_source.name].submission_date_column }} = DATE('2020-01-01')
 GROUP BY
     submission_date,

--- a/.script/validate.py
+++ b/.script/validate.py
@@ -18,6 +18,7 @@ import logging
 import multiprocessing
 import sys
 from pathlib import Path
+from time import perf_counter
 from typing import Any
 import google.auth
 from google.auth.transport.requests import Request as GoogleAuthRequest
@@ -120,7 +121,7 @@ def dry_run_query(sql: str) -> None:
             )
         )
         response = json.load(r)
-    except Exception as e:
+    except Exception:
         # This may be a JSONDecode exception or something else.
         # If we got a HTTP exception, that's probably the most interesting thing to raise.
         try:
@@ -152,7 +153,9 @@ def dry_run_query(sql: str) -> None:
         logger.info("Dry run OK")
         return
 
-    raise DryRunFailedError((error and error.get("message", None)) or response["errors"], sql=sql)
+    raise DryRunFailedError(
+        (error and error.get("message", None)) or response["errors"], sql=sql
+    )
 
 
 def _is_sql_valid(sql):
@@ -217,7 +220,9 @@ def validate(path, config_repos):
                 print(e)
             else:
                 if not isinstance(entity, FunctionsSpec):
-                    validation_template = (Path(TEMPLATES_DIR) / "validation_query.sql").read_text()
+                    validation_template = (
+                        Path(TEMPLATES_DIR) / "validation_query.sql"
+                    ).read_text()
                     env = config_collection.get_env().from_string(validation_template)
 
                     i = 0
@@ -260,7 +265,9 @@ def validate(path, config_repos):
                                 segments=[],
                                 segment_data_sources=[],
                                 data_sources={
-                                    name: d.resolve(entity.spec, entity, config_collection)
+                                    name: d.resolve(
+                                        entity.spec, entity, config_collection
+                                    )
                                     for name, d in data_sources.items()
                                 },
                             )
@@ -298,7 +305,11 @@ def validate(path, config_repos):
 
     print(f"Dry running {len(sql_to_validate)} SQL query batches")
     with multiprocessing.Pool(multiprocessing.cpu_count()) as p:
+        start = perf_counter()
         result = p.map(_is_sql_valid, sql_to_validate, chunksize=1)
+        end = perf_counter()
+        print(f"Done. ({round(end - start, 1)} seconds)")
+
     if not all(result):
         sys.exit(1)
     print(f"{config_file} OK")


### PR DESCRIPTION
Because
- segments are only used for experimentation
- segments can reference fields in the enrollments with `e.` prefix

This commit
- adds a mock enrollments CTE for segment validation

I also added `venv` to the gitignore and some perf timing to the validate script.