### PR TITLE
Add custom configs for Smart Shortcuts v4

### DIFF
--- a/jetstream/smart-shortcuts-v4p1.toml
+++ b/jetstream/smart-shortcuts-v4p1.toml
@@ -1,0 +1,91 @@
+[experiment]
+reference_branch = "control"
+
+# overwrite nonessential metrics with no-op
+
+[metrics]
+
+overall = ['urlbar_topsite_clicks']
+
+[metrics.organic_pocket_clicks]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.newtab_searches]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.newtab_pocket_enabled]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.newtab_sponsored_pocket_stories_enabled]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.organic_pocket_impressions]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.sponsored_pocket_ctr]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.any_sponsored_tiles_dismissals]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+
+[metrics.sponsored_tiles_dismissals_pos1_2]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.newtab_any_searches]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.newtab_gt4_searches]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.sponsored_pocket_clicks]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.sponsored_pocket_impressions]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.sponsored_tile_ctr]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.urlbar_topsite_clicks]
+select_expression = "SUM(IF(product_result_type = 'top_site', urlbar_clicks, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+friendly_name = "Urlbar topsite clicks"
+[metrics.urlbar_topsite_clicks.statistics.bootstrap_mean]
+
+[data_sources.noop_source]
+from_expression = """(
+    SELECT
+        '1234' AS client_id,
+        '12345' AS profile_group_id,
+        DATE('2022-01-01') AS submission_date
+)"""
+experiments_column_type = "none"
+friendly_name = "No-Op"
+description = "No-op that creates the required columns"

--- a/jetstream/smart-shortcuts-v4p1.toml
+++ b/jetstream/smart-shortcuts-v4p1.toml
@@ -1,6 +1,3 @@
-[experiment]
-reference_branch = "control"
-
 [metrics]
 overall = ['urlbar_topsite_clicks']
 
@@ -8,4 +5,5 @@ overall = ['urlbar_topsite_clicks']
 select_expression = "SUM(IF(product_result_type = 'top_site', urlbar_clicks, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 friendly_name = "Urlbar topsite clicks"
+description = "Total clicks on URL bar top site results."
 [metrics.urlbar_topsite_clicks.statistics.bootstrap_mean]

--- a/jetstream/smart-shortcuts-v4p1.toml
+++ b/jetstream/smart-shortcuts-v4p1.toml
@@ -1,91 +1,11 @@
 [experiment]
 reference_branch = "control"
 
-# overwrite nonessential metrics with no-op
-
 [metrics]
-
 overall = ['urlbar_topsite_clicks']
-
-[metrics.organic_content_clicks]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.newtab_searches]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.newtab_content_enabled]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.newtab_sponsored_content_stories_enabled]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.organic_content_impressions]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.sponsored_content_ctr]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.any_sponsored_tiles_dismissals]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-
-[metrics.sponsored_tiles_dismissals_pos1_2]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.newtab_any_searches]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.newtab_gt4_searches]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.sponsored_content_clicks]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.sponsored_content_impressions]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.sponsored_tile_ctr]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
 
 [metrics.urlbar_topsite_clicks]
 select_expression = "SUM(IF(product_result_type = 'top_site', urlbar_clicks, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 friendly_name = "Urlbar topsite clicks"
 [metrics.urlbar_topsite_clicks.statistics.bootstrap_mean]
-
-[data_sources.noop_source]
-from_expression = """(
-    SELECT
-        '1234' AS client_id,
-        '12345' AS profile_group_id,
-        DATE('2022-01-01') AS submission_date
-)"""
-experiments_column_type = "none"
-friendly_name = "No-Op"
-description = "No-op that creates the required columns"

--- a/jetstream/smart-shortcuts-v4p1.toml
+++ b/jetstream/smart-shortcuts-v4p1.toml
@@ -7,7 +7,7 @@ reference_branch = "control"
 
 overall = ['urlbar_topsite_clicks']
 
-[metrics.organic_pocket_clicks]
+[metrics.organic_content_clicks]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
@@ -17,22 +17,22 @@ select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.newtab_pocket_enabled]
+[metrics.newtab_content_enabled]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.newtab_sponsored_pocket_stories_enabled]
+[metrics.newtab_sponsored_content_stories_enabled]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.organic_pocket_impressions]
+[metrics.organic_content_impressions]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.sponsored_pocket_ctr]
+[metrics.sponsored_content_ctr]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
@@ -58,12 +58,12 @@ select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.sponsored_pocket_clicks]
+[metrics.sponsored_content_clicks]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.sponsored_pocket_impressions]
+[metrics.sponsored_content_impressions]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }

