### PR TITLE
Add Jetstream config for semantic-history-search-v3

### DIFF
--- a/jetstream/semantic-history-search-v3.toml
+++ b/jetstream/semantic-history-search-v3.toml
@@ -1,0 +1,326 @@
+# Semantic History Search v3
+#
+# Custom "history success rate" measurement requested by the experiment owner:
+# https://docs.google.com/document/d/1kLwVmOGud7_lDkgDv_cJ7qjzd1ldfePmGH4JImEmQMc/
+#
+# The metric: of all urlbar sessions where the user typed at least N characters,
+# what share end with a click on a browsing-history result (as opposed to a search
+# result, an ad, or abandonment)? Tab results are deliberately excluded (semantic
+# matching applies there too, but volume is too low to be informative).
+#
+# The character floor matters. Short prefixes are dominated by the adaptive cache,
+# which is high-volume, high-success, and unaffected by the experiment. N = 8 is the
+# primary cut because it is the only apples-to-apples comparison: the fuzzier branch
+# sets suggestSemanticHistoryMinLength = 8, so below 8 characters its treatment is
+# inert and it would be diluted toward control. N = 5 is reported as a secondary cut
+# because that is the default branch's own floor.
+#
+# Three aggregations are reported for each cut, per the doc:
+#   global    session-weighted; every session counts equally. Heavy users dominate,
+#             and the owner reports this fails to replicate across random halves.
+#   per_user  every user weighted equally. Reproducible, but answers "the typical
+#             user's rate" rather than "the rate across traffic".
+#   capped    session-weighted with each user's weight capped at the 95th percentile
+#             of per-user session counts. The owner's preferred estimator.
+
+[experiment]
+# Randomization unit is group_id (bucketConfig.randomizationUnit), so profile_group_id
+# is the primary analysis unit; client_id is carried along for comparison.
+enrollment_period = 7
+
+[experiment.exposure_signal]
+name = "typed_urlbar_session"
+friendly_name = "Typed a qualifying urlbar session"
+description = "Had at least one terminal, typed urlbar session with 5+ characters, i.e. was in a position for semantic history matching to matter"
+select_expression = "num_chars_typed >= 5"
+data_source = "urlbar_terminal_typed_sessions"
+window_start = "enrollment_start"
+window_end = "analysis_window_end"
+
+[metrics]
+weekly = [
+  "urlbar_typed_sessions_8",
+  "urlbar_history_clicks_8",
+  "history_success_rate_global_8",
+  "history_success_rate_per_user_8",
+  "history_success_rate_capped_8_weekly",
+  "urlbar_typed_sessions_5",
+  "urlbar_history_clicks_5",
+  "history_success_rate_global_5",
+  "history_success_rate_per_user_5",
+  "history_success_rate_capped_5_weekly",
+]
+overall = [
+  "urlbar_typed_sessions_8",
+  "urlbar_history_clicks_8",
+  "history_success_rate_global_8",
+  "history_success_rate_per_user_8",
+  "history_success_rate_capped_8_overall",
+  "urlbar_typed_sessions_5",
+  "urlbar_history_clicks_5",
+  "history_success_rate_global_5",
+  "history_success_rate_per_user_5",
+  "history_success_rate_capped_5_overall",
+]
+
+
+########################################################################
+## Primary cut: 8+ characters typed
+########################################################################
+
+## --- Base counts -----------------------------------------------------
+
+[metrics.urlbar_typed_sessions_8]
+friendly_name = "Qualifying urlbar sessions (8+ chars)"
+description = "Terminal typed urlbar sessions with 8 or more characters typed, i.e. the denominator of the history success rate"
+select_expression = "COUNT(DISTINCT IF(num_chars_typed >= 8, event_id, NULL))"
+data_source = "urlbar_terminal_typed_sessions"
+exposure_basis = ["exposures", "enrollments"]
+[metrics.urlbar_typed_sessions_8.statistics.bootstrap_mean]
+
+[metrics.urlbar_history_clicks_8]
+friendly_name = "History-click sessions (8+ chars)"
+description = "Qualifying sessions that ended with a click on any browsing-history result, i.e. the numerator of the history success rate"
+select_expression = "COUNT(DISTINCT IF(num_chars_typed >= 8 AND is_history_click, event_id, NULL))"
+data_source = "urlbar_terminal_typed_sessions"
+exposure_basis = ["exposures", "enrollments"]
+[metrics.urlbar_history_clicks_8.statistics.bootstrap_mean]
+
+## --- Aggregation 1: global (session-weighted) -------------------------
+
+[metrics.history_success_rate_global_8]
+friendly_name = "History success rate, global (8+ chars)"
+description = "Share of qualifying urlbar sessions ending on a history result, pooled across all sessions. Session-weighted: heavy users dominate. This is a population-ratio metric, not a client-level metric."
+depends_on = ["urlbar_history_clicks_8", "urlbar_typed_sessions_8"]
+
+[metrics.history_success_rate_global_8.statistics.population_ratio]
+numerator = "urlbar_history_clicks_8"
+denominator = "urlbar_typed_sessions_8"
+
+## --- Aggregation 2: per-user mean -------------------------------------
+
+[metrics.history_success_rate_per_user_8]
+friendly_name = "History success rate, per user (8+ chars)"
+description = "Each user's own history success rate, averaged with every user weighted equally. NULL for users with no qualifying sessions, so this is best read on the exposures basis."
+select_expression = """SAFE_DIVIDE(
+  COUNT(DISTINCT IF(num_chars_typed >= 8 AND is_history_click, event_id, NULL)),
+  COUNT(DISTINCT IF(num_chars_typed >= 8, event_id, NULL))
+)"""
+data_source = "urlbar_terminal_typed_sessions"
+exposure_basis = ["exposures", "enrollments"]
+[metrics.history_success_rate_per_user_8.statistics.bootstrap_mean]
+
+## --- Aggregation 3: capped (winsorized) -------------------------------
+#
+# Reconstructs the owner's estimator:
+#     sum over users of  rate * min(sessions, c95)
+#     ---------------------------------------------
+#     sum over users of         min(sessions, c95)
+#
+# population_ratio computes mean(numerator) / mean(denominator), which over a fixed
+# set of users equals sum(numerator) / sum(denominator), so the two metrics below
+# reproduce it exactly.
+#
+# c95 cannot be computed inside a metric definition (it is a population-level
+# quantile, and select_expressions are per-client aggregates), so it is hard-coded.
+# The values come from a one-off query over 2026-07-08..2026-08-04, enrolled
+# profile_group_ids, same filters as below:
+#     8+ chars:  p95 = 238 over the full period, 78 within a calendar week
+#     5+ chars:  p95 = 281 over the full period, 92 within a calendar week
+# For scale, the median user has 21 qualifying 8+ char sessions over the full period
+# and the heaviest has 38,502, which is the skew the capping is there to contain.
+# Weekly and overall therefore need separate constants; a single one would be wrong
+# for one of the two windows.
+
+[metrics.capped_numerator_8_weekly]
+friendly_name = "Capped history-click weight (8+ chars, weekly)"
+description = "Per-user history success rate multiplied by that user's session count capped at 78, the weekly 95th percentile of per-user qualifying session counts"
+select_expression = """SAFE_DIVIDE(
+  COUNT(DISTINCT IF(num_chars_typed >= 8 AND is_history_click, event_id, NULL)),
+  COUNT(DISTINCT IF(num_chars_typed >= 8, event_id, NULL))
+) * LEAST(COUNT(DISTINCT IF(num_chars_typed >= 8, event_id, NULL)), 78)"""
+data_source = "urlbar_terminal_typed_sessions"
+statistics = { sum = {} }
+
+[metrics.capped_denominator_8_weekly]
+friendly_name = "Capped session weight (8+ chars, weekly)"
+description = "Per-user qualifying session count capped at 78, the weekly 95th percentile"
+select_expression = "LEAST(COUNT(DISTINCT IF(num_chars_typed >= 8, event_id, NULL)), 78)"
+data_source = "urlbar_terminal_typed_sessions"
+statistics = { sum = {} }
+
+[metrics.history_success_rate_capped_8_weekly]
+friendly_name = "History success rate, capped (8+ chars)"
+description = "Share of qualifying urlbar sessions ending on a history result, session-weighted but with each user's weight capped at the 95th percentile of per-user session counts. The owner's preferred estimator. This is a population-ratio metric, not a client-level metric."
+depends_on = ["capped_numerator_8_weekly", "capped_denominator_8_weekly"]
+
+[metrics.history_success_rate_capped_8_weekly.statistics.population_ratio]
+numerator = "capped_numerator_8_weekly"
+denominator = "capped_denominator_8_weekly"
+# Capping already handles the heavy tail; do not also trim the top 0.5%.
+drop_highest = 0.0
+
+[metrics.capped_numerator_8_overall]
+friendly_name = "Capped history-click weight (8+ chars, overall)"
+description = "Per-user history success rate multiplied by that user's session count capped at 238, the full-period 95th percentile of per-user qualifying session counts"
+select_expression = """SAFE_DIVIDE(
+  COUNT(DISTINCT IF(num_chars_typed >= 8 AND is_history_click, event_id, NULL)),
+  COUNT(DISTINCT IF(num_chars_typed >= 8, event_id, NULL))
+) * LEAST(COUNT(DISTINCT IF(num_chars_typed >= 8, event_id, NULL)), 238)"""
+data_source = "urlbar_terminal_typed_sessions"
+statistics = { sum = {} }
+
+[metrics.capped_denominator_8_overall]
+friendly_name = "Capped session weight (8+ chars, overall)"
+description = "Per-user qualifying session count capped at 238, the full-period 95th percentile"
+select_expression = "LEAST(COUNT(DISTINCT IF(num_chars_typed >= 8, event_id, NULL)), 238)"
+data_source = "urlbar_terminal_typed_sessions"
+statistics = { sum = {} }
+
+[metrics.history_success_rate_capped_8_overall]
+friendly_name = "History success rate, capped (8+ chars)"
+description = "Share of qualifying urlbar sessions ending on a history result, session-weighted but with each user's weight capped at the 95th percentile of per-user session counts. The owner's preferred estimator. This is a population-ratio metric, not a client-level metric."
+depends_on = ["capped_numerator_8_overall", "capped_denominator_8_overall"]
+
+[metrics.history_success_rate_capped_8_overall.statistics.population_ratio]
+numerator = "capped_numerator_8_overall"
+denominator = "capped_denominator_8_overall"
+drop_highest = 0.0
+
+
+########################################################################
+## Secondary cut: 5+ characters typed
+########################################################################
+
+[metrics.urlbar_typed_sessions_5]
+friendly_name = "Qualifying urlbar sessions (5+ chars)"
+description = "Terminal typed urlbar sessions with 5 or more characters typed. Note the fuzzier branch cannot serve a semantic result below 8 characters, so this cut favours the default branch."
+select_expression = "COUNT(DISTINCT event_id)"
+data_source = "urlbar_terminal_typed_sessions"
+exposure_basis = ["exposures", "enrollments"]
+[metrics.urlbar_typed_sessions_5.statistics.bootstrap_mean]
+
+[metrics.urlbar_history_clicks_5]
+friendly_name = "History-click sessions (5+ chars)"
+description = "Qualifying sessions with 5+ characters typed that ended with a click on any browsing-history result"
+select_expression = "COUNT(DISTINCT IF(is_history_click, event_id, NULL))"
+data_source = "urlbar_terminal_typed_sessions"
+exposure_basis = ["exposures", "enrollments"]
+[metrics.urlbar_history_clicks_5.statistics.bootstrap_mean]
+
+[metrics.history_success_rate_global_5]
+friendly_name = "History success rate, global (5+ chars)"
+description = "Share of 5+ character urlbar sessions ending on a history result, pooled across all sessions. This is a population-ratio metric, not a client-level metric."
+depends_on = ["urlbar_history_clicks_5", "urlbar_typed_sessions_5"]
+
+[metrics.history_success_rate_global_5.statistics.population_ratio]
+numerator = "urlbar_history_clicks_5"
+denominator = "urlbar_typed_sessions_5"
+
+[metrics.history_success_rate_per_user_5]
+friendly_name = "History success rate, per user (5+ chars)"
+description = "Each user's own history success rate at the 5-character floor, averaged with every user weighted equally"
+select_expression = "SAFE_DIVIDE(COUNT(DISTINCT IF(is_history_click, event_id, NULL)), COUNT(DISTINCT event_id))"
+data_source = "urlbar_terminal_typed_sessions"
+exposure_basis = ["exposures", "enrollments"]
+[metrics.history_success_rate_per_user_5.statistics.bootstrap_mean]
+
+# Caps for the 5-char cut: 92 weekly, 281 over the full period. Same derivation as
+# the 8-char caps above.
+[metrics.capped_numerator_5_weekly]
+friendly_name = "Capped history-click weight (5+ chars, weekly)"
+description = "Per-user history success rate multiplied by that user's session count capped at the weekly 95th percentile"
+select_expression = """SAFE_DIVIDE(
+  COUNT(DISTINCT IF(is_history_click, event_id, NULL)),
+  COUNT(DISTINCT event_id)
+) * LEAST(COUNT(DISTINCT event_id), 92)"""
+data_source = "urlbar_terminal_typed_sessions"
+statistics = { sum = {} }
+
+[metrics.capped_denominator_5_weekly]
+friendly_name = "Capped session weight (5+ chars, weekly)"
+description = "Per-user qualifying session count capped at the weekly 95th percentile"
+select_expression = "LEAST(COUNT(DISTINCT event_id), 92)"
+data_source = "urlbar_terminal_typed_sessions"
+statistics = { sum = {} }
+
+[metrics.history_success_rate_capped_5_weekly]
+friendly_name = "History success rate, capped (5+ chars)"
+description = "Share of 5+ character urlbar sessions ending on a history result, session-weighted with each user's weight capped at the 95th percentile. This is a population-ratio metric, not a client-level metric."
+depends_on = ["capped_numerator_5_weekly", "capped_denominator_5_weekly"]
+
+[metrics.history_success_rate_capped_5_weekly.statistics.population_ratio]
+numerator = "capped_numerator_5_weekly"
+denominator = "capped_denominator_5_weekly"
+drop_highest = 0.0
+
+[metrics.capped_numerator_5_overall]
+friendly_name = "Capped history-click weight (5+ chars, overall)"
+description = "Per-user history success rate multiplied by that user's session count capped at the full-period 95th percentile"
+select_expression = """SAFE_DIVIDE(
+  COUNT(DISTINCT IF(is_history_click, event_id, NULL)),
+  COUNT(DISTINCT event_id)
+) * LEAST(COUNT(DISTINCT event_id), 281)"""
+data_source = "urlbar_terminal_typed_sessions"
+statistics = { sum = {} }
+
+[metrics.capped_denominator_5_overall]
+friendly_name = "Capped session weight (5+ chars, overall)"
+description = "Per-user qualifying session count capped at the full-period 95th percentile"
+select_expression = "LEAST(COUNT(DISTINCT event_id), 281)"
+data_source = "urlbar_terminal_typed_sessions"
+statistics = { sum = {} }
+
+[metrics.history_success_rate_capped_5_overall]
+friendly_name = "History success rate, capped (5+ chars)"
+description = "Share of 5+ character urlbar sessions ending on a history result, session-weighted with each user's weight capped at the 95th percentile. This is a population-ratio metric, not a client-level metric."
+depends_on = ["capped_numerator_5_overall", "capped_denominator_5_overall"]
+
+[metrics.history_success_rate_capped_5_overall.statistics.population_ratio]
+numerator = "capped_numerator_5_overall"
+denominator = "capped_denominator_5_overall"
+drop_highest = 0.0
+
+
+########################################################################
+## Data source
+########################################################################
+#
+# The Firefox Suggest outcome reads urlbar_events_daily_engagement_by_product_result_type,
+# which is pre-aggregated per client per day per product_result_type and therefore has
+# no num_chars_typed. The character floor is the whole point of this metric, so we go
+# to the session-grain table instead.
+#
+# Filters mirror the owner's query: one row per terminal typed urlbar session on
+# release. sample_id is deliberately not filtered here (the doc's `sample_id < 20`
+# was an exploration-speed device, not part of the metric).
+
+[data_sources.urlbar_terminal_typed_sessions]
+from_expression = """(
+    SELECT
+        *,
+        (
+            event_action = 'engaged'
+            AND selected_result IN (
+                'history',
+                'history_adaptive',
+                'history_adaptive_serp',
+                'history_serp',
+                'history_semantic',
+                'history_semantic_serp'
+            )
+        ) AS is_history_click
+    FROM `moz-fx-data-shared-prod.firefox_desktop_derived.urlbar_events_v2`
+    WHERE is_terminal
+      AND event_name IN ('engagement', 'abandonment')
+      AND interaction = 'typed'
+      AND normalized_channel = 'release'
+      AND num_chars_typed >= 5
+)"""
+friendly_name = "Terminal typed urlbar sessions"
+description = "One row per terminal typed urlbar session (engagement or abandonment) on release with 5 or more characters typed, flagged for whether it ended on a browsing-history result"
+submission_date_column = "submission_date"
+client_id_column = "legacy_telemetry_client_id"
+group_id_column = "profile_group_id"
+analysis_units = ["profile_group_id", "client_id"]
+experiments_column_type = "native"


