### PR TITLE
fix(nimbus): remove bookmarks and urlbar features with incorrect metric names

### DIFF
--- a/featmon/firefox_desktop.toml
+++ b/featmon/firefox_desktop.toml
@@ -198,37 +198,6 @@ dismiss = {}
 impression = {}
 click = {}
 
-[features.bookmarks]
-slug = "bookmarks"
-
-[features.bookmarks.metrics_by_source.metrics.boolean]
-bookmarks_has_mobile_bookmarks = {}
-metrics_has_desktop_bookmarks = {}
-
-[features.bookmarks.metrics_by_source.metrics.labeled_counter.bookmarks_add]
-aggregators = ["sum"]
-
-[features.bookmarks.metrics_by_source.metrics.labeled_counter.bookmarks_open]
-aggregators = ["sum"]
-
-[features.bookmarks.metrics_by_source.metrics.labeled_counter.bookmarks_edit]
-aggregators = ["sum"]
-
-[features.bookmarks.metrics_by_source.metrics.labeled_counter.bookmarks_delete]
-aggregators = ["sum"]
-
-[features.urlbar]
-slug = "urlbar"
-
-[features.urlbar.metrics_by_source.metrics.boolean]
-urlbar_pref_suggest_all = {}
-urlbar_pref_suggest_sponsored = {}
-urlbar_pref_suggest_nonsponsored = {}
-urlbar_pref_suggest_online_enabled = {}
-
-[features.urlbar.metrics_by_source.metrics.labeled_counter.browser_search_content_urlbar]
-aggregators = ["sum"]
-
 [data_sources.messaging_system]
 analysis_unit_id = "client_info.client_id"
 table_name = "messaging_system"


### PR DESCRIPTION
## Summary

Removes the `bookmarks` and `urlbar` features added in #1438 because the metric names used don't exist in the Firefox Desktop Glean `metrics` ping:

- `bookmarks_has_mobile_bookmarks` — iOS-only metric (`firefox_ios` dataset)
- `metrics_has_desktop_bookmarks` — Fenix/Android-only metric
- `bookmarks_add/open/edit/delete` labeled counters — also iOS-only
- `urlbar_pref_suggest_*` booleans — not present in the Firefox Desktop metrics ping
- `browser_search_content_urlbar` labeled counter — legacy telemetry histogram, not a Glean metric

These were caught by the bigquery-etl integration tests (dry-run against the real BigQuery schema). The features will be re-added once the correct Firefox Desktop Glean metric names are confirmed.