### PR TITLE
Add aggregate lapsed-user segment to top-sites-welcome-back-spotlight

### DIFF
--- a/jetstream/top-sites-welcome-back-spotlight.toml
+++ b/jetstream/top-sites-welcome-back-spotlight.toml
@@ -13,6 +13,9 @@ segments = [
   "last_active_120_to_180_days_ago",
   "last_active_more_than_180_days_ago",
 
+  # Aggregate lapse (union of the four buckets above)
+  "last_active_more_than_28_days_ago",
+
   # Default browser status
   "firefox_default",
   "firefox_not_default",
@@ -200,6 +203,26 @@ select_expression = """
   (
     MAX(submission_date) IS NULL
     OR DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) > 180
+  )
+"""
+data_source = "active_users_last_seen"
+window_start = -183
+window_end = -1
+
+# Aggregate lapse segment: the exact union of the four buckets above. The
+# buckets are contiguous (28-59 / 60-119 / 120-180 / >180), so the union is
+# ">= 28 days, or no DAU in the 183-day lookback". Note the threshold is
+# INCLUSIVE of day 28 (>=, not >) so this segment's population equals the sum
+# of the four buckets; the name follows the existing more_than_180 convention.
+# Gives an aggregate lapsed-user read without collapsing the depth buckets.
+
+[segments.last_active_more_than_28_days_ago]
+friendly_name = "Last active 28+ days ago (all lapse buckets)"
+description = "Aggregate lapsed population: clients whose last DAU before enrollment is 28 or more days prior, or who had no DAU in the 183-day lookback. Exact union of the 28-59 / 60-119 / 120-180 / 180+ buckets."
+select_expression = """
+  (
+    MAX(submission_date) IS NULL
+    OR DATE_DIFF(MIN(e.enrollment_date), MAX(submission_date), DAY) >= 28
   )
 """
 data_source = "active_users_last_seen"


### PR DESCRIPTION
Amends the merged config for `top-sites-welcome-back-spotlight` (added in #1549) to add one aggregate lapse segment.

## What this adds
- **`last_active_more_than_28_days_ago`** — the exact union of the four existing lapse-depth buckets, giving an aggregate lapsed-user read without collapsing the depth cuts.
  - The existing buckets are contiguous (28-59 / 60-119 / 120-180 / >180 or no DAU in lookback), so the union is `>= 28 days, or MAX(submission_date) IS NULL`.
  - Threshold is **inclusive** of day 28 (`>=`, not `>`) so this segment's population equals the sum of the four buckets. The name follows the existing `last_active_more_than_180_days_ago` convention; precise semantics are in `friendly_name` / `description`.
  - Reuses the existing `[segments.data_sources.active_users_last_seen]` source with the same `window_start = -183` / `window_end = -1` as the four buckets. No new data source needed.

Note: this segment intentionally **overlaps** the four bucket segments — it is an aggregate roll-up, not a mutually exclusive cut.

## What is unchanged
All 12 metrics, the 6 custom web-app metric blocks, `[data_sources.web_app_events]`, the four lapse buckets, the default-browser and Windows 10/11 segments, and the segment data source are untouched. Diff is purely additive (23 lines added, 0 removed).

## Experiment context
- Nimbus: https://experimenter.services.mozilla.com/nimbus/top-sites-welcome-back-spotlight
- Foreground Spotlight (`fxms-message-15`), 3 branches — no background-updater `enrollment_query` / `analysis_unit`.
- Base config PR: #1549

🤖 Generated via `/create-custom-config`