### PR TITLE
feat(nimbus): add messaging_system data source and 12 messaging features

### DIFF
--- a/featmon/firefox_desktop.toml
+++ b/featmon/firefox_desktop.toml
@@ -228,3 +228,92 @@ urlbar_pref_suggest_online_enabled = {}
 
 [features.urlbar.metrics_by_source.metrics.labeled_counter.browser_search_content_urlbar]
 aggregators = ["sum"]
+
+[data_sources.messaging_system]
+analysis_unit_id = "client_info.client_id"
+table_name = "messaging_system"
+type = "metrics"
+
+[features.infobar]
+slug = "infobar"
+
+[features.infobar.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.aboutwelcome]
+slug = "aboutwelcome"
+
+[features.aboutwelcome.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.feature_callout]
+slug = "featureCallout"
+
+[features.feature_callout.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_bmb_button]
+slug = "fxms-bmb-button"
+
+[features.fxms_bmb_button.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_22]
+slug = "fxms-message-22"
+
+[features.fxms_message_22.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_1]
+slug = "fxms-message-1"
+
+[features.fxms_message_1.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_20]
+slug = "fxms-message-20"
+
+[features.fxms_message_20.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_7]
+slug = "fxms-message-7"
+
+[features.fxms_message_7.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_16]
+slug = "fxms-message-16"
+
+[features.fxms_message_16.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_21]
+slug = "fxms-message-21"
+
+[features.fxms_message_21.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.background_task_message]
+slug = "backgroundTaskMessage"
+
+[features.background_task_message.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.preonboarding]
+slug = "preonboarding"
+
+[features.preonboarding.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}


### PR DESCRIPTION
## Summary

Add `messaging_system` as a new data source in `featmon/firefox_desktop.toml` and configure feature monitoring for 12 messaging-system Nimbus features.

**Key finding:** the `messaging_system` Glean ping uses `ping_info.experiments` (same as the standard `metrics` ping), so `type = "metrics"` works without any new data source type in metric-config-parser.

**What's tracked:** `messaging_system_event` (IMPRESSION, CLICK, DISMISS, etc.) and `messaging_system_ping_type` string metrics. Since each ping = one event, `COUNT(string_field)` gives event counts per client.

**Features added:** infobar, aboutwelcome, featureCallout, fxms-bmb-button, fxms-message-22/1/20/7/16/21, backgroundTaskMessage, preonboarding

Depends on mozilla/bigquery-etl#9351 (fixes the `string` metric type `ping_aggregator` default from broken `sum` to `count`).