### PR TITLE
Additional config for split view feature usage metric

### DIFF
--- a/jetstream/split-view-onboarding.toml
+++ b/jetstream/split-view-onboarding.toml
@@ -10,7 +10,7 @@ weekly = ["split_view_usage"]
 overall = ["split_view_usage"]
 
 [metrics.split_view_usage]
-select_expression = "mozfun.map.extract_keyed_scalar_sum(metrics.labeled_counter.splitview_uri_count) > 0"
+select_expression = "COALESCE(LOGICAL_OR(mozfun.map.extract_keyed_scalar_sum(metrics.labeled_counter.splitview_uri_count) > 0), FALSE)"
 data_source = "metrics"
 friendly_name = "Split-view feature DAU"
 description = "The number of unique daily clients loading at least one URI in a split view tab pane (either side)."

--- a/jetstream/split-view-onboarding.toml
+++ b/jetstream/split-view-onboarding.toml
@@ -1,0 +1,18 @@
+## No overrides of existing configuration settings; just adding one custom metric
+##  for feature-specific usage
+
+[metrics]
+
+daily = ["split_view_usage"]
+
+weekly = ["split_view_usage"]
+
+overall = ["split_view_usage"]
+
+[metrics.split_view_usage]
+select_expression = "mozfun.map.extract_keyed_scalar_sum(metrics.labeled_counter.splitview_uri_count) > 0"
+data_source = "metrics"
+friendly_name = "Split-view feature DAU"
+description = "The number of unique daily clients loading at least one URI in a split view tab pane (either side)."
+
+[metrics.split_view_usage.statistics.binomial]


### PR DESCRIPTION
This adds a small change for the ["split-view-onboarding" experiment](https://experimenter.services.mozilla.com/nimbus/split-view-onboarding/results/?analysis_basis=enrollments&reference_branch=control&segment=all) analysis to add one additional metric for feature-specific usage. Since the experiment is already complete, the intent is to have one additional rerun to calculate the effect on this metric at the daily, weekly, and overall levels.

My understanding from repo conventions and the [experimenter.info online documentation](https://experimenter.info/data-analysis/jetstream/configuration) is that a basic additive change like this should not necessarily require a formal review and approval before merging to trigger a rerun. That said, I would appreciate a quick review since:

1. This is my first time submitting a config change for an experiment, and
2. I'm not sure if the use of the default `metrics` data source is unduly inefficient for this calculation.