--- a/jetstream/smart-shortcuts-v4p2.toml
+++ b/jetstream/smart-shortcuts-v4p2.toml
@@ -1,0 +1,91 @@
+[experiment]
+reference_branch = "control"
+
+# overwrite nonessential metrics with no-op
+
+[metrics]
+
+overall = ['urlbar_topsite_clicks']
+
+[metrics.organic_pocket_clicks]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.newtab_searches]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.newtab_pocket_enabled]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.newtab_sponsored_pocket_stories_enabled]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.organic_pocket_impressions]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.sponsored_pocket_ctr]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.any_sponsored_tiles_dismissals]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+
+[metrics.sponsored_tiles_dismissals_pos1_2]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.newtab_any_searches]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.newtab_gt4_searches]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.sponsored_pocket_clicks]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.sponsored_pocket_impressions]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.sponsored_tile_ctr]
+select_expression = 'SUM(0)'
+data_source = "noop_source"
+statistics = { bootstrap_mean = {} }
+
+[metrics.urlbar_topsite_clicks]
+select_expression = "SUM(IF(product_result_type = 'top_site', urlbar_clicks, 0))"
+data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
+friendly_name = "Urlbar topsite clicks"
+[metrics.urlbar_topsite_clicks.statistics.bootstrap_mean]
+
+[data_sources.noop_source]
+from_expression = """(
+    SELECT
+        '1234' AS client_id,
+        '12345' AS profile_group_id,
+        DATE('2022-01-01') AS submission_date
+)"""
+experiments_column_type = "none"
+friendly_name = "No-Op"
+description = "No-op that creates the required columns"

--- a/jetstream/smart-shortcuts-v4p2.toml
+++ b/jetstream/smart-shortcuts-v4p2.toml
@@ -1,77 +1,61 @@
 [experiment]
 reference_branch = "control"
 
-# overwrite nonessential metrics with no-op
-
 [metrics]
+weekly = [
+  "newtab_visits",
+  "newtab_engaged_visits",
+  "newtab_ad_click_rate",
+  "newtab_homepage_enabled",
+  "newtab_engagement",
+  "newtab_any_searches",
+  "newtab_gt4_searches",
+  "sponsored_tile_clicks",
+  "sponsored_tile_impressions",
+  "newtab_organic_topsite_clicks_v2",
+  "newtab_organic_topsite_impressions_v2",
+  "sponsored_content_clicks",
+  "sponsored_content_impressions",
+  "organic_content_clicks",
+  "organic_content_impressions",
+  "sponsored_tile_ctr",
+  "sponsored_content_ctr",
+  "newtab_searches",
+  "newtab_content_enabled",
+  "newtab_sponsored_content_stories_enabled",
+  "any_organic_content_clicks",
+  "newtab_sponsored_tiles_enabled",
+  "any_sponsored_tiles_dismissals",
+  "sponsored_tiles_dismissals",
+]
 
-overall = ['urlbar_topsite_clicks']
-
-[metrics.organic_content_clicks]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.newtab_searches]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.newtab_content_enabled]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.newtab_sponsored_content_stories_enabled]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.organic_content_impressions]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.sponsored_content_ctr]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.any_sponsored_tiles_dismissals]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-
-[metrics.sponsored_tiles_dismissals_pos1_2]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.newtab_any_searches]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.newtab_gt4_searches]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.sponsored_content_clicks]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.sponsored_content_impressions]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
-
-[metrics.sponsored_tile_ctr]
-select_expression = 'SUM(0)'
-data_source = "noop_source"
-statistics = { bootstrap_mean = {} }
+overall = [
+  "urlbar_topsite_clicks",
+  "newtab_visits",
+  "newtab_engaged_visits",
+  "newtab_ad_click_rate",
+  "newtab_homepage_enabled",
+  "newtab_engagement",
+  "newtab_any_searches",
+  "newtab_gt4_searches",
+  "sponsored_tile_clicks",
+  "sponsored_tile_impressions",
+  "newtab_organic_topsite_clicks_v2",
+  "newtab_organic_topsite_impressions_v2",
+  "sponsored_content_clicks",
+  "sponsored_content_impressions",
+  "organic_content_clicks",
+  "organic_content_impressions",
+  "sponsored_tile_ctr",
+  "sponsored_content_ctr",
+  "newtab_searches",
+  "newtab_content_enabled",
+  "newtab_sponsored_content_stories_enabled",
+  "any_organic_content_clicks",
+  "newtab_sponsored_tiles_enabled",
+  "any_sponsored_tiles_dismissals",
+  "sponsored_tiles_dismissals",
+]
 
 [metrics.urlbar_topsite_clicks]
 select_expression = "SUM(IF(product_result_type = 'top_site', urlbar_clicks, 0))"
