### PR TITLE
feat(nimbus): add urlbar feature monitoring via events data source

### DIFF
--- a/featmon/firefox_desktop.toml
+++ b/featmon/firefox_desktop.toml
@@ -198,6 +198,22 @@ dismiss = {}
 impression = {}
 click = {}
 
+[data_sources.events]
+analysis_unit_id = "client_info.client_id"
+table_name = "events"
+type = "metrics"
+
+[features.urlbar]
+slug = "urlbar"
+
+[features.urlbar.metrics_by_source.events.boolean]
+urlbar_pref_suggest_sponsored = {}
+urlbar_pref_suggest_nonsponsored = {}
+urlbar_pref_suggest_all = {}
+urlbar_pref_suggest_data_collection = {}
+urlbar_pref_suggest_online_available = {}
+urlbar_pref_suggest_online_enabled = {}
+
 [data_sources.messaging_system]
 analysis_unit_id = "client_info.client_id"
 table_name = "messaging_system"


### PR DESCRIPTION
## Summary

- Adds `events` as a new data source (`type = "metrics"`, standard Glean ping with `ping_info.experiments`)
- Adds `urlbar` feature monitoring with 6 suggest pref boolean metrics

The urlbar pref metrics live in the `events` ping (`events_v1`), not the `metrics` ping. Confirmed from the existing `urlbar_events` SQL generator template which reads these fields from `events_v1`.

**Metrics tracked:**
- `urlbar_pref_suggest_sponsored`
- `urlbar_pref_suggest_nonsponsored`
- `urlbar_pref_suggest_all`
- `urlbar_pref_suggest_data_collection`
- `urlbar_pref_suggest_online_available`
- `urlbar_pref_suggest_online_enabled`