### PR TITLE
Fix iOS sponsored tiles metrics: event.category 'top_site' -> 'top_sites'

### DIFF
--- a/definitions/firefox_ios.toml
+++ b/definitions/firefox_ios.toml
@@ -242,7 +242,7 @@ owner = "xluo-all@mozilla.com"
 [metrics.spoc_tiles_impressions]
 select_expression = """
       COALESCE(COUNTIF(
-          event.category = 'top_site'
+          event.category = 'top_sites'
           AND event.name = 'contile_impression'
       ),0)
 """
@@ -254,7 +254,7 @@ owner = "xluo-all@mozilla.com"
 [metrics.spoc_tiles_clicks]
 select_expression = """
       COALESCE(COUNTIF(
-          event.category = 'top_site'
+          event.category = 'top_sites'
           AND event.name = 'contile_click'
       ),0)
 """

--- a/jetstream/outcomes/firefox_ios/sponsored_tiles.toml
+++ b/jetstream/outcomes/firefox_ios/sponsored_tiles.toml
@@ -7,7 +7,7 @@ friendly_name = "Sponsored Tiles Impressions"
 description = "Number of times Contile Sponsored Tiles are shown."
 select_expression = """
       COALESCE(COUNTIF(
-          event.category = 'top_site'
+          event.category = 'top_sites'
           AND event.name = 'contile_impression'
       ),0)
 """
@@ -20,7 +20,7 @@ friendly_name = "Sponsored Tiles Clicks"
 description = "Number of times user clicked a Contile Sponsored Tile."
 select_expression = """
       COALESCE(COUNTIF(
-          event.category = 'top_site'
+          event.category = 'top_sites'
           AND event.name = 'contile_click'
       ),0)
 """


### PR DESCRIPTION
## Problem

The Firefox iOS Sponsored Tiles metrics `spoc_tiles_impressions` and `spoc_tiles_clicks` filter on `event.category = 'top_site'` (**singular**). Firefox iOS actually emits these Contile events with category **`top_sites`** (**plural**), so both metrics evaluate to `COUNTIF(...) = 0` for every client in every branch.

This silently returned 0 impressions / 0 clicks on the Sponsored Tiles outcome — e.g. the `default-shortcuts-feature2` experiment showed 0 impressions in **both** control and treatment, which is indistinguishable from "suppression working as intended" and hid the fact that the outcome was measuring nothing.

## Evidence

Reproducible query (STMO / Redash): **https://sql.telemetry.mozilla.org/queries/122875**

It shows, side by side:
- **Section A** — the Jetstream-recorded outcome (`default_shortcuts_feature2` enrollments): `spoc_tiles_impressions` and `spoc_tiles_clicks` are **0 in both branches** (control and treatment-a).
- **Section B** — raw `org_mozilla_ios_firefox.events` for 2025-08-05: Contile events fire with category **`top_sites`** (plural) — `contile_impression` ≈ 12.1M, `contile_click` ≈ 19K — while the singular `top_site` returns nothing for these event names (it only appears for `tile_pressed` / `contextual_menu`).

The Fenix config for the same feature already uses the correct plural `top_sites`.

## Fix

Change `'top_site'` → `'top_sites'` in the two metrics, in both places they are defined:
- `definitions/firefox_ios.toml` (shared metric definitions)
- `jetstream/outcomes/firefox_ios/sponsored_tiles.toml` (outcome)

Intentionally **not** changed:
- `spoc_tiles_preference_toggled` — filters `event.category = 'preferences'` (correct).
- `smart-shortcuts-*.toml` — those use `product_result_type = 'top_site'`, a different column (a urlbar result type), unrelated to Contile.
