### PR TITLE
[Fix] Add custom data source to experiment config

### DIFF
--- a/jetstream/split-view-onboarding.toml
+++ b/jetstream/split-view-onboarding.toml
@@ -10,9 +10,25 @@ weekly = ["split_view_usage"]
 overall = ["split_view_usage"]
 
 [metrics.split_view_usage]
-select_expression = "COALESCE(LOGICAL_OR(mozfun.map.extract_keyed_scalar_sum(metrics.labeled_counter.splitview_uri_count) > 0), FALSE)"
-data_source = "metrics"
+select_expression = "COALESCE(LOGICAL_OR(mozfun.map.extract_keyed_scalar_sum(splitview_uri_count) > 0), FALSE)"
+data_source = "split_view_metrics"
 friendly_name = "Split-view feature DAU"
 description = "The number of unique daily clients loading at least one URI in a split view tab pane (either side)."
 
 [metrics.split_view_usage.statistics.binomial]
+
+[data_sources]
+
+[data_sources.split_view_metrics]
+from_expression = """(
+    SELECT
+        DATE(submission_timestamp) AS submission_date,
+        metrics.uuid.legacy_telemetry_client_id AS client_id,
+        metrics.uuid.legacy_telemetry_profile_group_id AS profile_group_id,
+        ping_info,
+        metrics.labeled_counter.splitview_uri_count AS splitview_uri_count
+    FROM
+        `mozdata.firefox_desktop.metrics` 
+)"""
+client_id_column = "client_id"
+experiments_column_type = "glean"


### PR DESCRIPTION
After the change in https://github.com/mozilla/metric-hub/pull/1441, the automated rerun did not produce values for most analysis periods. I am assuming this is an issue with running out of time or resources in Jetstream, since the custom metric specification was pulling in the most broad and general `metrics` table data source.

This change adds a custom data source to the experiment, only pulling in the fields (I believe) are needed, in hopes that this will help a rerun succeed.