@@ -79,13 +63,72 @@ data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 friendly_name = "Urlbar topsite clicks"
 [metrics.urlbar_topsite_clicks.statistics.bootstrap_mean]
 
-[data_sources.noop_source]
-from_expression = """(
-    SELECT
-        '1234' AS client_id,
-        '12345' AS profile_group_id,
-        DATE('2022-01-01') AS submission_date
-)"""
-experiments_column_type = "none"
-friendly_name = "No-Op"
-description = "No-op that creates the required columns"
+# Copied from jetstream/outcomes/firefox_desktop/newtab_do_no_harm.toml
+[metrics.newtab_visits.statistics.bootstrap_mean]
+[metrics.newtab_visits.statistics.deciles]
+
+[metrics.newtab_engaged_visits.statistics.bootstrap_mean]
+[metrics.newtab_engaged_visits.statistics.deciles]
+
+[metrics.newtab_ad_click_rate.statistics.bootstrap_mean]
+[metrics.newtab_ad_click_rate.statistics.deciles]
+
+[metrics.newtab_homepage_enabled.statistics.binomial]
+[metrics.newtab_engagement.statistics.binomial]
+[metrics.newtab_any_searches.statistics.binomial]
+[metrics.newtab_gt4_searches.statistics.binomial]
+
+[metrics.sponsored_tile_clicks.statistics.sum]
+[metrics.sponsored_tile_clicks.statistics.linear_model_mean]
+[metrics.sponsored_tile_impressions.statistics.sum]
+[metrics.sponsored_tile_impressions.statistics.linear_model_mean]
+
+[metrics.newtab_organic_topsite_clicks_v2.statistics.sum]
+[metrics.newtab_organic_topsite_clicks_v2.statistics.linear_model_mean]
+[metrics.newtab_organic_topsite_impressions_v2.statistics.sum]
+[metrics.newtab_organic_topsite_impressions_v2.statistics.linear_model_mean]
+
+[metrics.sponsored_content_clicks.statistics.sum]
+[metrics.sponsored_content_clicks.statistics.linear_model_mean]
+[metrics.sponsored_content_impressions.statistics.sum]
+[metrics.sponsored_content_impressions.statistics.linear_model_mean]
+
+[metrics.organic_content_clicks.statistics.sum]
+[metrics.organic_content_clicks.statistics.linear_model_mean]
+[metrics.organic_content_impressions.statistics.sum]
+[metrics.organic_content_impressions.statistics.linear_model_mean]
+
+[metrics.sponsored_tile_ctr.statistics.population_ratio]
+numerator = 'sponsored_tile_clicks'
+denominator = 'sponsored_tile_impressions'
+
+[metrics.sponsored_content_ctr.statistics.population_ratio]
+numerator = 'sponsored_content_clicks'
+denominator = 'sponsored_content_impressions'
+
+# Copied from jetstream/outcomes/firefox_desktop/pocket_newtab.toml
+[metrics.organic_content_clicks.statistics.bootstrap_mean]
+[metrics.organic_content_clicks.statistics.deciles]
+
+[metrics.sponsored_content_clicks.statistics.bootstrap_mean]
+[metrics.sponsored_content_clicks.statistics.deciles]
+
+[metrics.newtab_searches.statistics.bootstrap_mean]
+[metrics.newtab_searches.statistics.deciles]
+
+[metrics.newtab_content_enabled.statistics.binomial]
+[metrics.newtab_sponsored_content_stories_enabled.statistics.binomial]
+[metrics.any_organic_content_clicks.statistics.binomial]
+
+# Copied from jetstream/outcomes/firefox_desktop/sponsored_tiles.toml
+[metrics.newtab_sponsored_tiles_enabled.statistics.binomial]
+[metrics.any_sponsored_tiles_dismissals.statistics.binomial]
+
+[metrics.sponsored_tiles_dismissals.statistics.bootstrap_mean]
+[metrics.sponsored_tiles_dismissals.statistics.deciles]
+
+[metrics.sponsored_tile_clicks.statistics.bootstrap_mean]
+[metrics.sponsored_tile_clicks.statistics.deciles]
+
+[metrics.sponsored_tile_impressions.statistics.bootstrap_mean]
+[metrics.sponsored_tile_impressions.statistics.deciles]

