### PR TITLE
[ci rerun-skip] chore(jetstream): remove end_date and enrollment_period from privacy-enhancing-firefox-suggest-m5-holdback

### DIFF
--- a/jetstream/privacy-enhancing-firefox-suggest-m5-holdback-experiment.toml
+++ b/jetstream/privacy-enhancing-firefox-suggest-m5-holdback-experiment.toml
@@ -1,6 +1,4 @@
 [experiment]
-enrollment_period = 14
-end_date = "2026-05-28"
 
 [experiment.exposure_signal]
 


### PR DESCRIPTION
Removes `enrollment_period` and `end_date` from the Jetstream config so this holdback experiment runs continuously with weekly reruns and no fixed cutoff.

Jira: [EXP-7489](https://mozilla-hub.atlassian.net/browse/EXP-7489)