### PR TITLE
[ci rerun-skip] feat(config): add mean_lm no-clip default as additional stat to default metrics

### DIFF
--- a/jetstream/defaults/fenix.toml
+++ b/jetstream/defaults/fenix.toml
@@ -1,59 +1,59 @@
 [metrics]
 daily = [
-    "retained",
-    "client_level_daily_active_users_v2",
     "active_hours",
-    "total_uri_count",
-    "search_count",
     "active_in_last_3_days",
+    "client_level_daily_active_users_v2",
+    "retained",
+    "search_count",
+    "total_uri_count",
 ]
 weekly = [
-    "retained",
     "active_hours",
+    "client_level_daily_active_users_v2",
+    "days_of_use",
+    "retained",
     "search_count",
     "serp_ad_clicks",
     "tagged_search_count",
     "total_uri_count",
-    "days_of_use",
-    "client_level_daily_active_users_v2",
 ]
 overall = [
     "active_hours",
-    "serp_ad_clicks",
-    "tagged_search_count",
+    "client_level_daily_active_users_v2",
+    "days_of_use",
     "organic_searches",
     "search_count",
     "searches_with_ads",
+    "serp_ad_clicks",
     "tagged_follow_on_searches",
+    "tagged_search_count",
     "total_uri_count",
-    "days_of_use",
-    "client_level_daily_active_users_v2",
 ]
 
 preenrollment_weekly = [
     "active_hours",
-    "serp_ad_clicks",
+    "client_level_daily_active_users_v2",
+    "days_of_use",
     "organic_searches",
     "search_count",
     "searches_with_ads",
+    "serp_ad_clicks",
     "tagged_follow_on_searches",
-    "total_uri_count",
-    "days_of_use",
-    "client_level_daily_active_users_v2",
     "tagged_search_count",
+    "total_uri_count",
 ]
 
 preenrollment_days28 = [
     "active_hours",
-    "serp_ad_clicks",
+    "client_level_daily_active_users_v2",
+    "days_of_use",
     "organic_searches",
     "search_count",
     "searches_with_ads",
+    "serp_ad_clicks",
     "tagged_follow_on_searches",
-    "total_uri_count",
-    "days_of_use",
-    "client_level_daily_active_users_v2",
     "tagged_search_count",
+    "total_uri_count",
 ]
 
 [metrics.retained]
@@ -84,6 +84,10 @@ deciles = {}
 [metrics.active_hours.statistics.linear_model_mean]
 [metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.active_hours.statistics.linear_model_mean_no_clip]
