### PR TITLE
Switch events_stream data sources to experiments_column_type = "json"

### DIFF
--- a/definitions/fenix.toml
+++ b/definitions/fenix.toml
@@ -616,7 +616,7 @@ from_expression = """(
     WHERE p.event_category in ('customize_home', 'top_sites')
 )"""
 client_id_column = "client_id"
-experiments_column_type = "events_stream"
+experiments_column_type = "json"
 default_dataset = "fenix"
 friendly_name = "Sponsored Tiles Events Stream"
 description = "Sponsored tiles Events pings from events stream"
@@ -632,7 +632,7 @@ from_expression = """(
         `moz-fx-data-shared-prod.{dataset}.events_stream` p
     WHERE event_category IN ('urlbar', 'awesomebar')
 )"""
-experiments_column_type = "events_stream"
+experiments_column_type = "json"
 default_dataset = "org_mozilla_firefox"
 friendly_name = "Awesomebar Events"
 description = "Glean Awesomebar Events Stream"

--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -2293,7 +2293,7 @@ from_expression = """(
     WHERE
         event_category = 'webcompatreporting'
 )"""
-experiments_column_type = "events_stream"
+experiments_column_type = "json"
 friendly_name = "Webcompat reporting tool events"
 description = "Webcompat 'Report Broken Site' pings"
 
@@ -2310,7 +2310,7 @@ from_expression = """(
     WHERE
         event_category = 'security.ui.protectionspopup'
 )"""
-experiments_column_type = "events_stream"
+experiments_column_type = "json"
 friendly_name = "Protections popup events"
 description = "Sheild icon 'Protections Popup' pings"
 


### PR DESCRIPTION
> [!WARNING]
> **Draft — do not merge yet.** Blocked on the full `"json"` type chain landing first:
> 1. metric-config-parser: **#1541** (allowlist + PyPI release)
> 2. mozanalysis: **[mozilla/mozanalysis#542](https://github.com/mozilla/mozanalysis/pull/542)** (SQL guard + release)
> 3. `jetstream` image rebuilt to pick up both, and metric-hub's pinned versions bumped.
>
> Until #1541 is merged into `main`, this PR's `validate-metrics` fails with `experiments_column_type 'json' must be one of ...`.

## What

Switch the four `events_stream` data sources from `experiments_column_type = "events_stream"` to the new `"json"` type:
- **fenix**: `sponsored_tiles_events_stream`, `events_stream_awesomebar`
- **firefox_desktop**: `protections_popup_events`, `site_breakage_events`

## Why

The `"events_stream"` type reads experiment/branch from each event's own `event_extra` JSON, which is only populated on **nimbus** event rows. So its day-0 "ignore pre-enrollment data" guard drops **all** enrollment-day metric events (generic events like `contile_impression` carry no `$.experiment`). For first-run experiments this undercounts exposure/engagement badly — observed **16.2% vs 56.4%** ground-truth control exposure on a Fenix sponsored-tiles experiment.

The new `"json"` type reads the client-level `experiments` JSON map, which every `events_stream` row carries, so enrollment-day events are attributed correctly. All four data sources already project the `experiments` column.

## Prerequisites / sequencing
1. Merge metric-config-parser **#1541** (publishes the parser that accepts `"json"`).
2. Merge/release mozanalysis **#542** (generates the `"json"` guard SQL).
3. Rebuild the `jetstream` image and bump metric-hub's pinned mozanalysis/metric-config-parser versions.
4. Rebase this PR — `validate-metrics` passes once `main`'s `lib/metric-config-parser` knows `"json"` — and merge.
5. Re-analyze affected experiments (their events_stream exposure/engagement metrics were undercounted).

## ⚠️ Testing & coverage gap

The new `"json"` day-0 guard is **not** exercised against the real schema by this PR's CI:

- `validate-metrics` (which this PR triggers) dry-runs only each metric's `select_expression` + `from_expression` (see `.script/templates/validation_query.sql`); it does **not** include the mozanalysis `experiments_column_type` day-0 guard, so a broken guard would pass here.
- `validate-jetstream` — the job that *does* build the full analysis SQL via mozanalysis `build_query` (guard included) and dry-runs it — only fires on `jetstream/**` changes, so it does **not** run on this definitions-only PR.
- mozanalysis has no dry-run/integration test layer (its query tests are string comparisons), so mozanalysis#542 doesn't cover it either.

Real-schema coverage of the guard therefore only occurs once the `jetstream` image ships the mozanalysis version with `"json"` **and** a `jetstream/**` config using one of these data sources is validated/re-run.

**Manual verification in the meantime:** the exact generated guard SQL was dry-run against the real `fenix.events_stream` and validated successfully, and `JSON_VALUE(ds.experiments, '$."<slug>".branch')` was executed against it directly (returned the branch on 2,184,022 / 2,187,667 enrollment-day rows). So the guard is schema-valid and correct; it's simply not covered by an automated check yet.
