### PR TITLE
[jetstream] Add enrollment period and end date for Win10 Differentiation/Privacy default zh-cn and pl

### DIFF
--- a/jetstream/win10-eos-hnt-differentiationprivacy-default-pl.toml
+++ b/jetstream/win10-eos-hnt-differentiationprivacy-default-pl.toml
@@ -1,2 +1,4 @@
 [experiment]
+enrollment_period = 7
+end_date = "2026-06-16"
 outcomes = ["firefox_backup", "firefox_sync"]

--- a/jetstream/win10-eos-hnt-differentiationprivacy-default-zh-cn.toml
+++ b/jetstream/win10-eos-hnt-differentiationprivacy-default-zh-cn.toml
@@ -1,2 +1,4 @@
 [experiment]
+enrollment_period = 7
+end_date = "2026-06-16"
 outcomes = ["firefox_backup", "firefox_sync"]


### PR DESCRIPTION
Adds enrollment period of 7 days and an end date (to have 28 days of observation) for [Win10 EoS HNT - Differentiation/Privacy (default) zh-cn](https://experimenter.services.mozilla.com/nimbus/win10-eos-hnt-differentiationprivacy-default-zh-cn/summary/) and [Win10 EoS HNT - Differentiation/Privacy (default) pl](https://experimenter.services.mozilla.com/nimbus/win10-eos-hnt-differentiationprivacy-default-pl/summary/) which ended with no observation period.