### PR TITLE
adding glean fxa sign in rate

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1541,6 +1541,13 @@ name = "fxa_signed_in"
 friendly_name = "FxA Sign-in Rate"
 description = "Is the client signed in at any point during the experiment"
 
+[metrics.fxa_signed_in_glean]
+data_source = "metrics"
+select_expression = "CAST(COALESCE(SUM(CASE WHEN metrics.boolean.fxa_account_enabled IS TRUE THEN 1 ELSE 0 END),0) > 0 AS INT)"
+name = "fxa_signed_in_glean"
+friendly_name = "FxA Sign-in Rate (Glean)"
+description = "Is the client signed in at any point during the experiment, based on the Glean `fxa.account_enabled` metric"
+
 [metrics.retained]
 select_expression = "COALESCE(SUM(pings_aggregated_by_this_row), 0) > 0"
 data_source = "clients_daily"


### PR DESCRIPTION
FxA sign-in rate already exists in firefox_backup.toml on legacy telemetry, but I'm rebuilding it in Glean.

For July 2026, the two approaches produced nearly identical rates (14.30% vs. 14.35%), despite the ~7% smaller client population on Glean.

More details: https://docs.google.com/document/d/18oK3Z5r4ZQ7fw4LDWWvJm5IoLuFhgsmG5WuYPslvACU/edit?tab=t.0