### PR DESCRIPTION
Adds the custom measurement requested by the experiment owner for [semantic-history-search-v3](https://experimenter.services.mozilla.com/nimbus/semantic-history-search-v3/summary/). Spec doc: https://docs.google.com/document/d/1kLwVmOGud7_lDkgDv_cJ7qjzd1ldfePmGH4JImEmQMc/

## The metric

Of all terminal typed urlbar sessions where the user typed at least N characters, what share end with a click on a browsing-history result, as opposed to a search result, an ad, or abandonment? Tab results are excluded deliberately (semantic matching applies there too, but volume is too low to be informative).

The character floor is the point of the metric. Short prefixes are dominated by the adaptive cache, which is high-volume, high-success, and unaffected by the experiment.

**8+ characters is the primary cut.** It is the only apples-to-apples comparison across branches: `suggestSemanticHistoryMinLength` is 8 on `semantic-search-fuzzier`, so below 8 that branch's treatment is inert and would be diluted toward control. The filter itself is applied uniformly to all three branches. 5+ characters is reported as a secondary cut because that is the default branch's own floor.

## Aggregations

The owner reports that the plain session-weighted rate fails to replicate across random halves of the population, because a small number of users with thousands of sessions each dominate it. All three aggregations from the doc are therefore included:

| Metric | Statistic | Weighting |
|---|---|---|
| `history_success_rate_global_{8,5}` | `population_ratio` | every session equal |
| `history_success_rate_per_user_{8,5}` | `bootstrap_mean` | every user equal |
| `history_success_rate_capped_{8,5}_{weekly,overall}` | `population_ratio` | session-weighted, each user capped at p95 |

The capped (winsorized) rate is the owner's preferred estimator. `population_ratio` computes `mean(numerator) / mean(denominator)`, which over a fixed user set equals `sum/sum`, so encoding `rate x LEAST(sessions, c95)` and `LEAST(sessions, c95)` as two metrics reproduces the estimator exactly.

`c95` is hard-coded, since a population-level quantile cannot be computed inside a per-client `select_expression`. Values were derived by query over 2026-07-08 to 2026-08-04 on enrolled `profile_group_id`s:

| Cut | Weekly p95 | Full-period p95 |
|---|---|---|
| 8+ chars | 78 | 238 |
| 5+ chars | 92 | 281 |

Weekly and overall need separate constants, hence the `_weekly` / `_overall` variants. `drop_highest = 0.0` on those statistics, since capping already handles the tail and the 0.5% default trim would double up.

## Data source

The Firefox Suggest outcome (this experiment's primary outcome) reads `urlbar_events_daily_engagement_by_product_result_type`, which is pre-aggregated per client per day per `product_result_type` and has no `num_chars_typed`. This config therefore reads the session-grain `firefox_desktop_derived.urlbar_events_v2` table, matching the owner's query. The doc's `sample_id < 20` is not carried over; that was an exploration-speed device, not part of the metric.

Randomization unit is `group_id`, so `profile_group_id` is the primary analysis unit; `client_id` is declared as well.

An exposure signal (had at least one qualifying session) is included so the per-user mean can be read over users who actually had qualifying sessions.

## Validation

Resolves cleanly against `metric-config-parser` with the shared definitions and the real branch list: 10 summaries at weekly, 10 at overall, both analysis units.

Sanity check of the three aggregations run directly against the table (2026-07-08 to 2026-08-04, `profile_group_id`, 8+ chars):

| Branch | Users | Global | Per-user | Capped (238) |
|---|---|---|---|---|
| `no-semantic-search` | 754,287 | 3.441% | 4.036% | 3.330% |
| `semantic-search-default` | 756,395 | 3.456% | 4.086% | 3.388% |
| `semantic-search-fuzzier` | 755,938 | 3.503% | 4.158% | 3.441% |

Consistent branch ordering across all three.

Note for the owner: the capped rate lands below the global rate rather than between global and per-user. That is possible (the weight path from per-user to global need not be monotone), but it implies both very light and very heavy users have higher success rates than mid-volume users, which is worth understanding before the capped number becomes the headline.

The experiment has ended, so this intentionally does **not** carry `[ci rerun-skip]`; a rerun is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)