### PR TITLE
Fix capped ratio metrics for semantic-history-search-v3

### DIFF
--- a/jetstream/semantic-history-search-v3.toml
+++ b/jetstream/semantic-history-search-v3.toml
@@ -38,17 +38,28 @@ window_start = "enrollment_start"
 window_end = "analysis_window_end"
 
 [metrics]
+# population_ratio is computed at the statistics stage, reading the numerator and
+# denominator as columns of the already-materialized metrics table. A metric only
+# becomes a column if it is listed here; depends_on declares the relationship but
+# does not materialize anything. So every component of a ratio has to appear in the
+# same period list as the ratio itself, which is why the capped_* metrics are listed
+# below alongside the rates they feed. The global rates need no extra entries: their
+# components (urlbar_history_clicks_*, urlbar_typed_sessions_*) are already listed.
 weekly = [
   "urlbar_typed_sessions_8",
   "urlbar_history_clicks_8",
   "history_success_rate_global_8",
   "history_success_rate_per_user_8",
   "history_success_rate_capped_8_weekly",
+  "capped_numerator_8_weekly",
+  "capped_denominator_8_weekly",
   "urlbar_typed_sessions_5",
   "urlbar_history_clicks_5",
   "history_success_rate_global_5",
   "history_success_rate_per_user_5",
   "history_success_rate_capped_5_weekly",
+  "capped_numerator_5_weekly",
+  "capped_denominator_5_weekly",
 ]
 overall = [
   "urlbar_typed_sessions_8",
@@ -56,11 +67,15 @@ overall = [
   "history_success_rate_global_8",
   "history_success_rate_per_user_8",
   "history_success_rate_capped_8_overall",
+  "capped_numerator_8_overall",
+  "capped_denominator_8_overall",
   "urlbar_typed_sessions_5",
   "urlbar_history_clicks_5",
   "history_success_rate_global_5",
   "history_success_rate_per_user_5",
   "history_success_rate_capped_5_overall",
+  "capped_numerator_5_overall",
+  "capped_denominator_5_overall",
 ]
 
 


### PR DESCRIPTION
## Problem

The four capped history-success-rate metrics added in #1595 fail in Jetstream. From `moz-fx-data-experiments.monitoring.logs`, 12 error rows since that merge (retries of 4 distinct failures):

| Metric | Bases | Error |
|---|---|---|
| `history_success_rate_capped_8_weekly` | enrollments, exposures | `400 Unrecognized name: capped_numerator_8_weekly at [15:15]` |
| `history_success_rate_capped_5_weekly` | enrollments, exposures | `400 Unrecognized name: capped_numerator_5_weekly at [15:15]` |

## Cause

`population_ratio` is computed at the statistics stage, reading its numerator and denominator as columns of the already-materialized metrics table. A metric only becomes a column if it is listed in a period list. `depends_on` declares the relationship for config resolution but does not materialize anything.

The `capped_numerator_*` / `capped_denominator_*` metrics were defined and given `statistics = { sum = {} }`, but never listed under `weekly` or `overall`, so the columns were never built.

The global rates use the same `population_ratio` + `depends_on` shape and did **not** fail, because their components (`urlbar_history_clicks_*`, `urlbar_typed_sessions_*`) were already in both lists. That difference is what isolates the cause.

## Fix

Each component is added to the period list matching its window, plus a comment recording why ratio components have to be listed.

No `exposure_basis` was needed: the parser default is already both enrollments and exposures, covering the two bases that failed.

## Verification

- BigQuery: zero columns matching `capped_%` across all 246 `semantic_history_search_v3*` tables, while `urlbar_typed_sessions_*` has 16.
- Resolving with `metric-config-parser`: 10 to 14 summaries per period, with all four components present in the correct period and on both bases.

## Notes

- Weekly is what errored on the #1595 rerun. `overall` had not run yet (no `*_overall` tables exist) and carries the identical defect, so both lists are fixed here.
- No `[ci rerun-skip]`: the capped results are missing and a rerun is wanted.
- Adds 8 `sum` summaries for the component metrics, the normal cost of reconstructing a winsorized estimator this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)