### PR TITLE
[ci rerun-skip] Retire older DAU-related metrics from Desktop defaults

### DIFF
--- a/definitions/firefox_desktop.toml
+++ b/definitions/firefox_desktop.toml
@@ -362,13 +362,25 @@ deprecated = true
 data_source = "clients_daily"
 select_expression = "COUNT(submission_date)"
 friendly_name = "Days of use"
-description = "The number of days in the interval that each client sent a main ping."
+description = """
+    The number of days in the interval that each client sent a main ping.
+
+    Note: As of September 2026, this metric is being deprecated in favor of "DAU per 1,000 clients", the streamlined
+    DAU metric now recommended by Data Science for measuring DAU effects in experiments.
+"""
+deprecated = true
 
 [metrics.days_of_use_glean]
 data_source = "baseline_clients_daily"
 select_expression = "COUNT(submission_date)"
 friendly_name = "Days of use in Glean"
-description = "The number of days in the interval that each client sent a baseline ping."
+description = """
+    The number of days in the interval that each client sent a baseline ping.
+
+    Note: As of September 2026, this metric is being deprecated in favor of "DAU per 1,000 clients (Glean)", the streamlined
+    DAU metric now recommended by Data Science for measuring DAU effects in experiments.
+"""
+deprecated = true
 
 [metrics.qualified_cumulative_days_of_use]
 data_source = "clients_daily"
@@ -380,7 +392,11 @@ friendly_name = "QCDOU"
 description = """
     The number of days in the interval that each client sent a main ping,
     given that the client had >0 active hours and >0 URIs loaded.
+
+    Note: As of September 2026, this metric is being deprecated in favor of "DAU per 1,000 clients", the streamlined
+    DAU metric now recommended by Data Science for measuring DAU effects in experiments.
 """
+deprecated = true
 
 [metrics.qualified_cumulative_days_of_use_glean]
 data_source = "baseline_clients_daily"
@@ -392,7 +408,11 @@ friendly_name = "QCDOU in Glean"
 description = """
     The number of days in the interval that each client sent a baseline ping,
     given that the client had >0 active hours and >0 URIs loaded.
+
+    Note: As of September 2026, this metric is being deprecated in favor of "DAU per 1,000 clients (Glean)", the streamlined
+    DAU metric now recommended by Data Science for measuring DAU effects in experiments.
 """
+deprecated = true
 
 [metrics.daily_active_users]
 data_source = "clients_daily"
@@ -459,9 +479,12 @@ description = """
     and is automatically cross-checked, actively monitored, and change controlled.
     This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`, it is
     similar to a "days of use" metric, and not DAU.
+
+    Note: As of September 2026, this metric is being deprecated in favor of "DAU per 1,000 clients", the streamlined
+    DAU metric now recommended by Data Science for measuring DAU effects in experiments.
 """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
-deprecated = false
+deprecated = true
 
 [metrics.daily_active_users_per_1000_clients_legacy]
 friendly_name = "DAU per 1,000 clients"
@@ -493,9 +516,12 @@ description = """
     and is automatically cross-checked, actively monitored, and change controlled.
     This metric needs to be aggregated by `submission_date`. If it is not aggregated by `submission_date`, it is
     similar to a "days of use" metric, and not DAU.
+
+    Note: As of September 2026, this metric is being deprecated in favor of "DAU per 1,000 clients (Glean)", the streamlined
+    DAU metric now recommended by Data Science for measuring DAU effects in experiments.
 """
 owner = ["bochocki@mozilla.com", "firefox-kpi@mozilla.com"]
-deprecated = false
+deprecated = true
 
 [metrics.daily_active_users_per_1000_clients]
 friendly_name = "DAU per 1,000 clients (Glean)"

