### PR TITLE
feat(parser): add outcomes as configurable list for experiments

### DIFF
--- a/lib/metric-config-parser/metric_config_parser/analysis.py
+++ b/lib/metric-config-parser/metric_config_parser/analysis.py
@@ -94,7 +94,12 @@ class AnalysisSpec:
             raise Exception("Can't resolve an AnalysisSpec twice")
         self._resolved = True
 
-        for slug in experiment.outcomes:
+        outcome_slugs = list(experiment.outcomes)
+        for slug in self.experiment.outcomes:
+            if slug not in outcome_slugs:
+                outcome_slugs.append(slug)
+
+        for slug in outcome_slugs:
             outcome = configs.spec_for_outcome(slug, experiment.app_name)
 
             if outcome is not None:

--- a/lib/metric-config-parser/metric_config_parser/experiment.py
+++ b/lib/metric-config-parser/metric_config_parser/experiment.py
@@ -318,6 +318,7 @@ class ExperimentSpec:
     start_date: str | None = attr.ib(default=None, validator=_validate_yyyy_mm_dd)
     end_date: str | None = attr.ib(default=None, validator=_validate_yyyy_mm_dd)
     segments: list[SegmentReference] = attr.Factory(list)
+    outcomes: list[str] = attr.Factory(list)
     skip: bool = False
     exposure_signal: ExposureSignalDefinition | None = None
     is_private: bool = False

--- a/lib/metric-config-parser/metric_config_parser/tests/test_outcomes.py
+++ b/lib/metric-config-parser/metric_config_parser/tests/test_outcomes.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import re
 from textwrap import dedent
+from unittest.mock import patch
 
 import pytest
 import pytz
@@ -315,6 +316,47 @@ class TestOutcomes:
 
         with pytest.raises(ClassValidationError):
             AnalysisSpec.from_dict(toml.loads(config_str))
+
+    def test_resolving_outcomes_from_external_config(self, experiments, config_collection):
+        """Outcomes listed under `[experiment]` in an external config should be
+        resolved in addition to any outcomes attached to the experiment itself."""
+        config_str = dedent(
+            """
+            [experiment]
+            outcomes = ["performance"]
+            """
+        )
+
+        spec = AnalysisSpec.from_dict(toml.loads(config_str))
+        cfg = spec.resolve(experiments[9], config_collection)
+        overall_metrics = [s.metric.name for s in cfg.metrics[AnalysisPeriod.OVERALL]]
+
+        assert "speed" in overall_metrics
+
+    def test_resolving_outcomes_from_external_config_deduplicated(
+        self, experiments, config_collection
+    ):
+        """Outcomes already attached to the experiment shouldn't be resolved twice
+        when also listed in the external config."""
+        config_str = dedent(
+            """
+            [experiment]
+            outcomes = ["performance", "tastiness"]
+            """
+        )
+
+        spec = AnalysisSpec.from_dict(toml.loads(config_str))
+
+        # experiments[5] already has outcomes=["performance", "tastiness"] attached,
+        # so each slug should only be resolved once even though it's listed in both
+        # the experiment and the external config.
+        with patch.object(
+            config_collection, "spec_for_outcome", wraps=config_collection.spec_for_outcome
+        ) as spec_for_outcome:
+            spec.resolve(experiments[5], config_collection)
+
+        resolved_slugs = [call.args[0] for call in spec_for_outcome.call_args_list]
+        assert resolved_slugs == ["performance", "tastiness"]
 
     def test_unsupported_platform_outcomes(self, config_collection):
         spec = AnalysisSpec.from_dict(toml.loads(""))

--- a/lib/metric-config-parser/pyproject.toml
+++ b/lib/metric-config-parser/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mozilla-metric-config-parser"
-version = "2026.7.1"
+version = "2026.8.1"
 authors = [{ name = "Mozilla Corporation", email = "fx-data-dev@mozilla.org" }]
 description = "Parses metric configuration files."
 readme = "README.md"


### PR DESCRIPTION
- adds `outcomes` list to the `ExperimentSpec` so it gets picked up in custom configs
- dedupes outcome slugs when resolving for analysis
- adds tests
- bumps to version `2026.8.1`