### PR TITLE
Add OS segments (Windows/macOS/Linux) to world-cup-start-of-tournament-privacy-campaign

### DIFF
--- a/jetstream/world-cup-start-of-tournament-privacy-campaign.toml
+++ b/jetstream/world-cup-start-of-tournament-privacy-campaign.toml
@@ -8,6 +8,10 @@ segments = [
   "profile_age_181_to_365_days",
   "profile_age_more_than_365_days",
 
+  "os_windows",
+  "os_mac",
+  "os_linux",
+
   "last_dau_28_to_59_days_ago",
   "last_dau_60_to_179_days_ago",
   "last_dau_180plus_days_ago",
@@ -97,6 +101,34 @@ data_source = "clients_last_seen"
 friendly_name = "Profile Age more than 365 days"
 description = "Time since first-seen more than 365 days"
 select_expression = "COALESCE(LOGICAL_OR(days_since_first_seen > 365), FALSE)"
+data_source = "clients_last_seen"
+
+# ============================================================================
+# SEGMENTS - Operating system (clients_last_seen os field)
+# ============================================================================
+# Windows / macOS / Linux split. OS is not affected by treatment, so analysis-
+# window measurement on the built-in clients_last_seen segment data source is
+# unbiased (same pattern as the profile-age segments above). Enrollment is
+# foreground (fxms-message-4 on nthTabClosed), so every enrolled client is active
+# in-window and has an os value populated. LOWER() guards against casing variants
+# (e.g. Windows_NT / Darwin / Linux).
+
+[segments.os_windows]
+friendly_name = "OS: Windows"
+description = "Clients whose reported OS is Windows"
+select_expression = "COALESCE(LOGICAL_OR(LOWER(os) LIKE '%windows%'), FALSE)"
+data_source = "clients_last_seen"
+
+[segments.os_mac]
+friendly_name = "OS: macOS"
+description = "Clients whose reported OS is macOS (Darwin)"
+select_expression = "COALESCE(LOGICAL_OR(LOWER(os) = 'darwin'), FALSE)"
+data_source = "clients_last_seen"
+
+[segments.os_linux]
+friendly_name = "OS: Linux"
+description = "Clients whose reported OS is Linux"
+select_expression = "COALESCE(LOGICAL_OR(LOWER(os) = 'linux'), FALSE)"
 data_source = "clients_last_seen"
 
 # ============================================================================


### PR DESCRIPTION
Amends the merged Jetstream config for `world-cup-start-of-tournament-privacy-campaign` (added in #1524) to add operating-system segmentation.

## What this adds
- Three new segments — `os_windows`, `os_mac`, `os_linux` — appended to `segments = [...]` and defined as `[segments.X]` blocks.
- Each uses the built-in `clients_last_seen` segment data source (`os` column), analysis-window measurement, matching the existing `profile_age_*` segment pattern. `LOWER(os)` guards casing variants (`Windows_NT` / `Darwin` / `Linux`).

## Why analysis-window (not pre-enrollment)
OS is not treatment-affected, and this is a foreground experiment (`fxms-message-4`), so every enrolled client is active in-window with `os` populated. No pre-enrollment data source is needed (unlike the default-browser segments, which guard against post-treatment bias).

Segments are additive — this does not change the existing "all"-segment or exposure-level results, metrics, or the other 8 segments.

## Experiment context
- Nimbus: https://experimenter.services.mozilla.com/nimbus/world-cup-start-of-tournament-privacy-campaign
- Original config PR: #1524

🤖 Generated via `/create-custom-config`