### PR TITLE
[ci rerun-skip] Move 3-day retention out of Desktop default and into Onboarding outcome

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -1580,14 +1580,25 @@ description = """
 [metrics.active_in_last_3_days]
 select_expression = "COALESCE(MIN(days_since_desktop_active), 30) < 3"
 data_source = "firefox_desktop_baseline_active_users_view"
-friendly_name = "3 Days Retention"
-description = "Records whether a client submitted any pings (i.e. used Firefox) on any of the last 3 days."
+friendly_name = "First 3 Days Retention (Glean)"
+description = """
+    Whether an enrolled client qualified as DAU on at least one of the three days
+    ending on the analysis day. Read at day 4 in Experimenter, this covers the three
+    days immediately after enrollment, a critical window for new-profile engagement
+    and activation and a more robust signal than retention on exactly the third day.
+"""
 
 [metrics.active_in_last_3_days_legacy]
 select_expression = "COALESCE(MIN(mozfun.bits28.days_since_seen(days_active_bits)), 30) < 3"
 data_source = "firefox_desktop_active_users_view"
-friendly_name = "3 Days Retention"
-description = "Records whether a client submitted any pings (i.e. used Firefox) on any of the last 3 days. Uses legacy telemetry."
+friendly_name = "First 3 Days Retention"
+description = """
+    Whether an enrolled client qualified as DAU on at least one of the three days
+    ending on the analysis day. Read at day 4 in Experimenter, this covers the three
+    days immediately after enrollment, a critical window for new-profile engagement
+    and activation and a more robust signal than retention on exactly the third day.
+    Uses Legacy telemetry.
+"""
 
 [metrics.non_ssl_loads_v1]
 select_expression = """SUM(

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -3,7 +3,6 @@
 [metrics]
 daily = [
   "active_hours",
-  "active_in_last_3_days_legacy",
   "client_level_daily_active_users_v2",
   "daily_active_users_per_1000_clients_legacy",
   "retained",
@@ -114,9 +113,6 @@ period = "preenrollment_week"
 [metrics.retained.statistics.binomial]
 
 [metrics.retained_dau.statistics.binomial]
-
-
-[metrics.active_in_last_3_days_legacy.statistics.binomial]
 
 
 [metrics.uri_count.statistics.linear_model_mean]

--- a/jetstream/outcomes/firefox_desktop/new_user_onboarding.toml
+++ b/jetstream/outcomes/firefox_desktop/new_user_onboarding.toml
@@ -3,8 +3,34 @@ description = """
     Measures changes to metrics we want to drive 
     through onboarding, such as import rates of 
     history and bookmarks, default & pin rates, 
-    and FxA sign-in rates. 
+    FxA sign-in rates, and returning activity in 
+    the critical period just after the first day. 
 """
+
+# Analysis windows per metric. 3-day retention is only meaningful in the daily
+# window (Experimenter reads it at day 4); the remaining metrics keep the
+# historical outcome behavior of weekly + overall.
+daily = [
+  "active_in_last_3_days_legacy",
+]
+
+weekly = [
+  "is_default_browser",
+  "is_pinned",
+  "imported_bookmarks",
+  "imported_logins",
+  "imported_history",
+  "fxa_signed_in",
+]
+
+overall = [
+  "is_default_browser",
+  "is_pinned",
+  "imported_bookmarks",
+  "imported_logins",
+  "imported_history",
+  "fxa_signed_in",
+]
 
 [metrics.is_default_browser.statistics.binomial]
 [metrics.is_pinned.statistics.binomial]
@@ -14,3 +40,8 @@ description = """
 [metrics.imported_history.statistics.binomial]
 
 [metrics.fxa_signed_in.statistics.binomial]
+
+# Moved here from the Desktop defaults: 3-day retention behaves as a new-user
+# metric rather than a general default. Uses legacy telemetry, matching how
+# Desktop DAU is still measured.
+[metrics.active_in_last_3_days_legacy.statistics.binomial]


### PR DESCRIPTION
Follow-up from https://github.com/mozilla/metric-hub/pull/1525. 

Now that the option is available to calculate daily metrics in Outcomes, this continues the previous implementation plan to move "3 Day Retention" out of the list of defaults for _all_ experiments, since it was designed to be used for new profiles specifically.

This also includes some metadata updates to the metric friendly UI name and description to explain this nuance.

**Not** in scope of this change:
1. Any corresponding changes in mobile -- this is Desktop only.
2. Any Experimenter UI changes that might be required to account for 3 Day Retention no longer being a KPI on every experiment.

[ci rerun-skip]