### PR TITLE
Add Jetstream config for kitified-value-prop-experiments-on-new-tab-countries-with-no-content-re-run

### DIFF
--- a/jetstream/kitified-value-prop-experiments-on-new-tab-countries-with-no-content-re-run.toml
+++ b/jetstream/kitified-value-prop-experiments-on-new-tab-countries-with-no-content-re-run.toml
@@ -1,0 +1,116 @@
+[experiment]
+
+segments = [
+    "onboarding_intent_privacy_and_security",
+    "onboarding_intent_productivity",
+    "onboarding_intent_other",
+    "os_windows",
+    "os_mac",
+    "os_linux",
+]
+
+## Segments — Onboarding Intent
+
+[segments.onboarding_intent_privacy_and_security]
+friendly_name = "Onboarding Intent Privacy and Security"
+description = "Users who selected Privacy and Security as onboarding intent"
+select_expression = "LOGICAL_OR(COALESCE(selection LIKE '%Privacy and Security%', FALSE))"
+data_source = "onboarding_selection"
+window_start = -3
+window_end = "analysis_window_end"
+
+[segments.onboarding_intent_productivity]
+friendly_name = "Onboarding Intent Productivity"
+description = "Users who selected Productivity as onboarding intent"
+select_expression = "LOGICAL_OR(COALESCE(selection LIKE '%Productivity%', FALSE))"
+data_source = "onboarding_selection"
+window_start = -3
+window_end = "analysis_window_end"
+
+[segments.onboarding_intent_other]
+friendly_name = "Onboarding Intent Other"
+description = "Users who selected Other as onboarding intent"
+select_expression = "LOGICAL_OR(COALESCE(selection LIKE '%Other%', FALSE))"
+data_source = "onboarding_selection"
+window_start = -3
+window_end = "analysis_window_end"
+
+## Segments — OS
+
+[segments.os_windows]
+friendly_name = "OS Windows"
+description = "Users on Windows"
+select_expression = "COALESCE(LOGICAL_OR(LOWER(os) LIKE '%windows%'), FALSE)"
+data_source = "clients_last_seen"
+window_start = -3
+window_end = "analysis_window_end"
+
+[segments.os_mac]
+friendly_name = "OS macOS"
+description = "Users on macOS"
+select_expression = "COALESCE(LOGICAL_OR(LOWER(os) = 'darwin'), FALSE)"
+data_source = "clients_last_seen"
+window_start = -3
+window_end = "analysis_window_end"
+
+[segments.os_linux]
+friendly_name = "OS Linux"
+description = "Users on Linux"
+select_expression = "COALESCE(LOGICAL_OR(LOWER(os) = 'linux'), FALSE)"
+data_source = "clients_last_seen"
+window_start = -3
+window_end = "analysis_window_end"
+
+## Custom data source for onboarding intent
+
+[segments.data_sources.onboarding_selection]
+from_expression = """(
+WITH
+ExperimentEvents AS (
+  SELECT
+    client_id,
+    DATE(submission_timestamp) AS submission_date,
+    JSON_EXTRACT_ARRAY(event_context, '$.source') AS checkbox_sources
+  FROM `moz-fx-data-shared-prod.firefox_desktop.onboarding`
+  WHERE
+    DATE(submission_timestamp) >= '2026-04-20'
+    AND event = 'SELECT_CHECKBOX'
+),
+CheckboxSelectionByClientID AS (
+  SELECT
+    client_id,
+    submission_date,
+    ARRAY_CONCAT_AGG(checkbox_sources) AS all_selected_checkboxes
+  FROM ExperimentEvents
+  GROUP BY client_id, submission_date
+),
+SelectionPerClient AS (
+  SELECT
+    client_id,
+    submission_date,
+    ARRAY_TO_STRING(
+        ARRAY_AGG(
+          CASE
+              WHEN s = '"checkbox-motivation-1"' THEN 'Privacy and Security'
+              WHEN s = '"checkbox-motivation-2"' THEN 'Productivity'
+              WHEN s = '"checkbox-motivation-3"' THEN 'Other'
+          END ),
+        ', '
+      ) AS selection
+  FROM CheckboxSelectionByClientID, UNNEST(all_selected_checkboxes) AS s
+  WHERE
+    ARRAY_LENGTH(all_selected_checkboxes) > 0
+    AND s IN ('"checkbox-motivation-1"',
+      '"checkbox-motivation-2"',
+      '"checkbox-motivation-3"')
+  GROUP BY client_id, submission_date
+)
+SELECT
+  cfs.profile_group_id,
+  s.submission_date,
+  s.selection
+FROM SelectionPerClient s
+JOIN `moz-fx-data-shared-prod.telemetry.clients_first_seen` cfs
+  ON cfs.client_id = s.client_id
+)"""
+window_start = -3


### PR DESCRIPTION
Adds a custom Jetstream config for the `kitified-value-prop-experiments-on-new-tab-countries-with-no-content-re-run` experiment (no-content-countries pair of #1446).

## What this adds
- 3 onboarding-intent segments (Privacy and Security / Productivity / Other) derived from `firefox_desktop.onboarding` `SELECT_CHECKBOX` events on `checkbox-motivation-1/2/3`
- 3 OS segments (Windows / macOS / Linux) keyed on `clients_last_seen.os`

Identical to #1446 (the content-countries pair); same segments, same data source. No custom metrics — relies on Jetstream's auto-applied desktop default set.

## Experiment context
- Nimbus: https://experimenter.services.mozilla.com/nimbus/kitified-value-prop-experiments-on-new-tab-countries-with-no-content-re-run
- Start: 2026-04-23 · Enrollment end: 2026-04-30 · App: firefox_desktop
- Branches: control, treatment-a, treatment-b (reference = control)

🤖 Generated via `/create-custom-config`