### PR TITLE
Add Jetstream config for addons-video-extensions-promo-v2

### DIFF
--- a/jetstream/addons-video-extensions-promo-v2.toml
+++ b/jetstream/addons-video-extensions-promo-v2.toml
@@ -1,0 +1,74 @@
+[experiment]
+
+# Add-on resonance discovery — Video Streaming (FXE-1763). Feature: fxms-message-23.
+# Branches: control, treatment-a (Enhancer for YouTube), treatment-b (Turn Off the Lights).
+# SponsorBlock did not launch (Legal pause) — no treatment-c.
+#
+# WHAT THIS CONFIG CAPTURES: per-arm add-on ADOPTION/KEEP proxy = "was the promoted
+# extension enabled on >=1 day in the analysis window," from clients_daily.active_addons,
+# on BOTH enrollments + exposures bases. Because these are one-click callouts, exposure
+# ~= install time, so exposures-basis weekly windows approximate post-install keep
+# (week 2 ~= still enabled ~7-14d after install). Read each metric on its matching
+# treatment arm; the exposures basis gives the clean treatment-vs-treatment resonance
+# ranking (control emits no native exposure event, so treatment-vs-control lives on the
+# enrollments basis).
+#
+# NOT HERE — handled in Redash, not Jetstream:
+#   - Keep-rate CONDITIONAL ON INSTALL (installer denominator + install-anchored window)
+#   - Message funnel: impression rate, CTR, install-rate-per-impression (control has no
+#     message; within-treatment funnel on fxms messaging telemetry)
+#   - Prior add-on ownership by category, and frecency-depth (frecency is local-only)
+# Guardrails DAU / search / ad_clicks / retention / uri_count are AUTO-APPLIED -> omitted.
+
+segments = [
+    "activity_infrequent",
+    "activity_casual",
+    "activity_regular",
+    "activity_core",
+    "profile_age_7_to_28_days",
+    "profile_age_more_than_28_days",
+    "default_browser",
+    "not_default_browser",
+]
+
+[metrics]
+weekly = ["enhancer_for_youtube_enabled", "turn_off_the_lights_enabled"]
+overall = ["enhancer_for_youtube_enabled", "turn_off_the_lights_enabled"]
+
+[metrics.enhancer_for_youtube_enabled]
+data_source = "clients_daily"
+select_expression = "COALESCE(LOGICAL_OR(EXISTS(SELECT 1 FROM UNNEST(active_addons) AS a WHERE a.addon_id = 'enhancerforyoutube@maximerf.addons.mozilla.org')), FALSE)"
+friendly_name = "Enhancer for YouTube enabled (Treatment A)"
+description = "Client had Enhancer for YouTube (enhancerforyoutube@maximerf.addons.mozilla.org) enabled on at least one day in the analysis window. Adoption/keep proxy; read on treatment-a."
+analysis_bases = ["enrollments", "exposures"]
+
+[metrics.enhancer_for_youtube_enabled.statistics.binomial]
+
+[metrics.turn_off_the_lights_enabled]
+data_source = "clients_daily"
+select_expression = "COALESCE(LOGICAL_OR(EXISTS(SELECT 1 FROM UNNEST(active_addons) AS a WHERE a.addon_id = 'stefanvandamme@stefanvd.net')), FALSE)"
+friendly_name = "Turn Off the Lights enabled (Treatment B)"
+description = "Client had Turn Off the Lights (stefanvandamme@stefanvd.net) enabled on at least one day in the analysis window. Adoption/keep proxy; read on treatment-b."
+analysis_bases = ["enrollments", "exposures"]
+
+[metrics.turn_off_the_lights_enabled.statistics.binomial]
+
+# Segments — engagement level (built-in activity_*) and profile age at enrollment
+# (built-in; the >=14d targeting gate means profile_age_7_to_28_days reads as 14-28d).
+# Default-browser status is a custom cut (copied verbatim from vpn-hnt-promo).
+
+[segments.default_browser]
+friendly_name = "Is default browser"
+description = "Clients for whom Firefox is the default browser at enrollment."
+select_expression = "COALESCE(LOGICAL_OR(is_default_browser), FALSE)"
+data_source = "clients_last_seen"
+window_start = -3
+window_end = "analysis_window_end"
+
+[segments.not_default_browser]
+friendly_name = "Is not default browser"
+description = "Clients for whom Firefox is NOT the default browser at enrollment."
+select_expression = "COALESCE(LOGICAL_OR(NOT is_default_browser), FALSE)"
+data_source = "clients_last_seen"
+window_start = -3
+window_end = "analysis_window_end"


### PR DESCRIPTION
Adds a custom Jetstream config for the `addons-video-extensions-promo-v2` experiment (FXE-1763).

## What this adds
- 2 custom binomial metrics on `clients_daily.active_addons` — per-arm add-on adoption/keep proxy (`enhancer_for_youtube_enabled`, `turn_off_the_lights_enabled`), on both enrollments + exposures bases.
- Segments: built-in engagement (`activity_*`), built-in profile age (`profile_age_7_to_28_days`, `_more_than_28_days`), custom default-browser cut.
- Auto-applied guardrails omitted. Keep-rate-conditional-on-install and message-funnel CTR live in Redash (control has no message). SponsorBlock arm did not launch (Legal pause).

## Experiment context
- Nimbus: https://experimenter.services.mozilla.com/nimbus/addons-video-extensions-promo-v2

🤖 Generated via /create-custom-config