+[metrics.active_hours.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -95,6 +99,9 @@ data_source = "mobile_search_clients_engines_sources_daily"
 deciles = {}
 [metrics.serp_ad_clicks.statistics.linear_model_mean]
 [metrics.serp_ad_clicks.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
+[metrics.serp_ad_clicks.statistics.linear_model_mean_no_clip]
+[metrics.serp_ad_clicks.statistics.linear_model_mean_no_clip.covariate_adjustment]
 period = "preenrollment_week"
 
 ##
@@ -108,6 +115,9 @@ deciles = {}
 [metrics.organic_searches.statistics.linear_model_mean]
 [metrics.organic_searches.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
+[metrics.organic_searches.statistics.linear_model_mean_no_clip]
+[metrics.organic_searches.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 
 ##
@@ -116,6 +126,9 @@ period = "preenrollment_week"
 deciles = {}
 [metrics.search_count.statistics.linear_model_mean]
 [metrics.search_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
+[metrics.search_count.statistics.linear_model_mean_no_clip]
+[metrics.search_count.statistics.linear_model_mean_no_clip.covariate_adjustment]
 period = "preenrollment_week"
 
 ##
@@ -129,6 +142,10 @@ deciles = {}
 [metrics.searches_with_ads.statistics.linear_model_mean]
 [metrics.searches_with_ads.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.searches_with_ads.statistics.linear_model_mean_no_clip]
+[metrics.searches_with_ads.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 
 ##
@@ -137,6 +154,10 @@ period = "preenrollment_week"
 deciles = {}
 [metrics.tagged_search_count.statistics.linear_model_mean]
 [metrics.tagged_search_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.tagged_search_count.statistics.linear_model_mean_no_clip]
+[metrics.tagged_search_count.statistics.linear_model_mean_no_clip.covariate_adjustment]
 period = "preenrollment_week"
 
 ##
@@ -150,6 +171,10 @@ deciles = {}
 [metrics.tagged_follow_on_searches.statistics.linear_model_mean]
 [metrics.tagged_follow_on_searches.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.tagged_follow_on_searches.statistics.linear_model_mean_no_clip]
+[metrics.tagged_follow_on_searches.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -161,6 +186,10 @@ data_source = "metrics"
 deciles = {}
 [metrics.total_uri_count.statistics.linear_model_mean]
 [metrics.total_uri_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.total_uri_count.statistics.linear_model_mean_no_clip]
+[metrics.total_uri_count.statistics.linear_model_mean_no_clip.covariate_adjustment]
 period = "preenrollment_week"
 
 [metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -2,87 +2,95 @@
 
 [metrics]
 daily = [
+  "active_hours",
+  "active_in_last_3_days_legacy",
+  "client_level_daily_active_users_v2",
+  "daily_active_users_per_1000_clients_legacy",
   "retained",
   "retained_dau",
-  "unenroll",
-  "client_level_daily_active_users_v2",
-  "active_hours",
   "search_count",
-  "active_in_last_3_days_legacy",
-  "daily_active_users_per_1000_clients_legacy",
+  "unenroll",
 ]
 
 weekly = [
   "active_hours",
   "ad_clicks",
-  "days_of_use",
-  "retained",
-  "retained_dau",
-  "uri_count",
-  "search_count",
-  "qualified_cumulative_days_of_use",
-  "is_default_browser",
   "client_level_daily_active_users_v2",
   "daily_active_users_per_1000_clients_legacy",
+  "days_of_use",
+  "is_default_browser",
+  "qualified_cumulative_days_of_use",
+  "retained",
+  "retained_dau",
+  "search_count",
+  "uri_count",
 ]
 
 overall = [
   "active_hours",
   "ad_clicks",
-  "days_of_use",
-  "organic_search_count",
-  "search_count",
-  "searches_with_ads",
-  "tagged_search_count",
-  "tagged_follow_on_search_count",
-  "uri_count",
-  "qualified_cumulative_days_of_use",
-  "is_default_browser",
   "client_level_daily_active_users_v2",
   "daily_active_users_per_1000_clients_legacy",
+  "days_of_use",
+  "is_default_browser",
+  "organic_search_count",
+  "qualified_cumulative_days_of_use",
+  "search_count",
+  "searches_with_ads",
+  "tagged_follow_on_search_count",
+  "tagged_search_count",
+  "uri_count",
 ]
 
 preenrollment_weekly = [
   "active_hours",
   "ad_clicks",
-  "days_of_use",
-  "organic_search_count",
-  "search_count",
-  "searches_with_ads",
-  "tagged_search_count",
-  "tagged_follow_on_search_count",
-  "uri_count",
-  "qualified_cumulative_days_of_use",
-  "is_default_browser",
   "client_level_daily_active_users_v2",
   "daily_active_users_per_1000_clients_legacy",
+  "days_of_use",
+  "is_default_browser",
+  "organic_search_count",
+  "qualified_cumulative_days_of_use",
+  "search_count",
+  "searches_with_ads",
+  "tagged_follow_on_search_count",
+  "tagged_search_count",
+  "uri_count",
 ]
 
 preenrollment_days28 = [
   "active_hours",
   "ad_clicks",
+  "client_level_daily_active_users_v2",
   "days_of_use",
+  "is_default_browser",
   "organic_search_count",
+  "qualified_cumulative_days_of_use",
   "search_count",
   "searches_with_ads",
-  "tagged_search_count",
   "tagged_follow_on_search_count",
+  "tagged_search_count",
   "uri_count",
-  "qualified_cumulative_days_of_use",
-  "is_default_browser",
-  "client_level_daily_active_users_v2",
 ]
 
 [metrics.active_hours.statistics.linear_model_mean]
 [metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
 [metrics.active_hours.statistics.deciles]
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.active_hours.statistics.linear_model_mean_no_clip]
+[metrics.active_hours.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 
 [metrics.ad_clicks.statistics.linear_model_mean]
 [metrics.ad_clicks.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
 [metrics.ad_clicks.statistics.deciles]
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.ad_clicks.statistics.linear_model_mean_no_clip]
+[metrics.ad_clicks.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 
 [metrics.days_of_use.statistics.linear_model_mean]
@@ -97,6 +105,10 @@ period = "preenrollment_week"
 [metrics.organic_search_count.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
 [metrics.organic_search_count.statistics.deciles]
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.organic_search_count.statistics.linear_model_mean_no_clip]
+[metrics.organic_search_count.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 
 [metrics.retained.statistics.binomial]
@@ -111,30 +123,50 @@ period = "preenrollment_week"
 [metrics.uri_count.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
 [metrics.uri_count.statistics.deciles]
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.uri_count.statistics.linear_model_mean_no_clip]
+[metrics.uri_count.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 
 [metrics.search_count.statistics.linear_model_mean]
 [metrics.search_count.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
 [metrics.search_count.statistics.deciles]
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.search_count.statistics.linear_model_mean_no_clip]
+[metrics.search_count.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 
 [metrics.searches_with_ads.statistics.linear_model_mean]
 [metrics.searches_with_ads.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
 [metrics.searches_with_ads.statistics.deciles]
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.searches_with_ads.statistics.linear_model_mean_no_clip]
+[metrics.searches_with_ads.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 
 [metrics.tagged_search_count.statistics.linear_model_mean]
 [metrics.tagged_search_count.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
 [metrics.tagged_search_count.statistics.deciles]
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.tagged_search_count.statistics.linear_model_mean_no_clip]
+[metrics.tagged_search_count.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 
 [metrics.tagged_follow_on_search_count.statistics.linear_model_mean]
 [metrics.tagged_follow_on_search_count.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
 [metrics.tagged_follow_on_search_count.statistics.deciles]
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.tagged_follow_on_search_count.statistics.linear_model_mean_no_clip]
+[metrics.tagged_follow_on_search_count.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 
 [metrics.unenroll.statistics.binomial]

--- a/jetstream/defaults/firefox_ios.toml
+++ b/jetstream/defaults/firefox_ios.toml
@@ -1,45 +1,45 @@
 [metrics]
 daily = [
-    "retained",
-    "client_level_daily_active_users_v2",
     "active_hours",
+    "active_in_last_3_days",
+    "client_level_daily_active_users_v2",
+    "retained",
     "search_count",
     "total_uri_count",
-    "active_in_last_3_days",
 ]
 weekly = [
-    "retained",
     "active_hours",
+    "client_level_daily_active_users_v2",
     "days_of_use",
+    "retained",
     "search_count",
     "serp_ad_clicks",
-    "client_level_daily_active_users_v2",
     "total_uri_count",
 ]
 overall = [
     "active_hours",
+    "client_level_daily_active_users_v2",
     "days_of_use",
     "search_count",
     "serp_ad_clicks",
-    "client_level_daily_active_users_v2",
     "total_uri_count",
 ]
 
 preenrollment_weekly = [
     "active_hours",
+    "client_level_daily_active_users_v2",
     "days_of_use",
     "search_count",
     "serp_ad_clicks",
-    "client_level_daily_active_users_v2",
     "total_uri_count",
 ]
 
 preenrollment_days28 = [
     "active_hours",
+    "client_level_daily_active_users_v2",
     "days_of_use",
     "search_count",
     "serp_ad_clicks",
-    "client_level_daily_active_users_v2",
     "total_uri_count",
 ]
 
@@ -60,6 +60,10 @@ deciles = {}
 [metrics.active_hours.statistics.linear_model_mean]
 [metrics.active_hours.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.active_hours.statistics.linear_model_mean_no_clip]
+[metrics.active_hours.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -78,6 +82,10 @@ deciles = {}
 [metrics.search_count.statistics.linear_model_mean]
 [metrics.search_count.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.search_count.statistics.linear_model_mean_no_clip]
+[metrics.search_count.statistics.linear_model_mean_no_clip.covariate_adjustment]
+period = "preenrollment_week"
 
 ##
 
@@ -91,6 +99,10 @@ data_source = "mobile_search_clients_engines_sources_daily"
 deciles = {}
 [metrics.serp_ad_clicks.statistics.linear_model_mean]
 [metrics.serp_ad_clicks.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.serp_ad_clicks.statistics.linear_model_mean_no_clip]
+[metrics.serp_ad_clicks.statistics.linear_model_mean_no_clip.covariate_adjustment]
 period = "preenrollment_week"
 
 [metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]
@@ -106,4 +118,8 @@ description = "Total number of URIs visited by each client."
 deciles = {}
 [metrics.total_uri_count.statistics.linear_model_mean]
 [metrics.total_uri_count.statistics.linear_model_mean.covariate_adjustment]
+period = "preenrollment_week"
+# no_clip version of mean_lm is the same as mean_lm but with `drop_highest = 0.0` as the default
+[metrics.total_uri_count.statistics.linear_model_mean_no_clip]
+[metrics.total_uri_count.statistics.linear_model_mean_no_clip.covariate_adjustment]
 period = "preenrollment_week"


### PR DESCRIPTION
- adds an additional `LinearModelMeanNoClip` statistic to the metrics that currently have `mean_lm` configured
- my IDE sorted all the daily/weekly/etc lists when I saved and I decided that wasn't a bad idea

~Blocked by https://github.com/mozilla/jetstream/pull/3310 because we don't want to land this until the results can be differentiated in the output.~ this is landed now