### PR TITLE
add suggest query normalization config

### DIFF
--- a/jetstream/suggest-query-normalization-experiment.toml
+++ b/jetstream/suggest-query-normalization-experiment.toml
@@ -1,0 +1,134 @@
+# Custom Jetstream config for: suggest-query-normalization-experiment (Firefox Desktop)
+# Replicates the Query Normalization analysis on-platform. Pattern follows
+# navigational-suggestions.toml: one urlbar-events source, per-provider rates via
+# population_ratio. Providers: 'market' (finance), 'sports'.
+#
+# Winsorization uses the standard population_ratio drop_highest (no bespoke caps),
+# applied per provider by data density:
+#   Finance ('market'): drop_highest = 0.001 — ~9% of clients see a market result,
+#     dense enough for a standard 99.9th-pct trim.
+#   Sports: drop_highest = 0.0 (unwinsorized) — only ~0.5% of clients ever see a
+#     sports result, so any percentile trim degenerates (cap lands at 0 -> NaN).
+
+[experiment]
+# Exposed = shown a market or sports result.
+[experiment.exposure_signal]
+name = "exposed_to_market_or_sports"
+friendly_name = "Exposed to a market or sports result"
+description = "Clients with at least one urlbar session that surfaced a market (finance) or sports result."
+select_expression = "EXISTS(SELECT 1 FROM UNNEST(results) r WHERE r.product_result_type IN ('market', 'sports'))"
+data_source = "urlbar_events"
+window_end = "analysis_window_end"
+
+
+[metrics]
+weekly = [
+  "total_urlbar_sessions",
+  "market_impressions", "market_clicks", "market_match_rate", "market_ctr",
+  "sports_impressions", "sports_clicks", "sports_match_rate", "sports_ctr",
+  "search_count", "active_hours",
+]
+overall = [
+  "total_urlbar_sessions",
+  "market_impressions", "market_clicks", "market_match_rate", "market_ctr",
+  "sports_impressions", "sports_clicks", "sports_match_rate", "sports_ctr",
+  "search_count", "active_hours",
+]
+
+
+# Counts per client (bootstrap_mean). These feed the ratios below; winsorization
+# is applied by the ratio statistics, not here.
+[metrics.total_urlbar_sessions]
+friendly_name = "Total urlbar sessions"
+description = "Total terminal urlbar sessions per client. Match-rate denominator."
+select_expression = "COUNT(*)"
+data_source = "urlbar_events"
+[metrics.total_urlbar_sessions.statistics.bootstrap_mean]
+
+[metrics.market_impressions]
+friendly_name = "Finance (market) impressions"
+description = "Urlbar sessions that surfaced a market result, per client. Match-rate numerator and CTR denominator."
+select_expression = "COUNTIF(EXISTS(SELECT 1 FROM UNNEST(results) r WHERE r.product_result_type = 'market'))"
+data_source = "urlbar_events"
+[metrics.market_impressions.statistics.bootstrap_mean]
+
+[metrics.market_clicks]
+friendly_name = "Finance (market) clicks"
+description = "Engaged clicks on a market result, per client. CTR numerator."
+select_expression = "COUNTIF(product_selected_result = 'market' AND event_action = 'engaged')"
+data_source = "urlbar_events"
+[metrics.market_clicks.statistics.bootstrap_mean]
+
+[metrics.sports_impressions]
+friendly_name = "Sports impressions"
+description = "Urlbar sessions that surfaced a sports result, per client. Match-rate numerator and CTR denominator."
+select_expression = "COUNTIF(EXISTS(SELECT 1 FROM UNNEST(results) r WHERE r.product_result_type = 'sports'))"
+data_source = "urlbar_events"
+[metrics.sports_impressions.statistics.bootstrap_mean]
+
+[metrics.sports_clicks]
+friendly_name = "Sports clicks"
+description = "Engaged clicks on a sports result, per client. CTR numerator."
+select_expression = "COUNTIF(product_selected_result = 'sports' AND event_action = 'engaged')"
+data_source = "urlbar_events"
+[metrics.sports_clicks.statistics.bootstrap_mean]
+
+
+# SUCCESS metrics: match rate = provider impressions / total sessions (99.9th-pct trim)
+[metrics.market_match_rate]
+friendly_name = "Finance (market) match rate"
+description = "sum(market impressions) / sum(total sessions)."
+depends_on = ["market_impressions", "total_urlbar_sessions"]
+[metrics.market_match_rate.statistics.population_ratio]
+numerator = "market_impressions"
+denominator = "total_urlbar_sessions"
+drop_highest = 0.001
+
+[metrics.sports_match_rate]
+friendly_name = "Sports match rate"
+description = "sum(sports impressions) / sum(total sessions)."
+depends_on = ["sports_impressions", "total_urlbar_sessions"]
+[metrics.sports_match_rate.statistics.population_ratio]
+numerator = "sports_impressions"
+denominator = "total_urlbar_sessions"
+drop_highest = 0.0
+
+# GUARDRAIL metrics: CTR = provider clicks / provider impressions (unwinsorized)
+[metrics.market_ctr]
+friendly_name = "Finance (market) CTR"
+description = "sum(market clicks) / sum(market impressions)."
+depends_on = ["market_clicks", "market_impressions"]
+[metrics.market_ctr.statistics.population_ratio]
+numerator = "market_clicks"
+denominator = "market_impressions"
+drop_highest = 0.001
+
+[metrics.sports_ctr]
+friendly_name = "Sports CTR"
+description = "sum(sports clicks) / sum(sports impressions)."
+depends_on = ["sports_clicks", "sports_impressions"]
+[metrics.sports_ctr.statistics.population_ratio]
+numerator = "sports_clicks"
+denominator = "sports_impressions"
+drop_highest = 0.0
+
+
+# One row per terminal urlbar session (release), with results[] and selected-result fields.
+[data_sources.urlbar_events]
+from_expression = """(
+    SELECT
+        glean_client_id AS client_id,
+        DATE(submission_date) AS submission_date,
+        experiments,
+        results,
+        product_selected_result,
+        event_action
+    FROM `mozdata.firefox_desktop.urlbar_events`
+    WHERE is_terminal
+      AND normalized_channel = 'release'
+)"""
+friendly_name = "Urlbar events (terminal sessions)"
+description = "Terminal urlbar sessions on release, with results[] and selected-result fields for per-provider metrics."
+experiments_column_type = "native"
+
+


### PR DESCRIPTION
Per the Query Normalization experiment [proposal](https://docs.google.com/document/d/158GidXdX9dkirtYPHL1yqittSoQW1tC35cVPLiRDRqw/edit?tab=t.0), this adds a custom metric-hub config for suggest-query-normalization-experiment to reproduce the interim analysis. The experiment tests whether normalizing Firefox Suggest queries improves matching for the Finance (market) and Sports (sports) urlbar product result types.

For each provider, the config adds:

- Match rate (success metric) — provider impressions / total urlbar sessions, via population_ratio
- CTR (guardrail metric) — provider clicks / provider impressions, via population_ratio
- Supporting per-client impressions and clicks counts, via bootstrap_mean

Plus an exposure signal (clients shown a market or sports result) and search_count / active_hours as do-no-harm guardrails — all computed for the weekly and overall periods. Built on a single urlbar_events data source, following the navigational-suggestions.toml pattern.