### PR TITLE
Fix missing 'autofill' product_result_type in adaptive-autofill-revam…

### DIFF
--- a/jetstream/adaptive-autofill-revamp.toml
+++ b/jetstream/adaptive-autofill-revamp.toml
@@ -75,7 +75,7 @@ from_expression = """(
          SUM(urlbar_clicks) AS urlbar_clicks
          
   FROM `mozdata.firefox_desktop.urlbar_events_daily_engagement_by_product_result_type`
-  WHERE product_result_type IN ('about_autofill', 'adaptive_autofill')
+  WHERE product_result_type IN ('about_autofill', 'autofill', 'adaptive_autofill')
   GROUP BY ALL
 )"""
 experiments_column_type = "none"


### PR DESCRIPTION
…p.toml

The urlbar_product_autofill data source only filtered on 'about_autofill' and 'adaptive_autofill', excluding the plain 'autofill' product result type. This caused autofill impression/click metrics to undercount, making the branches not comparable.