--- a/jetstream/smart-shortcuts-v4p2.toml
+++ b/jetstream/smart-shortcuts-v4p2.toml
@@ -1,6 +1,3 @@
-[experiment]
-reference_branch = "control"
-
 [metrics]
 weekly = [
   "newtab_visits",
@@ -61,6 +58,7 @@ overall = [
 select_expression = "SUM(IF(product_result_type = 'top_site', urlbar_clicks, 0))"
 data_source = "urlbar_events_daily_engagement_by_product_result_type_v1"
 friendly_name = "Urlbar topsite clicks"
+description = "Total clicks on URL bar top site results."
 [metrics.urlbar_topsite_clicks.statistics.bootstrap_mean]
 
 # Copied from jetstream/outcomes/firefox_desktop/newtab_do_no_harm.toml
@@ -78,24 +76,16 @@ friendly_name = "Urlbar topsite clicks"
 [metrics.newtab_any_searches.statistics.binomial]
 [metrics.newtab_gt4_searches.statistics.binomial]
 
-[metrics.sponsored_tile_clicks.statistics.sum]
 [metrics.sponsored_tile_clicks.statistics.linear_model_mean]
-[metrics.sponsored_tile_impressions.statistics.sum]
 [metrics.sponsored_tile_impressions.statistics.linear_model_mean]
 
-[metrics.newtab_organic_topsite_clicks_v2.statistics.sum]
 [metrics.newtab_organic_topsite_clicks_v2.statistics.linear_model_mean]
-[metrics.newtab_organic_topsite_impressions_v2.statistics.sum]
 [metrics.newtab_organic_topsite_impressions_v2.statistics.linear_model_mean]
 
-[metrics.sponsored_content_clicks.statistics.sum]
 [metrics.sponsored_content_clicks.statistics.linear_model_mean]
-[metrics.sponsored_content_impressions.statistics.sum]
 [metrics.sponsored_content_impressions.statistics.linear_model_mean]
 
-[metrics.organic_content_clicks.statistics.sum]
 [metrics.organic_content_clicks.statistics.linear_model_mean]
-[metrics.organic_content_impressions.statistics.sum]
 [metrics.organic_content_impressions.statistics.linear_model_mean]
 
 [metrics.sponsored_tile_ctr.statistics.population_ratio]

--- a/jetstream/smart-shortcuts-v4p2.toml
+++ b/jetstream/smart-shortcuts-v4p2.toml
@@ -7,7 +7,7 @@ reference_branch = "control"
 
 overall = ['urlbar_topsite_clicks']
 
-[metrics.organic_pocket_clicks]
+[metrics.organic_content_clicks]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
@@ -17,22 +17,22 @@ select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.newtab_pocket_enabled]
+[metrics.newtab_content_enabled]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.newtab_sponsored_pocket_stories_enabled]
+[metrics.newtab_sponsored_content_stories_enabled]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.organic_pocket_impressions]
+[metrics.organic_content_impressions]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.sponsored_pocket_ctr]
+[metrics.sponsored_content_ctr]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
@@ -58,12 +58,12 @@ select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.sponsored_pocket_clicks]
+[metrics.sponsored_content_clicks]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }
 
-[metrics.sponsored_pocket_impressions]
+[metrics.sponsored_content_impressions]
 select_expression = 'SUM(0)'
 data_source = "noop_source"
 statistics = { bootstrap_mean = {} }


### PR DESCRIPTION
Adds Jetstream custom configs for smart-shortcuts-v4p1 and smart-shortcuts-v4p2.

For both we are adding urlbar-clicks.

For v4p1, I want the experimenter UI metrics plus this additional one.

For v4p2, we are adding some metrics when none existed before.