### PR TITLE
Expand VPN holdback enrollment_period from 14 to 28 days

### DIFF
--- a/jetstream/vpn-mvp-beta-holdback.toml
+++ b/jetstream/vpn-mvp-beta-holdback.toml
@@ -1,5 +1,5 @@
 [experiment]
-enrollment_period = 14
+enrollment_period = 28
 segments = [
   "country_de",
   "country_fr",


### PR DESCRIPTION
## Summary
Bumps `enrollment_period` from 14 to 28 in `jetstream/vpn-mvp-beta-holdback.toml`.

The holdback experiment ends on 2026-05-18. Expanding the analysis-side
`enrollment_period` to 28 includes the full first-4-weeks cohort (enrolled
2026-03-23 through 2026-04-19), which lets Jetstream auto-compute 4-week
retention and the default browser-usage metrics on the intended cohort.

The 28-day retention window for the latest enrollee (2026-04-19) completes
on 2026-05-16, fitting cleanly within the experiment's endDate.

## Test plan
- [ ] validate-jetstream check passes
- [ ] Review the metrics query estimate in the validate-jetstream task details (was 51 TB at enrollment_period=14; expect ~2x at 28)
- [ ] Merge timing: any time before 2026-05-18 — earlier means intermediate results reflect the final cohort; later means one fewer Jetstream rerun