### PR TITLE
feat: ability to specify experiment params in DS from_expression

### DIFF
--- a/lib/metric-config-parser/README.md
+++ b/lib/metric-config-parser/README.md
@@ -6,6 +6,30 @@ This package parses configuration files that are compatible with [jetstream](htt
 
 `pip install mozilla-metric-config-parser`
 
+## Templating in `from_expression`
+
+A data source's `from_expression` supports two independent templating layers:
+
+* `{dataset}` (single braces, Python `str.format`) is replaced with an app-specific dataset
+  for Glean apps. If used, `default_dataset` is mandatory.
+* `{{experiment.<attr>}}` (double braces, Jinja) is replaced with an attribute of the
+  experiment the data source is being resolved for, e.g. `{{experiment.normandy_slug}}`,
+  `{{experiment.start_date_str}}`, `{{experiment.end_date_str}}`,
+  `{{experiment.last_enrollment_date_str}}`. This is only rendered when the expression
+  actually references `experiment`, and is only available when resolving a data source for
+  an experiment.
+
+```toml
+[data_sources.messaging_events]
+from_expression = """(
+    SELECT *
+    FROM `moz-fx-data-shared-prod.fenix.events_stream`
+    WHERE STARTS_WITH(extras.string.message_key, '{{experiment.normandy_slug}}:')
+)"""
+experiments_column_type = "none"
+```
+
+A literal brace can still be written by doubling it, e.g. `'{{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}}'`.
 
 ## Testing
 

--- a/lib/metric-config-parser/metric_config_parser/data_source.py
+++ b/lib/metric-config-parser/metric_config_parser/data_source.py
@@ -1,9 +1,13 @@
 import fnmatch
+import logging
 import re
 from enum import Enum
+from string import Formatter
 from typing import TYPE_CHECKING, Any, Union
 
 import attr
+import jinja2
+from jinja2 import StrictUndefined, meta
 
 from metric_config_parser.errors import DefinitionNotFound
 
@@ -17,6 +21,69 @@ if TYPE_CHECKING:
 
 from . import AnalysisUnit
 from .util import converter, is_valid_slug
+
+logger = logging.getLogger(__name__)
+
+EXPERIMENT_TEMPLATE_VAR = "experiment"
+
+
+def render_from_expression(name: str, from_expression: str, experiment: Any | None) -> str:
+    """Render Jinja templating in a data source ``from_expression``.
+
+    ``from_expression`` carries two independent templating layers:
+
+    * ``{dataset}`` (single braces), substituted later by
+      :meth:`DataSource.from_expr_for` using Python ``str.format``.
+    * ``{{experiment.<attr>}}`` (Jinja), substituted here against the experiment
+      the configuration is being resolved for.
+
+    Because ``str.format`` also treats ``{{`` as the escape for a literal ``{``,
+    Jinja rendering is deliberately narrow: the expression is rendered *only* if it
+    references the ``experiment`` variable. Expressions that merely contain ``{{`` --
+    e.g. a literal add-on GUID written as
+    ``'{{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}}'`` -- keep their existing
+    ``str.format`` brace-escaping behaviour. (``SegmentDataSourceDefinition.resolve``
+    renders unconditionally; segment ``from_expression`` has been Jinja since day one,
+    so no brace-escaped content exists there. Do not "unify" the two.)
+
+    Never mutates its inputs: definitions are shared across every experiment resolved
+    from a ConfigCollection.
+    """
+    if not from_expression or "{{" not in from_expression:
+        return from_expression
+
+    env = jinja2.Environment(autoescape=False, undefined=StrictUndefined)
+    try:
+        ast = env.parse(from_expression)
+    except jinja2.TemplateSyntaxError:
+        # Not a Jinja template; `{{` is being used to escape a literal brace
+        # for `str.format`. Leave it untouched.
+        return from_expression
+
+    referenced = meta.find_undeclared_variables(ast)
+    if EXPERIMENT_TEMPLATE_VAR not in referenced:
+        if referenced:
+            logger.warning(
+                "%s: from_expression contains placeholder(s) %s that will not be "
+                "substituted and will be emitted as literal braces. To reference the "
+                "experiment, use {{experiment.normandy_slug}}.",
+                name,
+                sorted(referenced),
+            )
+        return from_expression
+
+    if experiment is None:
+        raise ValueError(
+            f"{name}: from_expression references `experiment`, but no experiment is "
+            "available in this context. Experiment templating is only supported when "
+            "resolving a data source for an experiment (Jetstream); it is not available "
+            "for OpMon projects or for standalone SQL/docs generation."
+        )
+
+    try:
+        return env.from_string(ast).render(**{EXPERIMENT_TEMPLATE_VAR: experiment})
+    except jinja2.TemplateError as e:
+        raise ValueError(f"{name}: could not render from_expression template: {e}") from e
 
 
 class DataSourceJoinRelationship(Enum):
@@ -54,10 +121,20 @@ class DataSource:
         name (str): Name for the Data Source. Used in sanity metric
             column names.
         from_expression (str): FROM expression - often just a fully-qualified
-            table name. Sometimes a subquery. May contain the string
-            ``{dataset}`` which will be replaced with an app-specific
-            dataset for Glean apps. If the expression is templated
-            on dataset, default_dataset is mandatory.
+            table name. Sometimes a subquery. Supports two independent
+            templating layers:
+            * ``{dataset}`` (single braces, Python ``str.format``), replaced
+              with an app-specific dataset for Glean apps. If the expression
+              is templated on dataset, default_dataset is mandatory.
+            * ``{{experiment.<attr>}}`` (double braces, Jinja), replaced with
+              an attribute of the experiment the data source is being
+              resolved for, e.g. ``{{experiment.normandy_slug}}``,
+              ``{{experiment.start_date_str}}``, ``{{experiment.end_date_str}}``,
+              ``{{experiment.last_enrollment_date_str}}``. Only rendered when
+              the expression actually references ``experiment``; a literal
+              brace can still be written by doubling it, e.g.
+              ``'{{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}}'``. Not available
+              when resolving a data source outside of an experiment context.
         experiments_column_type (str or None): Info about the schema
             of the table or view:
             * 'simple': There is an ``experiments`` column, which is an
@@ -110,6 +187,13 @@ class DataSource:
 
     name = attr.ib(validator=attr.validators.instance_of(str))
     from_expression = attr.ib(validator=attr.validators.instance_of(str))
+
+    @from_expression.validator
+    def _check_no_unrendered_experiment_template(self, attribute, value):
+        # Guards against an unrendered template reaching mozanalysis via a code path
+        # that skipped DataSourceDefinition.resolve().
+        render_from_expression(self.name, value, None)
+
     experiments_column_type = attr.ib(default="simple", type=str)
     client_id_column = attr.ib(default=AnalysisUnit.CLIENT.value, type=str)
     submission_date_column = attr.ib(default="submission_date", type=str)
@@ -140,20 +224,44 @@ class DataSource:
 
     def from_expr_for(self, dataset: str | None) -> str:
         """Expands the ``from_expression`` template for the given dataset.
+
+        Only ``{dataset}`` is substituted here. ``{{experiment.*}}`` Jinja
+        templating is resolved earlier, in ``DataSourceDefinition.resolve()``.
         If ``from_expression`` is not a template, returns ``from_expression``.
         Args:
             dataset (str or None): Dataset name to substitute
                 into the from expression.
         """
         effective_dataset = dataset or self.default_dataset
-        if effective_dataset is None:
-            try:
+        try:
+            if effective_dataset is None:
                 return self.from_expression.format()
-            except Exception as e:
-                raise ValueError(
-                    f"{self.name}: from_expression contains a dataset template but no value was provided."  # noqa:E501
-                ) from e
-        return self.from_expression.format(dataset=effective_dataset)
+            return self.from_expression.format(dataset=effective_dataset)
+        except Exception as e:
+            raise ValueError(self._from_expr_error()) from e
+
+    def _from_expr_error(self) -> str:
+        try:
+            unsupported = sorted(
+                {
+                    field
+                    for _, field, _, _ in Formatter().parse(self.from_expression)
+                    if field is not None and field != "dataset"
+                }
+            )
+        except Exception:
+            unsupported = []
+        if unsupported:
+            return (
+                f"{self.name}: from_expression contains unsupported placeholder(s) "
+                f"{unsupported}. Only `{{dataset}}` is substituted here. To reference "
+                "the experiment use Jinja syntax, e.g. `{{experiment.normandy_slug}}`; "
+                "to emit a literal brace, double it."
+            )
+        return (
+            f"{self.name}: from_expression contains a `{{dataset}}` template but no "
+            "value was provided and `default_dataset` is not set."
+        )
 
 
 @attr.s(auto_attribs=True)
@@ -232,9 +340,17 @@ class DataSourceDefinition:
         if app_name == "firefox_desktop":
             default_analysis_units.append(AnalysisUnit.PROFILE_GROUP)
 
+        # Jinja templating in `from_expression` is resolved per-experiment. Note we must
+        # not write back to `self.from_expression`: definitions are shared across all
+        # experiments resolved from a ConfigCollection.
+        experiment_context = conf if getattr(conf, "experiment", None) is not None else None
+        from_expression = self.from_expression
+        if from_expression is not None:
+            from_expression = render_from_expression(self.name, from_expression, experiment_context)
+
         params: dict[str, Any] = {
             "name": self.name,
-            "from_expression": self.from_expression,
+            "from_expression": from_expression,
         }
         # Allow mozanalysis to infer defaults for these values:
         for k in (

--- a/lib/metric-config-parser/metric_config_parser/tests/test_analysis.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_analysis.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from textwrap import dedent
 
+import attr
 import pytest
 import toml
 from cattrs.errors import ClassValidationError
@@ -132,6 +133,248 @@ class TestAnalysisSpec:
         assert "client_info" in spam.data_source.client_id_column
         assert spam.data_source.experiments_column_type == "simple"
         assert taunts.data_source.experiments_column_type is None
+
+    def test_data_source_from_expression_experiment_templating(
+        self, experiments, config_collection
+    ):
+        config_str = dedent(
+            """
+            [metrics]
+            weekly = ["spam"]
+            [metrics.spam]
+            data_source = "messaging_events"
+            select_expression = "1"
+            [metrics.spam.statistics.bootstrap_mean]
+
+            [data_sources.messaging_events]
+            from_expression = \"\"\"(
+                SELECT *
+                FROM mozdata.telemetry.messaging
+                WHERE STARTS_WITH(message_key, '{{experiment.normandy_slug}}:')
+            )\"\"\"
+            experiments_column_type = "none"
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(config_str))
+        cfg = spec.resolve(experiments[0], config_collection)
+        spam = next(m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam").metric
+
+        from_expression = spam.data_source.from_expression
+        assert "{{" not in from_expression
+        assert "{experiment" not in from_expression
+        assert "normandy-test-slug:" in from_expression
+
+    def test_data_source_from_expression_experiment_date_helpers(
+        self, experiments, config_collection
+    ):
+        config_str = dedent(
+            """
+            [metrics]
+            weekly = ["spam"]
+            [metrics.spam]
+            data_source = "messaging_events"
+            select_expression = "1"
+            [metrics.spam.statistics.bootstrap_mean]
+
+            [data_sources.messaging_events]
+            from_expression = "(SELECT 1 WHERE submission_date BETWEEN {{experiment.start_date_str}} AND {{experiment.last_enrollment_date_str}})"
+            experiments_column_type = "none"
+            """  # noqa:E501
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(config_str))
+        cfg = spec.resolve(experiments[0], config_collection)
+        spam = next(m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam").metric
+
+        from_expression = spam.data_source.from_expression
+        assert "{{" not in from_expression
+        assert "2019-12-01" in from_expression
+
+    def test_data_source_from_expression_dataset_and_experiment(
+        self, experiments, config_collection
+    ):
+        config_str = dedent(
+            """
+            [metrics]
+            weekly = ["spam"]
+            [metrics.spam]
+            data_source = "messaging_events"
+            select_expression = "1"
+            [metrics.spam.statistics.bootstrap_mean]
+
+            [data_sources.messaging_events]
+            from_expression = "mozdata.{dataset}.events WHERE e = '{{experiment.normandy_slug}}'"
+            default_dataset = "telemetry"
+            experiments_column_type = "none"
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(config_str))
+        cfg = spec.resolve(experiments[0], config_collection)
+        spam = next(m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam").metric
+
+        data_source = spam.data_source
+        assert "{dataset}" in data_source.from_expression
+        assert "normandy-test-slug" in data_source.from_expression
+        assert (
+            data_source.from_expr_for(None)
+            == "mozdata.telemetry.events WHERE e = 'normandy-test-slug'"
+        )
+
+    def test_data_source_from_expression_literal_braces_preserved(
+        self, experiments, config_collection
+    ):
+        config_str = dedent(
+            """
+            [metrics]
+            weekly = ["spam"]
+            [metrics.spam]
+            data_source = "search_and_addons"
+            select_expression = "1"
+            [metrics.spam.statistics.bootstrap_mean]
+
+            [data_sources.search_and_addons]
+            from_expression = "(SELECT '{{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}}')"
+            experiments_column_type = "none"
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(config_str))
+        cfg = spec.resolve(experiments[0], config_collection)
+        spam = next(m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam").metric
+
+        data_source = spam.data_source
+        assert data_source.from_expression == "(SELECT '{{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}}')"
+        rendered = data_source.from_expr_for(None)
+        assert rendered == "(SELECT '{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}')"
+
+    def test_data_source_from_expression_unknown_variable_raises(
+        self, experiments, config_collection
+    ):
+        config_str = dedent(
+            """
+            [metrics]
+            weekly = ["spam"]
+            [metrics.spam]
+            data_source = "messaging_events"
+            select_expression = "1"
+            [metrics.spam.statistics.bootstrap_mean]
+
+            [data_sources.messaging_events]
+            from_expression = "(SELECT '{{experiment.normandy_slug}}' WHERE x = '{{nope}}')"
+            experiments_column_type = "none"
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(config_str))
+        with pytest.raises(ValueError, match="nope"):
+            spec.resolve(experiments[0], config_collection)
+
+    def test_data_source_from_expression_unknown_variable_only_warns(
+        self, experiments, config_collection, caplog
+    ):
+        config_str = dedent(
+            """
+            [metrics]
+            weekly = ["spam"]
+            [metrics.spam]
+            data_source = "messaging_events"
+            select_expression = "1"
+            [metrics.spam.statistics.bootstrap_mean]
+
+            [data_sources.messaging_events]
+            from_expression = "(SELECT '{{slug}}')"
+            experiments_column_type = "none"
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(config_str))
+        cfg = spec.resolve(experiments[0], config_collection)
+        spam = next(m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam").metric
+
+        assert spam.data_source.from_expression == "(SELECT '{{slug}}')"
+        assert any("slug" in record.message for record in caplog.records)
+
+    def test_data_source_from_expression_in_join(self, experiments, config_collection):
+        config_str = dedent(
+            """
+            [metrics]
+            weekly = ["spam"]
+            [metrics.spam]
+            data_source = "baseline"
+            select_expression = "1"
+            [metrics.spam.statistics.bootstrap_mean]
+
+            [data_sources.baseline]
+            from_expression = "mozdata.telemetry.baseline"
+            experiments_column_type = "none"
+
+            [data_sources.messaging_events]
+            from_expression = "(SELECT '{{experiment.normandy_slug}}')"
+            experiments_column_type = "none"
+
+            [data_sources.baseline.joins.messaging_events]
+            on_expression = "messaging_events.client_id = baseline.client_id"
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(config_str))
+        cfg = spec.resolve(experiments[0], config_collection)
+        spam = next(m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam").metric
+
+        joined = spam.data_source.joins[0].data_source
+        assert joined.name == "messaging_events"
+        assert "normandy-test-slug" in joined.from_expression
+
+    def test_data_source_definition_not_mutated_by_resolve(self, experiments, config_collection):
+        config_str = dedent(
+            """
+            [metrics]
+            weekly = ["spam"]
+            [metrics.spam]
+            data_source = "messaging_events"
+            select_expression = "1"
+            [metrics.spam.statistics.bootstrap_mean]
+
+            [data_sources.messaging_events]
+            from_expression = "(SELECT '{{experiment.normandy_slug}}')"
+            experiments_column_type = "none"
+            """
+        )
+        other_experiment = attr.evolve(experiments[0], normandy_slug="other-slug")
+
+        spec_a = AnalysisSpec.from_dict(toml.loads(config_str))
+        cfg_a = spec_a.resolve(experiments[0], config_collection)
+        spam_a = next(
+            m for m in cfg_a.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam"
+        ).metric
+        assert "normandy-test-slug" in spam_a.data_source.from_expression
+
+        spec_b = AnalysisSpec.from_dict(toml.loads(config_str))
+        # The unresolved definition still carries the raw Jinja template.
+        assert "{{" in spec_b.data_sources.definitions["messaging_events"].from_expression
+        cfg_b = spec_b.resolve(other_experiment, config_collection)
+        spam_b = next(
+            m for m in cfg_b.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam"
+        ).metric
+        assert "other-slug" in spam_b.data_source.from_expression
+        assert "normandy-test-slug" not in spam_b.data_source.from_expression
+
+    def test_exposure_signal_data_source_from_expression(self, experiments, config_collection):
+        config_str = dedent(
+            """
+            [experiment.exposure_signal]
+            name = "spotlight_exposure"
+            data_source = "messaging_events"
+            select_expression = "1"
+            friendly_name = "Spotlight Exposure"
+            description = "Spotlight exposure"
+            window_start = 0
+            window_end = 7
+
+            [data_sources.messaging_events]
+            from_expression = "(SELECT '{{experiment.normandy_slug}}')"
+            experiments_column_type = "none"
+            """
+        )
+        spec = AnalysisSpec.from_dict(toml.loads(config_str))
+        cfg = spec.resolve(experiments[0], config_collection)
+
+        assert "normandy-test-slug" in cfg.experiment.exposure_signal.data_source.from_expression
 
     def test_definitions_override_other_metrics(self, experiments, config_collection):
         """Test that config definitions override mozanalysis definitions.

--- a/lib/metric-config-parser/metric_config_parser/tests/test_data_source.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_data_source.py
@@ -1,0 +1,67 @@
+import pytest
+
+from metric_config_parser.data_source import DataSource, render_from_expression
+
+
+class FakeExperiment:
+    normandy_slug = "my-slug"
+
+
+class TestRenderFromExpression:
+    def test_no_braces_is_identity(self):
+        expr = "mozdata.telemetry.events"
+        assert render_from_expression("t", expr, None) == expr
+
+    def test_syntax_error_is_identity(self):
+        # `{{` used as a str.format literal-brace escape, e.g. an add-on GUID.
+        expr = "(SELECT '{{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}}')"
+        assert render_from_expression("t", expr, None) == expr
+
+    def test_no_variables_is_identity(self):
+        expr = r"REGEXP_CONTAINS(x, r'\d{{4}}')"
+        assert render_from_expression("t", expr, None) == expr
+
+    def test_renders_experiment_reference(self):
+        expr = "(SELECT '{{experiment.normandy_slug}}')"
+        assert render_from_expression("t", expr, FakeExperiment()) == "(SELECT 'my-slug')"
+
+    def test_without_experiment_raises(self):
+        expr = "(SELECT '{{experiment.normandy_slug}}')"
+        with pytest.raises(ValueError, match="no experiment is available"):
+            render_from_expression("t", expr, None)
+
+    def test_unrelated_placeholder_is_left_unrendered(self):
+        expr = "(SELECT '{{slug}}')"
+        assert render_from_expression("t", expr, None) == expr
+
+    def test_unknown_variable_alongside_experiment_raises(self):
+        expr = "(SELECT '{{experiment.normandy_slug}}' WHERE x = '{{nope}}')"
+        with pytest.raises(ValueError, match="nope"):
+            render_from_expression("t", expr, FakeExperiment())
+
+
+class TestDataSource:
+    def test_rejects_unrendered_experiment_template(self):
+        with pytest.raises(ValueError, match="no experiment is available"):
+            DataSource(name="x", from_expression="a {{experiment.normandy_slug}} b")
+
+    def test_from_expr_for_unsupported_placeholder_message(self):
+        with pytest.raises(ValueError, match="unsupported placeholder"):
+            DataSource(name="x", from_expression="a {experiment.normandy_slug} b")
+
+    def test_from_expr_for_missing_default_dataset_message(self):
+        with pytest.raises(ValueError, match="default_dataset"):
+            DataSource(name="x", from_expression="mozdata.{dataset}.x")
+
+    def test_from_expr_for_with_dataset(self):
+        ds = DataSource(
+            name="x", from_expression="mozdata.{dataset}.x", default_dataset="telemetry"
+        )
+        assert ds.from_expr_for(None) == "mozdata.telemetry.x"
+        assert ds.from_expr_for("other") == "mozdata.other.x"
+
+    def test_from_expr_for_literal_braces(self):
+        ds = DataSource(
+            name="x", from_expression="(SELECT '{{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}}')"
+        )
+        assert ds.from_expr_for(None) == "(SELECT '{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}')"

--- a/lib/metric-config-parser/metric_config_parser/tests/test_monitoring.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_monitoring.py
@@ -102,6 +102,28 @@ class TestMonitoringSpec:
         assert test2.metric.data_source.name == "silly_knight"
         assert "france" in test2.metric.data_source.from_expression
 
+    def test_data_source_experiment_template_not_supported(self, config_collection):
+        config_str = dedent(
+            """
+            [project]
+            metrics = ["test"]
+
+            [metrics]
+            [metrics.test]
+            select_expression = "SELECT 1"
+            data_source = "eggs"
+
+            [metrics.test.statistics]
+            sum = {}
+
+            [data_sources.eggs]
+            from_expression = "(SELECT '{{experiment.normandy_slug}}')"
+            """
+        )
+        spec = MonitoringSpec.from_dict(toml.loads(config_str))
+        with pytest.raises(ValueError, match="no experiment is available"):
+            spec.resolve(experiment=None, configs=config_collection)
+
     def test_merge(self, config_collection):
         """Test merging configs"""
         config_str = dedent(

--- a/lib/metric-config-parser/pyproject.toml
+++ b/lib/metric-config-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-metric-config-parser"
-version = "2026.6.1"
+version = "2026.7.1"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Parses metric configuration files."
 readme = "README.md"


### PR DESCRIPTION
implements feature requested in https://github.com/mozilla/jetstream/issues/3293, giving the ability to include experiment parameters in a data source `from_expression` query template, using `{{experiment.attribute}}`.