### PR TITLE
Add vpn-android-phase-0-holdback-155 FxA adoption holdback config

### DIFF
--- a/jetstream/vpn-android-phase-0-holdback-155.toml
+++ b/jetstream/vpn-android-phase-0-holdback-155.toml
@@ -1,0 +1,29 @@
+# Firefox Android VPN Phase 0 holdback study, Firefox 155 relaunch
+# (vpn-android-phase-0-holdback-155). Re-run of the July study (vpn-android.toml)
+# after the 155 progressive rollout; same design, 155+ release, 29 regions.
+# Branches: control (VPN held back) vs treatment-a (VPN enabled), 1:1.
+#
+# Adds FxA adoption (fxa_sign_in) as a two-branch comparison, broken out for the
+# new_users segment. Retention, DAU, and search/ad guardrails come from the default
+# firefox_android metrics.
+
+[experiment]
+reference_branch = "control"
+# enrollment_period is intentionally not set: Jetstream derives it from Experimenter's
+# enrollmentEndDate once enrollment is ended there. Note Jetstream will not analyze
+# until that date is set (the July vpn-android study was ended without ever ending
+# enrollment, so it produced no results). Ending enrollment in Experimenter, not just
+# ending the experiment, is required.
+segments = [
+  "new_users",
+]
+
+[metrics]
+weekly = ["fxa_sign_in"]
+overall = ["fxa_sign_in"]
+
+# fxa_sign_in (definitions/fenix.toml): MAX(IF(metrics.boolean.preferences_signed_in_sync, 1, 0))
+# over the metrics ping, i.e. signed in to sync at any point in the window. Binomial gives
+# the per-branch rate and the treatment-a vs. control lift; on `overall` = ever signed
+# in, on `weekly` = per week. Android analog of desktop fxa_configured.
+[metrics.fxa_sign_in.statistics.binomial]


### PR DESCRIPTION
## What

Adds a Jetstream config for the **Firefox 155 relaunch of the Android VPN Phase 0 holdback study** (`vpn-android-phase-0-holdback-155`, branches `control` vs `treatment-a`, 1:1, Fenix release 155+, 29 regions).

The config defines one metric, **`fxa_sign_in`** (FxA adoption; `preferences.signed_in_sync` over the metrics ping), as a binomial on `weekly` + `overall`, with a `new_users` segment breakout. It is a clone of `jetstream/vpn-android.toml` (#1535), the config for the July run of the same study, with the header updated for the 155 relaunch.

## Why this is the only custom metric

- Retention, DAU, and search/ad guardrails come from the default `firefox_android` metrics.
- VPN feature events (`vpn.onboarding_shown`, `*_turned_on`, funnel, errors) fire only in `treatment-a`, so they have no treatment-vs-control comparison. Reach, adoption, funnel, and errors are computed separately against `fenix.events_stream`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
