### PR TITLE
[ci rerun-skip] Add new "DAU per 1,000 clients" metric for Desktop

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -463,6 +463,25 @@ description = """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
+[metrics.daily_active_users_per_1000_clients_legacy]
+friendly_name = "DAU per 1,000 clients"
+data_source = "firefox_desktop_active_users_view"
+select_expression = """COUNTIF(is_dau) * 1000"""
+type = "scalar"
+description = """
+    This metric uses our [canonical, supported definition of Daily Active Users 
+    (DAU)](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/314704478/Daily+Active+Users+DAU+Metric), expressed in a format
+    suited for use in experiments. In an experimental comparison, it describes the *additional (incremental) DAU* seen on each day from a treatment.
+    
+    The units are expressed in terms of thousands of clients enrolled or exposed, so the effect can be scaled to either the observed
+    or expected rollout population as needed to estimate absolute DAU impact.
+
+    Effects are averaged to a per-day basis over each analysis period. Since feature changes often show a strong "novelty effect", this 
+    metric is best interpretted over Week 4 or later, in order to better estimate what the lasting steady-state effects are.
+"""
+owner = ["bochocki@mozilla.com", "bbaird@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = false
+
 [metrics.client_level_daily_active_users_v2_glean]
 friendly_name = "Firefox Desktop Client-Level DAU in Glean"
 data_source = "firefox_desktop_baseline_active_users_view"
@@ -476,6 +495,25 @@ description = """
     similar to a "days of use" metric, and not DAU.
 """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
+deprecated = false
+
+[metrics.daily_active_users_per_1000_clients]
+friendly_name = "DAU per 1,000 clients (Glean)"
+data_source = "firefox_desktop_baseline_active_users_view"
+select_expression = """COUNTIF(is_dau) * 1000"""
+type = "scalar"
+description = """
+    This metric uses our [canonical, supported definition of Daily Active Users 
+    (DAU)](https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/314704478/Daily+Active+Users+DAU+Metric), expressed in a format
+    suited for use in experiments. In an experimental comparison, it describes the *additional (incremental) DAU* seen on each day from a treatment.
+    
+    The units are expressed in terms of thousands of clients enrolled or exposed, so the effect can be scaled to either the observed
+    or expected rollout population as needed to estimate absolute DAU impact.
+
+    Effects are averaged to a per-day basis over each analysis period. Since feature changes often show a strong "novelty effect", this 
+    metric is best interpretted over Week 4 or later, in order to better estimate what the lasting steady-state effects are.
+"""
+owner = ["bochocki@mozilla.com", "bbaird@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
 
 [metrics.desktop_dau_kpi]

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -477,7 +477,7 @@ description = """
     or expected rollout population as needed to estimate absolute DAU impact.
 
     Effects are averaged to a per-day basis over each analysis period. Since feature changes often show a strong "novelty effect", this 
-    metric is best interpretted over Week 4 or later, in order to better estimate what the lasting steady-state effects are.
+    metric is best interpreted over Week 4 or later, in order to better estimate what the lasting steady-state effects are.
 """
 owner = ["bochocki@mozilla.com", "bbaird@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false
@@ -511,7 +511,7 @@ description = """
     or expected rollout population as needed to estimate absolute DAU impact.
 
     Effects are averaged to a per-day basis over each analysis period. Since feature changes often show a strong "novelty effect", this 
-    metric is best interpretted over Week 4 or later, in order to better estimate what the lasting steady-state effects are.
+    metric is best interpreted over Week 4 or later, in order to better estimate what the lasting steady-state effects are.
 """
 owner = ["bochocki@mozilla.com", "bbaird@mozilla.com", "firefox-kpi@mozilla.com"]
 deprecated = false

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -160,8 +160,8 @@ pre_treatments = ['normalize_over_analysis_period']
 [metrics.daily_active_users_per_1000_clients_legacy.statistics.linear_model_mean]
 # The intended units for 'DAU per 1,000 clients' require that it:
 #  a. Be calculated as an average over the time period (such that it matches the *daily* interpretation of DAU)
-#  b. Expressly include all rows/values (such that clients who are active on *all* included days are counted as such
+#  b. Expressly include all rows/values (such that clients who are active on *all* included days are counted as such)
 pre_treatments = ['normalize_over_analysis_period']
 drop_highest = 0.0
-[metrics.days_of_use.daily_active_users_per_1000_clients_legacy.linear_model_mean.covariate_adjustment]
+[metrics.daily_active_users_per_1000_clients_legacy.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -163,5 +163,5 @@ pre_treatments = ['normalize_over_analysis_period']
 #  b. Expressly include all rows/values (such that clients who are active on *all* included days are counted as such)
 pre_treatments = ['normalize_over_analysis_period']
 drop_highest = 0.0
-[metrics.daily_active_users_per_1000_clients_legacy.linear_model_mean.covariate_adjustment]
+[metrics.daily_active_users_per_1000_clients_legacy.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -9,6 +9,7 @@ daily = [
   "active_hours",
   "search_count",
   "active_in_last_3_days_legacy",
+  "daily_active_users_per_1000_clients_legacy",
 ]
 
 weekly = [
@@ -22,6 +23,7 @@ weekly = [
   "qualified_cumulative_days_of_use",
   "is_default_browser",
   "client_level_daily_active_users_v2",
+  "daily_active_users_per_1000_clients_legacy",
 ]
 
 overall = [
@@ -37,6 +39,7 @@ overall = [
   "qualified_cumulative_days_of_use",
   "is_default_browser",
   "client_level_daily_active_users_v2",
+  "daily_active_users_per_1000_clients_legacy",
 ]
 
 preenrollment_weekly = [
@@ -52,6 +55,7 @@ preenrollment_weekly = [
   "qualified_cumulative_days_of_use",
   "is_default_browser",
   "client_level_daily_active_users_v2",
+  "daily_active_users_per_1000_clients_legacy",
 ]
 
 preenrollment_days28 = [
@@ -151,3 +155,13 @@ period = "preenrollment_week"
 
 [metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]
 pre_treatments = ['normalize_over_analysis_period']
+
+
+[metrics.daily_active_users_per_1000_clients_legacy.statistics.linear_model_mean]
+# The intended units for 'DAU per 1,000 clients' require that it:
+#  a. Be calculated as an average over the time period (such that it matches the *daily* interpretation of DAU)
+#  b. Expressly include all rows/values (such that clients who are active on *all* included days are counted as such
+pre_treatments = ['normalize_over_analysis_period']
+drop_highest = 0.0
+[metrics.days_of_use.daily_active_users_per_1000_clients_legacy.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"


### PR DESCRIPTION
This new metric is meant to express DAU impact from experiments in a format that is easier to directly interpret and build into impact analyses that try to estimate DAU impact from larger rollouts.

The expected impact is to show the same _statistical_ results as the current "Client-level DAU" metric used for Desktop, except:
1. Expressed in simpler units
2. Calculated without the need of the custom Jetstream statistic
3. With some extra precision from enabling one week pre-enrollment calculation for CUPED adjustment (which has not been enabled for the current metric)

Details [in Jira ticket [DS-4799]](https://mozilla-hub.atlassian.net/browse/DS-4799).

[ci rerun-skip]