### PR TITLE
[ci rerun-skip] Add improved Retention metric for Desktop Defaults

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1507,7 +1507,30 @@ description = "Is the client signed in at any point during the experiment"
 select_expression = "COALESCE(SUM(pings_aggregated_by_this_row), 0) > 0"
 data_source = "clients_daily"
 friendly_name = "Retained"
-description = "Records whether a client submitted any pings (i.e. used Firefox)."
+description = """
+    Records whether a client submitted any pings (i.e. used Firefox).
+
+    Note: As of May 2026, this metric is being deprecated in favor of "Retained (DAU)", which better matches the conventional 
+    definition of Retention based on "active" instead of "seen" now recommended by Data Science team and used for reporting in
+    other contexts. 
+"""
+deprecated = true
+
+[metrics.retained_dau]
+# As of May 2026, Desktop DAU is still primarily measured with regard to Legacy telemetry. 
+# Once DAU tracking is transitioned to Glean, this metric should also be updated to use the Glean data source:
+# "firefox_desktop_baseline_active_users_view"
+data_source = "firefox_desktop_active_users_view"
+select_expression = "COALESCE(LOGICAL_OR(is_dau), FALSE)"
+friendly_name = "Retained (DAU)"
+description = """
+    Whether the client had at least one DAU-qualifying day in the analysis window (is_dau = TRUE on any day).
+
+    Conventionally expressed as a percentage rate: The percentage of clients from the originating cohort that were then active in the later period. 
+    
+    Most typically, this is measured as Week 2 Retention in order to balance timeliness and accuracy. 
+    But when time permits, Data Science recommends using Week 4 Retention as more representative of long-term effects.
+"""
 
 [metrics.active_in_last_3_days]
 select_expression = "COALESCE(MIN(days_since_desktop_active), 30) < 3"

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1510,7 +1510,7 @@ friendly_name = "Retained"
 description = """
     Records whether a client submitted any pings (i.e. used Firefox).
 
-    Note: As of May 2026, this metric is being deprecated in favor of "Retained (DAU)", which better matches the conventional 
+    Note: As of June 2026, this metric is being deprecated in favor of "Retained (DAU)", which better matches the conventional 
     definition of Retention based on "active" instead of "seen" now recommended by Data Science team and used for reporting in
     other contexts. 
 """

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -2,7 +2,7 @@
 
 [metrics]
 daily = [
-  "retained",
+  "retained_dau",
   "unenroll",
   "client_level_daily_active_users_v2",
   "active_hours",
@@ -14,7 +14,7 @@ weekly = [
   "active_hours",
   "ad_clicks",
   "days_of_use",
-  "retained",
+  "retained_dau",
   "uri_count",
   "search_count",
   "qualified_cumulative_days_of_use",
@@ -93,7 +93,7 @@ period = "preenrollment_week"
 [metrics.organic_search_count.statistics.deciles]
 
 
-[metrics.retained.statistics.binomial]
+[metrics.retained_dau.statistics.binomial]
 
 
 [metrics.active_in_last_3_days_legacy.statistics.binomial]

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -96,6 +96,7 @@ period = "preenrollment_week"
 
 
 [metrics.retained.statistics.binomial]
+
 [metrics.retained_dau.statistics.binomial]
 
 

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -2,6 +2,7 @@
 
 [metrics]
 daily = [
+  "retained",
   "retained_dau",
   "unenroll",
   "client_level_daily_active_users_v2",
@@ -14,6 +15,7 @@ weekly = [
   "active_hours",
   "ad_clicks",
   "days_of_use",
+  "retained",
   "retained_dau",
   "uri_count",
   "search_count",
@@ -93,6 +95,7 @@ period = "preenrollment_week"
 [metrics.organic_search_count.statistics.deciles]
 
 
+[metrics.retained.statistics.binomial]
 [metrics.retained_dau.statistics.binomial]
 
 


### PR DESCRIPTION
This pull request is the first in a series of code and definition changes for key default metrics in Desktop Experiments related to DAU and retention. These changes are intended to better align the recommended metrics with DS team current best practices, and make it easier to interpret metrics when answering questions about the effects of treatments on overall app usage.

As a first change, this PR adds an updated version of the flagship `Retained` with one that explicitly looks for DAU-qualifying activity. The intention is to have this version run alongside the existing version (that counts *any* ping as retained), for a brief period to evaluate the effective difference between the new and old metrics. Then, a separate code change will more fully retire the old `Retained` version from the defaults, alongside changes to other DAU and activity metrics, as part of a communicated rollout.

[ci rerun-skip]