### PR TITLE
metric-config-parser: allow experiments_column_type "json"

### DIFF
--- a/lib/metric-config-parser/metric_config_parser/data_source.py
+++ b/lib/metric-config-parser/metric_config_parser/data_source.py
@@ -72,6 +72,12 @@ class DataSource:
               string.
             * 'events_stream': There is an ``experiment`` within a JSON
               column ``event_extra``. ``branch`` is in the same column.
+            * 'json': There is a top-level ``experiments`` column of
+              BigQuery ``JSON`` type, which is an (experiment_slug:str ->
+              struct) map with a ``branch`` field. This is the client-level
+              experiments map carried on every row of ``*.events_stream``
+              tables; unlike 'events_stream' it attributes metric events on
+              the enrollment day.
             * None: There is no ``experiments`` column, so skip the
               sanity checks that rely on it. We'll also be unable to
               filter out pre-enrollment data from day 0 in the
@@ -124,7 +130,14 @@ class DataSource:
     glean_client_id_column = attr.ib(default=None, type=str)
     legacy_client_id_column = attr.ib(default=None, type=str)
 
-    EXPERIMENT_COLUMN_TYPES = (None, "simple", "native", "glean", "events_stream")
+    EXPERIMENT_COLUMN_TYPES = (
+        None,
+        "simple",
+        "native",
+        "glean",
+        "events_stream",
+        "json",
+    )
 
     @experiments_column_type.validator
     def _check_experiments_column_type(self, attribute, value):

--- a/lib/metric-config-parser/metric_config_parser/tests/test_analysis.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_analysis.py
@@ -922,3 +922,22 @@ class TestAnalysisSpec:
             ValueError, match=r"data_source eggs \(app: firefox_desktop\) does not support"
         ):
             spec.resolve(experiments[0], config_collection)
+
+
+def test_datasource_accepts_json_experiments_column_type():
+    # "json" is valid: a top-level JSON experiments map (e.g. events_stream tables)
+    ds = DataSource(
+        name="foo",
+        from_expression="(SELECT 1)",
+        experiments_column_type="json",
+    )
+    assert ds.experiments_column_type == "json"
+
+
+def test_datasource_rejects_unknown_experiments_column_type():
+    with pytest.raises(ValueError, match="must be one of"):
+        DataSource(
+            name="foo",
+            from_expression="(SELECT 1)",
+            experiments_column_type="not_a_real_type",
+        )

--- a/lib/metric-config-parser/pyproject.toml
+++ b/lib/metric-config-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-metric-config-parser"
-version = "2026.6.1"
+version = "2026.7.0"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Parses metric configuration files."
 readme = "README.md"


### PR DESCRIPTION
Adds `"json"` to metric-config-parser's `DataSource.EXPERIMENT_COLUMN_TYPES` (the config-validation allowlist), so metric-hub configs can set `experiments_column_type = "json"` for data sources whose `experiments` column is a top-level BigQuery `JSON` map (e.g. `*.events_stream` tables).

## Why
The existing `"events_stream"` type gates enrollment-day events on per-event `event_extra`, which only nimbus event rows carry — so it drops **all** enrollment-day metric events for events_stream sources (observed: control exposure read **16.2%** vs **56.4%** ground truth on a Fenix sponsored-tiles experiment). The new `"json"` type reads the client-level `experiments` map instead.

This is the **config-parser half** of the fix. The SQL-generation half is [mozilla/mozanalysis#542](https://github.com/mozilla/mozanalysis/pull/542) — metric-config-parser only validates/parses the type; mozanalysis builds the day-0 attribution guard from the client-level map.

## Changes
- add `"json"` to `EXPERIMENT_COLUMN_TYPES` + docstring
- tests: accepts `"json"`, rejects unknown types
- bump version `2026.6.1` → `2026.7.0` to publish the parser to PyPI on merge

## Sequencing
Prerequisite for the metric-hub data-source switch ([#1540](https://github.com/mozilla/metric-hub/pull/1540)) and for the `jetstream` image (which needs both this parser release and the mozanalysis release) to accept/generate the `"json"` type.