--- a/jetstream/defaults/firefox_desktop.toml
+++ b/jetstream/defaults/firefox_desktop.toml
@@ -4,9 +4,7 @@
 daily = [
   "active_hours",
   "active_in_last_3_days_legacy",
-  "client_level_daily_active_users_v2",
   "daily_active_users_per_1000_clients_legacy",
-  "retained",
   "retained_dau",
   "search_count",
   "unenroll",
@@ -15,12 +13,8 @@ daily = [
 weekly = [
   "active_hours",
   "ad_clicks",
-  "client_level_daily_active_users_v2",
   "daily_active_users_per_1000_clients_legacy",
-  "days_of_use",
   "is_default_browser",
-  "qualified_cumulative_days_of_use",
-  "retained",
   "retained_dau",
   "search_count",
   "uri_count",
@@ -29,12 +23,9 @@ weekly = [
 overall = [
   "active_hours",
   "ad_clicks",
-  "client_level_daily_active_users_v2",
   "daily_active_users_per_1000_clients_legacy",
-  "days_of_use",
   "is_default_browser",
   "organic_search_count",
-  "qualified_cumulative_days_of_use",
   "search_count",
   "searches_with_ads",
   "tagged_follow_on_search_count",
@@ -45,12 +36,9 @@ overall = [
 preenrollment_weekly = [
   "active_hours",
   "ad_clicks",
-  "client_level_daily_active_users_v2",
   "daily_active_users_per_1000_clients_legacy",
-  "days_of_use",
   "is_default_browser",
   "organic_search_count",
-  "qualified_cumulative_days_of_use",
   "search_count",
   "searches_with_ads",
   "tagged_follow_on_search_count",
@@ -61,11 +49,8 @@ preenrollment_weekly = [
 preenrollment_days28 = [
   "active_hours",
   "ad_clicks",
-  "client_level_daily_active_users_v2",
-  "days_of_use",
   "is_default_browser",
   "organic_search_count",
-  "qualified_cumulative_days_of_use",
   "search_count",
   "searches_with_ads",
   "tagged_follow_on_search_count",
@@ -93,14 +78,6 @@ period = "preenrollment_week"
 period = "preenrollment_week"
 
 
-[metrics.days_of_use.statistics.linear_model_mean]
-drop_highest = 0.0
-[metrics.days_of_use.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
-[metrics.days_of_use.statistics.deciles]
-[metrics.days_of_use.statistics.empirical_cdf]
-
-
 [metrics.organic_search_count.statistics.linear_model_mean]
 [metrics.organic_search_count.statistics.linear_model_mean.covariate_adjustment]
 period = "preenrollment_week"
@@ -110,8 +87,6 @@ period = "preenrollment_week"
 [metrics.organic_search_count.statistics.linear_model_mean_no_clip.covariate_adjustment]
 period = "preenrollment_week"
 
-
-[metrics.retained.statistics.binomial]
 
 [metrics.retained_dau.statistics.binomial]
 
@@ -172,21 +147,10 @@ period = "preenrollment_week"
 [metrics.unenroll.statistics.binomial]
 
 
-[metrics.qualified_cumulative_days_of_use.statistics.linear_model_mean]
-drop_highest = 0.0
-[metrics.qualified_cumulative_days_of_use.statistics.linear_model_mean.covariate_adjustment]
-period = "preenrollment_week"
-[metrics.qualified_cumulative_days_of_use.statistics.deciles]
-
-
 [metrics.is_default_browser.statistics.binomial]
 
 
 [metrics.is_pinned.statistics.binomial]
-
-
-[metrics.client_level_daily_active_users_v2.statistics.per_client_dau_impact]
-pre_treatments = ['normalize_over_analysis_period']
 
 
 [metrics.daily_active_users_per_1000_clients_legacy.statistics.linear_model_mean]


### PR DESCRIPTION
Following up from the changes started in https://github.com/mozilla/metric-hub/pull/1501 and https://github.com/mozilla/metric-hub/pull/1455, this PR retires the other previously-used Desktop defaults that measure versions of DAU and Retention that are now superseded by `DAU per 1,000 clients` and the improved `Retained (DAU)`.

Specifically removed are:

- `client_level_daily_active_users_v2`
- `days_of_use`
- `qualified_cumulative_days_of_use`
- `retained`

"Retirement" here means that these other metrics are removed from the list of Desktop defaults. Their metadata descriptions are also updated with an explanatory note on their changes and rationales, and the `deprecated` value is set to `True`. Many of these metrics have both Legacy and Glean versions defined, if not used in the current set of defaults -- these explanatory notes point to the corresponding Legacy/Glean versions of the new metrics.

Definitions remain available for experiments and outcomes that reference them explicitly, and this change is not meant to invalidate any results where these are already calculated.

### Note for reviewers on non-experiment use cases
I do not fully understand non-experiment implications for changing metrics like this, that might be referenced in other OpMon or Looker contexts. My understanding is that changing the metadata will not break any of these downstream applications, and at most will cause a `deprecated` banner to appear in some limited cases.

### Note on sequencing
The Experimenter UI has some hard-coded references to these values still in place, in terms of how they are presented in the Results UI. Those display references will need to be updated to avoid displaying extra errors as experiment results start coming in without values for these metrics.

More details are ticketed in Jira here: https://mozilla-hub.atlassian.net/browse/EXP-7516 

### Note on communications
Because this change will affect the default values and interpretation of metrics that are highly visible, we will want to message widely to the affected audiences. These new metadata descriptions are meant to be a bit more complete in order to explain some of the context directly in-place, but more proactive outreach is also warranted.

### Scope limit
This change is **Desktop-only.** As with other recent changes, a separate mobile equivalent will need to be applied separately.

[ci rerun-skip]