### PR TITLE
feat: add new optional experiment params for forcing reruns

### DIFF
--- a/lib/metric-config-parser/metric_config_parser/experiment.py
+++ b/lib/metric-config-parser/metric_config_parser/experiment.py
@@ -75,6 +75,8 @@ class Experiment:
         enrollment_end_date: experiment enrollment_end_date
         is_enrollment_paused: True if enrollment has ended;
             needed because enrollment_end_date may be computed/proposed
+        do_rerun: True if analysis should be fully rerun
+        do_rerun_timestamp: fully rerun analysis if exp tables are older than this
     """
 
     experimenter_slug: str | None
@@ -97,6 +99,8 @@ class Experiment:
     boolean_pref: str | None = None
     channel: Channel | None = None
     is_rollout: bool = False
+    do_rerun: bool = False
+    do_rerun_timestamp: dt.datetime | None = None
 
 
 @attr.s(auto_attribs=True)
@@ -252,6 +256,14 @@ class ExperimentConfiguration:
         if self.experiment_spec.enrollments_query_type:
             return EnrollmentsQueryType(self.experiment_spec.enrollments_query_type)
         return None
+
+    @property
+    def do_rerun_timestamp(self) -> dt.datetime | None:
+        return self.experiment.do_rerun_timestamp
+
+    @property
+    def do_rerun(self) -> bool:
+        return self.experiment.do_rerun or False
 
     def has_external_config_overrides(self) -> bool:
         """Check whether the external config overrides experiment configuration."""

--- a/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_experiment.py
@@ -602,6 +602,62 @@ class TestExperimentConf:
         with pytest.raises(ValueError, match=re.escape(error_msg)):
             _a = cfg.experiment.analysis_unit
 
+    def test_experiment_config_rerun_defaults(self, config_collection):
+        conf = dedent(
+            """
+            [experiment]
+            """
+        )
+        exp = Experiment(
+            experimenter_slug="test_slug",
+            type="v6",
+            status="Complete",
+            start_date=dt.datetime(2019, 12, 1, tzinfo=pytz.utc),
+            end_date=dt.datetime(2020, 3, 1, tzinfo=pytz.utc),
+            proposed_enrollment=7,
+            branches=[Branch(slug="a", ratio=1), Branch(slug="b", ratio=1)],
+            normandy_slug="normandy-test-slug",
+            reference_branch="b",
+            is_high_population=False,
+            app_name="firefox_desktop",
+        )
+        assert not exp.do_rerun
+        assert exp.do_rerun_timestamp is None
+        spec = AnalysisSpec.from_dict(toml.loads(conf))
+        cfg = spec.resolve(exp, config_collection)
+
+        assert not cfg.experiment.do_rerun
+        assert cfg.experiment.do_rerun_timestamp is None
+
+    def test_experiment_config_rerun(self, config_collection):
+        conf = dedent(
+            """
+            [experiment]
+            """
+        )
+        exp = Experiment(
+            experimenter_slug="test_slug",
+            type="v6",
+            status="Complete",
+            start_date=dt.datetime(2019, 12, 1, tzinfo=pytz.utc),
+            end_date=dt.datetime(2020, 3, 1, tzinfo=pytz.utc),
+            proposed_enrollment=7,
+            branches=[Branch(slug="a", ratio=1), Branch(slug="b", ratio=1)],
+            normandy_slug="normandy-test-slug",
+            reference_branch="b",
+            is_high_population=False,
+            app_name="firefox_desktop",
+            do_rerun=True,
+            do_rerun_timestamp=dt.datetime(2020, 4, 1, tzinfo=pytz.utc),
+        )
+        assert exp.do_rerun
+        assert exp.do_rerun_timestamp == dt.datetime(2020, 4, 1, tzinfo=pytz.utc)
+        spec = AnalysisSpec.from_dict(toml.loads(conf))
+        cfg = spec.resolve(exp, config_collection)
+
+        assert cfg.experiment.do_rerun
+        assert cfg.experiment.do_rerun_timestamp == dt.datetime(2020, 4, 1, tzinfo=pytz.utc)
+
 
 class TestDefaultConfiguration:
     def test_descriptions_defined(self, experiments, config_collection):

--- a/lib/metric-config-parser/pyproject.toml
+++ b/lib/metric-config-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-metric-config-parser"
-version = "2026.4.4"
+version = "2026.6.1"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Parses metric configuration files."
 readme = "README.md"


### PR DESCRIPTION
These fields will be sent by the Experimenter API and used by Jetstream to determine if a full rerun should be triggered instead of normal analysis behavior.

cc @yashikakhurana 